### PR TITLE
CTW-327 Followup: Condition Table Column Width Patch

### DIFF
--- a/.changeset/seven-cats-join.md
+++ b/.changeset/seven-cats-join.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+In the condition table, column widths were recalculated to add up to 100% to avoid confusion. This will not impact how the table is viewed.

--- a/src/components/content/conditions-table-base.tsx
+++ b/src/components/content/conditions-table-base.tsx
@@ -30,7 +30,7 @@ export function ConditionsTableBase({
     {
       title: "Status",
       dataIndex: "clinicalStatus",
-      className: "ctw-w-[10%]",
+      className: "ctw-w-[5%]",
     },
     {
       title: "Recorded Date",
@@ -38,7 +38,7 @@ export function ConditionsTableBase({
       className: "ctw-w-[10%]",
     },
     {
-      className: "ctw-w-[10%] ctw-table-action-column",
+      className: "ctw-w-[5%] ctw-table-action-column",
       render: (condition: ConditionModel) => (
         <DropdownMenu menuItems={rowActions(condition)}>
           <DotsHorizontalIcon className="ctw-w-5" />


### PR DESCRIPTION
Recalculated the Condition table column width classes to total 100% to prevent confusion. This will not impact how the table is viewed.