### PR TITLE
Attempting to enable CI for changeset PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,3 +33,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Trigger Workflow
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'validate.yml',
+              ref: 'main',
+            })

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,6 @@
 name: Validation
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"


### PR DESCRIPTION
Trying to follow https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/

I believe:
1. Adding `workflow_dispatch` to the validate workflow should at least make it available to be manually run.
2. Trying to get the release workflow to trigger the validate workflow.