### PR TITLE
Edit Condition History to show both of them

### DIFF
--- a/src/components/content/conditions-history-drawer.tsx
+++ b/src/components/content/conditions-history-drawer.tsx
@@ -15,12 +15,17 @@ export function ConditionHistoryDrawer({
   isOpen,
   onClose,
 }: ConditionHistoryDrawerProps) {
-  let data;
-  if (condition?.icd10Code) {
-    data = ConditionHistory({ icd10Code: condition.icd10Code });
-  } else if (condition?.snomedCode) {
-    data = ConditionHistory({ snomedCode: condition.snomedCode });
-  }
+  // let data;
+  const data = ConditionHistory({
+    icd10Code: condition?.icd10Code,
+    snomedCode: condition?.snomedCode,
+  });
+
+  // if (condition?.icd10Code) {
+  //   data = ConditionHistory({ icd10Code: condition.icd10Code });
+  // } else if (condition?.snomedCode) {
+  //   data = ConditionHistory({ snomedCode: condition.snomedCode });
+  // }
   const conditionName = condition?.display;
   const title = "Condition History";
 

--- a/src/components/content/conditions-history-drawer.tsx
+++ b/src/components/content/conditions-history-drawer.tsx
@@ -15,7 +15,12 @@ export function ConditionHistoryDrawer({
   isOpen,
   onClose,
 }: ConditionHistoryDrawerProps) {
-  const data = ConditionHistory({ icd10: condition?.icd10 });
+  let data;
+  if (condition?.icd10Code) {
+    data = ConditionHistory({ icd10Code: condition.icd10Code });
+  } else if (condition?.snomedCode) {
+    data = ConditionHistory({ snomedCode: condition.snomedCode });
+  }
   const conditionName = condition?.display;
   const title = "Condition History";
 

--- a/src/components/content/conditions-history-drawer.tsx
+++ b/src/components/content/conditions-history-drawer.tsx
@@ -15,17 +15,10 @@ export function ConditionHistoryDrawer({
   isOpen,
   onClose,
 }: ConditionHistoryDrawerProps) {
-  // let data;
   const data = ConditionHistory({
     icd10Code: condition?.icd10Code,
     snomedCode: condition?.snomedCode,
   });
-
-  // if (condition?.icd10Code) {
-  //   data = ConditionHistory({ icd10Code: condition.icd10Code });
-  // } else if (condition?.snomedCode) {
-  //   data = ConditionHistory({ snomedCode: condition.snomedCode });
-  // }
   const conditionName = condition?.display;
   const title = "Condition History";
 

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -84,15 +84,15 @@ export function ConditionHistory({
               value: condition.icd10System,
             },
             {
-              label: "SnoMed Display",
+              label: "SNOMED Display",
               value: condition.snomedDisplay,
             },
             {
-              label: "SnoMed Code",
+              label: "SNOMED Code",
               value: condition.snomedCode,
             },
             {
-              label: "SnoMed System",
+              label: "SNOMED System",
               value: condition.snomedSystem,
             },
           ],

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -48,8 +48,6 @@ export function ConditionHistory({
         );
       }
 
-      console.log(filteredConditions);
-
       setConditions(filteredConditions.map((model) => setupData(model)));
       setLoading(false);
     }
@@ -74,16 +72,28 @@ export function ConditionHistory({
               value: condition.recordedDate,
             },
             {
-              label: "Display",
+              label: "ICD10 Display",
               value: condition.icd10Display,
             },
             {
-              label: "Code",
+              label: "ICD10 Code",
               value: condition.icd10Code,
             },
             {
-              label: "System",
+              label: "ICD10 System",
               value: condition.icd10System,
+            },
+            {
+              label: "SnoMed Display",
+              value: condition.snomedDisplay,
+            },
+            {
+              label: "SnoMed Code",
+              value: condition.snomedCode,
+            },
+            {
+              label: "SnoMed System",
+              value: condition.snomedSystem,
             },
           ],
         };

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -38,7 +38,13 @@ export function ConditionHistory({
 
       let filteredConditions;
 
-      if (icd10Code) {
+      if (icd10Code && snomedCode) {
+        filteredConditions = models.filter(
+          (condition) =>
+            condition.icd10Code === icd10Code ||
+            condition.snomedCode === snomedCode
+        );
+      } else if (icd10Code) {
         filteredConditions = models.filter(
           (condition) => condition.icd10Code === icd10Code
         );
@@ -55,7 +61,7 @@ export function ConditionHistory({
     load();
 
     function setupData(condition: ConditionModel): DataListStackEntry {
-      if (icd10Code) {
+      if (icd10Code && snomedCode) {
         return {
           id: condition.id,
           data: [
@@ -98,6 +104,38 @@ export function ConditionHistory({
           ],
         };
       }
+
+      if (snomedCode) {
+        return {
+          id: condition.id,
+          data: [
+            {
+              label: "Verification Status",
+              value: condition.verificationStatus,
+            },
+            {
+              label: "Clinical Status",
+              value: condition.clinicalStatus,
+            },
+            {
+              label: "Recorded Date",
+              value: condition.recordedDate,
+            },
+            {
+              label: "Display",
+              value: condition.snomedDisplay,
+            },
+            {
+              label: "Code",
+              value: condition.snomedCode,
+            },
+            {
+              label: "System",
+              value: condition.snomedSystem,
+            },
+          ],
+        };
+      }
       return {
         id: condition.id,
         data: [
@@ -115,15 +153,15 @@ export function ConditionHistory({
           },
           {
             label: "Display",
-            value: condition.snomedDisplay,
+            value: condition.icd10Display,
           },
           {
             label: "Code",
-            value: condition.snomedCode,
+            value: condition.icd10Code,
           },
           {
             label: "System",
-            value: condition.snomedSystem,
+            value: condition.icd10System,
           },
         ],
       };

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -36,23 +36,13 @@ export function ConditionHistory({
         (condition) => new ConditionModel(condition)
       );
 
-      let filteredConditions;
-
-      if (icd10Code && snomedCode) {
-        filteredConditions = models.filter(
-          (condition) =>
-            condition.icd10Code === icd10Code ||
-            condition.snomedCode === snomedCode
-        );
-      } else if (icd10Code) {
-        filteredConditions = models.filter(
-          (condition) => condition.icd10Code === icd10Code
-        );
-      } else {
-        filteredConditions = models.filter(
-          (condition) => condition.snomedCode === snomedCode
-        );
-      }
+      const filteredConditions = models.filter(
+        (condition) =>
+          (condition.icd10Code === icd10Code &&
+            typeof icd10Code !== "undefined") ||
+          (condition.snomedCode === snomedCode &&
+            typeof snomedCode !== "undefined")
+      );
 
       setConditions(filteredConditions.map((model) => setupData(model)));
       setLoading(false);
@@ -61,109 +51,60 @@ export function ConditionHistory({
     load();
 
     function setupData(condition: ConditionModel): DataListStackEntry {
-      if (icd10Code && snomedCode) {
-        return {
-          id: condition.id,
-          data: [
-            {
-              label: "Verification Status",
-              value: condition.verificationStatus,
-            },
-            {
-              label: "Clinical Status",
-              value: condition.clinicalStatus,
-            },
-            {
-              label: "Recorded Date",
-              value: condition.recordedDate,
-            },
-            {
-              label: "ICD10 Display",
-              value: condition.icd10Display,
-            },
-            {
-              label: "ICD10 Code",
-              value: condition.icd10Code,
-            },
-            {
-              label: "ICD10 System",
-              value: condition.icd10System,
-            },
-            {
-              label: "SNOMED Display",
-              value: condition.snomedDisplay,
-            },
-            {
-              label: "SNOMED Code",
-              value: condition.snomedCode,
-            },
-            {
-              label: "SNOMED System",
-              value: condition.snomedSystem,
-            },
-          ],
-        };
+      let data = [
+        {
+          label: "Verification Status",
+          value: condition.verificationStatus,
+        },
+        {
+          label: "Clinical Status",
+          value: condition.clinicalStatus,
+        },
+        {
+          label: "Recorded Date",
+          value: condition.recordedDate,
+        },
+      ];
+      const ICD10Fields = [
+        {
+          label: "ICD10 Display",
+          value: condition.icd10Display,
+        },
+        {
+          label: "ICD10 Code",
+          value: condition.icd10Code,
+        },
+        {
+          label: "ICD10 System",
+          value: condition.icd10System,
+        },
+      ];
+      const SNOMEDFields = [
+        {
+          label: "SNOMED Display",
+          value: condition.snomedDisplay,
+        },
+        {
+          label: "SNOMED Code",
+          value: condition.snomedCode,
+        },
+        {
+          label: "SNOMED System",
+          value: condition.snomedSystem,
+        },
+      ];
+
+      if (icd10Code) {
+        data = data.concat(ICD10Fields);
       }
 
       if (snomedCode) {
-        return {
-          id: condition.id,
-          data: [
-            {
-              label: "Verification Status",
-              value: condition.verificationStatus,
-            },
-            {
-              label: "Clinical Status",
-              value: condition.clinicalStatus,
-            },
-            {
-              label: "Recorded Date",
-              value: condition.recordedDate,
-            },
-            {
-              label: "Display",
-              value: condition.snomedDisplay,
-            },
-            {
-              label: "Code",
-              value: condition.snomedCode,
-            },
-            {
-              label: "System",
-              value: condition.snomedSystem,
-            },
-          ],
-        };
+        data = data.concat(SNOMEDFields);
       }
+
       return {
         id: condition.id,
-        data: [
-          {
-            label: "Verification Status",
-            value: condition.verificationStatus,
-          },
-          {
-            label: "Clinical Status",
-            value: condition.clinicalStatus,
-          },
-          {
-            label: "Recorded Date",
-            value: condition.recordedDate,
-          },
-          {
-            label: "Display",
-            value: condition.icd10Display,
-          },
-          {
-            label: "Code",
-            value: condition.icd10Code,
-          },
-          {
-            label: "System",
-            value: condition.icd10System,
-          },
-        ],
+        data: [...data],
       };
     }
   }, [getCTWFhirClient, icd10Code, snomedCode, patientUPIDPromise]);

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -13,10 +13,14 @@ import { Spinner } from "../core/spinner";
 const CONDITION_HISTORY_LIMIT = 10;
 
 export type ConditionHistoryProps = {
-  icd10?: string | undefined;
+  icd10Code?: string | undefined;
+  snomedCode?: string | undefined;
 };
 
-export function ConditionHistory({ icd10 }: ConditionHistoryProps) {
+export function ConditionHistory({
+  icd10Code,
+  snomedCode,
+}: ConditionHistoryProps) {
   const [conditions, setConditions] = useState<DataListStackEntries>([]);
   const [loading, setLoading] = useState(true);
   const { getCTWFhirClient } = useCTW();
@@ -31,49 +35,92 @@ export function ConditionHistory({ icd10 }: ConditionHistoryProps) {
       const models = allConditions.map(
         (condition) => new ConditionModel(condition)
       );
-      const filteredConditions = models.filter(
-        (condition) => condition.icd10 === icd10
-      );
+
+      let filteredConditions;
+
+      if (icd10Code) {
+        filteredConditions = models.filter(
+          (condition) => condition.icd10Code === icd10Code
+        );
+      } else {
+        filteredConditions = models.filter(
+          (condition) => condition.snomedCode === snomedCode
+        );
+      }
+
+      console.log(filteredConditions);
+
       setConditions(filteredConditions.map((model) => setupData(model)));
       setLoading(false);
     }
 
     load();
-  }, [getCTWFhirClient, icd10, patientUPIDPromise]);
 
-  function setupData(condition: ConditionModel): DataListStackEntry {
-    return {
-      id: condition.id,
-      data: [
-        {
-          label: "Verification Status",
-          value: condition.verificationStatus,
-        },
-        {
-          label: "Clinical Status",
-          value: condition.clinicalStatus,
-        },
-        {
-          label: "Recorded Date",
-          value: condition.recordedDate,
-        },
-        {
-          label: "Display",
-          value: condition.snomedDisplay,
-        },
-        {
-          label: "Code",
-          value: condition.snomedCode,
-        },
-        {
-          label: "System",
-          value: condition.snomedSystem,
-        },
-      ],
-    };
-  }
+    function setupData(condition: ConditionModel): DataListStackEntry {
+      if (icd10Code) {
+        return {
+          id: condition.id,
+          data: [
+            {
+              label: "Verification Status",
+              value: condition.verificationStatus,
+            },
+            {
+              label: "Clinical Status",
+              value: condition.clinicalStatus,
+            },
+            {
+              label: "Recorded Date",
+              value: condition.recordedDate,
+            },
+            {
+              label: "Display",
+              value: condition.icd10Display,
+            },
+            {
+              label: "Code",
+              value: condition.icd10Code,
+            },
+            {
+              label: "System",
+              value: condition.icd10System,
+            },
+          ],
+        };
+      }
+      return {
+        id: condition.id,
+        data: [
+          {
+            label: "Verification Status",
+            value: condition.verificationStatus,
+          },
+          {
+            label: "Clinical Status",
+            value: condition.clinicalStatus,
+          },
+          {
+            label: "Recorded Date",
+            value: condition.recordedDate,
+          },
+          {
+            label: "Display",
+            value: condition.snomedDisplay,
+          },
+          {
+            label: "Code",
+            value: condition.snomedCode,
+          },
+          {
+            label: "System",
+            value: condition.snomedSystem,
+          },
+        ],
+      };
+    }
+  }, [getCTWFhirClient, icd10Code, snomedCode, patientUPIDPromise]);
 
-  if (!icd10) {
+  if (!icd10Code && !snomedCode) {
     return <div>No history found.</div>;
   }
 

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -78,13 +78,14 @@ export function Conditions({ className }: ConditionsProps) {
           confirmedConditionInfo.value.map((c) => new ConditionModel(c))
         );
         const ICD10ConfirmedCodes = confirmedConditionInfo.value.map(
-          (c) => new ConditionModel(c).icd10
+          (c) => new ConditionModel(c).icd10Code
         );
 
         if (notReviewedConditionInfo.status === "fulfilled") {
           const notReviewedConditionsFiltered =
             notReviewedConditionInfo.value.filter(
-              (c) => !ICD10ConfirmedCodes.includes(new ConditionModel(c).icd10)
+              (c) =>
+                !ICD10ConfirmedCodes.includes(new ConditionModel(c).icd10Code)
             );
           setNotReviewedConditions(
             notReviewedConditionsFiltered.map((c) => new ConditionModel(c))

--- a/src/models/conditions.ts
+++ b/src/models/conditions.ts
@@ -129,6 +129,18 @@ export class ConditionModel {
     return codeableConceptLabel(this.resource.severity);
   }
 
+  get snomedCode(): string | undefined {
+    return findCoding(SYSTEM_SNOMED, this.resource.code)?.code;
+  }
+
+  get snomedDisplay(): string | undefined {
+    return findCoding(SYSTEM_SNOMED, this.resource.code)?.display;
+  }
+
+  get snomedSystem(): string | undefined {
+    return findCoding(SYSTEM_SNOMED, this.resource.code)?.system;
+  }
+
   get stages(): string[] {
     return (
       this.resource.stage?.map((stage) => {
@@ -141,17 +153,5 @@ export class ConditionModel {
 
   get verificationStatus(): string {
     return codeableConceptLabel(this.resource.verificationStatus);
-  }
-
-  get snomedCode(): string | undefined {
-    return findCoding(SYSTEM_SNOMED, this.resource.code)?.code;
-  }
-
-  get snomedSystem(): string | undefined {
-    return findCoding(SYSTEM_SNOMED, this.resource.code)?.system;
-  }
-
-  get snomedDisplay(): string | undefined {
-    return findCoding(SYSTEM_SNOMED, this.resource.code)?.display;
   }
 }

--- a/src/models/conditions.ts
+++ b/src/models/conditions.ts
@@ -71,8 +71,16 @@ export class ConditionModel {
     );
   }
 
-  get icd10(): string | undefined {
+  get icd10Code(): string | undefined {
     return findCoding(SYSTEM_ICD10, this.resource.code)?.code;
+  }
+
+  get icd10System(): string | undefined {
+    return findCoding(SYSTEM_ICD10, this.resource.code)?.system;
+  }
+
+  get icd10Display(): string | undefined {
+    return findCoding(SYSTEM_ICD10, this.resource.code)?.display;
   }
 
   get id(): string {


### PR DESCRIPTION
This PR adds fetching by icd10 or snomed and if there are both it displays both in the condition history drawer. First search is by icd10. 
![Screen Shot 2022-09-20 at 12 46 49 PM](https://user-images.githubusercontent.com/98342697/191328241-bc1a0bfe-4f83-40b0-acf5-ccc9d04ea10f.png)
