### PR TITLE
Don't use useLayoutEffect directly

### DIFF
--- a/.changeset/gentle-clouds-travel.md
+++ b/.changeset/gentle-clouds-travel.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix SSR issue by avoiding use of useLayoutEffect directly.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,6 +32,19 @@ module.exports = {
         ],
       },
     ],
+    "@typescript-eslint/no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          {
+            name: "react",
+            importNames: ["useLayoutEffect"],
+            message:
+              "`useLayoutEffect` causes a warning in SSR. Use `useIsomorphicLayoutEffect` instead.",
+          },
+        ],
+      },
+    ],
   },
   // we're using vitest which has a very similar API to jest
   // (so the linting plugins work nicely), but it we have to explicitly

--- a/src/hooks/use-breakpoints.ts
+++ b/src/hooks/use-breakpoints.ts
@@ -2,7 +2,8 @@ import { useCTW } from "@/components/core/ctw-provider";
 import { defaultBreakpoints } from "@/styles/tailwind.theme";
 import useResizeObserver from "@react-hook/resize-observer";
 import { mapValues } from "lodash";
-import { RefObject, useLayoutEffect, useState } from "react";
+import { RefObject, useState } from "react";
+import { useIsomorphicLayoutEffect } from "./use-isomorphic-layout-effect";
 
 type BreakpointKeys = keyof typeof defaultBreakpoints;
 type Breakpoints = Record<BreakpointKeys, boolean>;
@@ -25,8 +26,9 @@ export function useBreakpoints<T extends HTMLElement>(target: RefObject<T>) {
     setBreakpoints(breakpointsTmp);
   }
 
-  // Update on initial render (useLayout) and on any resizes.
-  useLayoutEffect(updateBreakpointClasses, [target, theme]);
+  // Update on initial render (useIsomorphicLayoutEffect) and
+  // on any resizes.
+  useIsomorphicLayoutEffect(updateBreakpointClasses, [target, theme]);
   useResizeObserver(target, (_) => updateBreakpointClasses());
 
   return breakpoints;

--- a/src/hooks/use-isomorphic-layout-effect.ts
+++ b/src/hooks/use-isomorphic-layout-effect.ts
@@ -1,0 +1,5 @@
+import { useEffect, useLayoutEffect } from "react";
+
+// Wraps use of useLayoutEffect in a guard to protect against SSR uses.
+export const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;

--- a/src/hooks/use-isomorphic-layout-effect.ts
+++ b/src/hooks/use-isomorphic-layout-effect.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { useEffect, useLayoutEffect } from "react";
 
 // Wraps use of useLayoutEffect in a guard to protect against SSR uses.


### PR DESCRIPTION
This fixes an issue with SSR.

> Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.

Followed https://medium.com/@alexandereardon/uselayouteffect-and-ssr-192986cdcf7a for work around.