### PR TITLE
Bugfix - reset the state after viewing condition

### DIFF
--- a/.changeset/rich-pets-refuse.md
+++ b/.changeset/rich-pets-refuse.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Couple fixes reseting the loading state after fetching condition history for a particular condition and increasing fetch size.

--- a/.changeset/rich-pets-refuse.md
+++ b/.changeset/rich-pets-refuse.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Couple fixes reseting the loading state after fetching condition history for a particular condition and increasing fetch size.
+Resets history loading state after fetching condition history for a particular condition and increases fetch size for searchAllRecords.

--- a/src/components/content/condition-form-drawer.tsx
+++ b/src/components/content/condition-form-drawer.tsx
@@ -12,7 +12,6 @@ export type ConditionFormDrawerProps = {
 
 export function ConditionFormDrawer({
   className,
-  editing,
   isOpen,
   onClose,
 }: ConditionFormDrawerProps) {

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -113,10 +113,11 @@ export function ConditionHistory({
 
     return function cleanup() {
       setConditions([]);
+      setLoading(true);
     };
   }, [getCTWFhirClient, icd10Code, snomedCode, patientPromise]);
 
-  if (!icd10Code && !snomedCode) {
+  if (conditions.length === 0 && !loading) {
     return <div>No history found.</div>;
   }
 

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -110,6 +110,10 @@ export function ConditionHistory({
         data: [...data],
       };
     }
+
+    return function cleanup() {
+      setConditions([]);
+    };
   }, [getCTWFhirClient, icd10Code, snomedCode, patientPromise]);
 
   if (!icd10Code && !snomedCode) {

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -30,6 +30,8 @@ export type SearchReturn<T extends ResourceTypeString> = {
   resources: ResourceType<T>[];
 };
 
+const MAX_COUNT = 250;
+
 // Performs a FHIR search for the given resourceType accross all resources
 // the user has access to. This can include lens and third party resources!
 // Returns {bundle: fhir4.Bundle, total: number, resources: ResourceType[]}.
@@ -42,11 +44,14 @@ export async function searchAllRecords<T extends ResourceTypeString>(
   fhirClient: Client,
   searchParams?: SearchParams
 ): Promise<SearchReturn<T>> {
-  const { patientUPID, ...params } = searchParams ?? {};
+  const { patientUPID, _count, ...params } = searchParams ?? {};
+  const fetchAll = typeof _count === "undefined";
+  const count = fetchAll ? MAX_COUNT : _count;
   const bundle = (await fhirClient.search({
     resourceType,
     searchParams: {
       ...params,
+      _count: count,
       ...patientSearchParams(resourceType, patientUPID as string),
     },
   })) as fhir4.Bundle;

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -10,6 +10,8 @@ import {
 } from "./system-urls";
 import { ResourceType, ResourceTypeString } from "./types";
 
+const MAX_COUNT = 250;
+
 // Enumerating ALL of the third party tags.
 const THIRD_PARTY_TAGS = [
   `${SYSTEM_ZUS_THIRD_PARTY}|surescripts`,
@@ -29,8 +31,6 @@ export type SearchReturn<T extends ResourceTypeString> = {
   total: number;
   resources: ResourceType<T>[];
 };
-
-const MAX_COUNT = 250;
 
 // Performs a FHIR search for the given resourceType accross all resources
 // the user has access to. This can include lens and third party resources!


### PR DESCRIPTION
This resets the state so if you view condition A and then click on condition B, it doesn't show you condition A.