### PR TITLE
Ctw 354/manage inconsistent coding in history panel

### DIFF
--- a/.changeset/dirty-pandas-dream.md
+++ b/.changeset/dirty-pandas-dream.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Manage inconsistent coding in Conditions History Panel. Now supports SNOMED, ICD-10, ICD-10CM, ICD-9, ICD-9CM for code matching. Will now filter out summary and lens tags as well.

--- a/src/components/content/conditions-history-drawer.tsx
+++ b/src/components/content/conditions-history-drawer.tsx
@@ -4,7 +4,7 @@ import { ConditionHistory } from "./conditions-history";
 
 export type ConditionHistoryDrawerProps = {
   className?: string;
-  condition?: ConditionModel;
+  condition: ConditionModel;
   isOpen: boolean;
   onClose: () => void;
 };
@@ -15,11 +15,8 @@ export function ConditionHistoryDrawer({
   isOpen,
   onClose,
 }: ConditionHistoryDrawerProps) {
-  const data = ConditionHistory({
-    icd10Code: condition?.icd10Code,
-    snomedCode: condition?.snomedCode,
-  });
-  const conditionName = condition?.display;
+  const data = ConditionHistory({ condition });
+  const conditionName = condition.display;
   const title = "Condition History";
 
   return (

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -1,7 +1,8 @@
-import { getConditionHistory } from "@/fhir/conditions";
+import { ACCEPTABLE_CODES, getConditionHistory } from "@/fhir/conditions";
+import { useFhirClientRef } from "@/fhir/utils";
 import { ConditionModel } from "@/models/conditions";
+import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import { useCTW } from "../core/ctw-provider";
 import {
   DataListStack,
   DataListStackEntries,
@@ -12,43 +13,53 @@ import { Spinner } from "../core/spinner";
 
 const CONDITION_HISTORY_LIMIT = 10;
 
-export type ConditionHistoryProps = {
-  icd10Code?: string | undefined;
-  snomedCode?: string | undefined;
-};
-
-export function ConditionHistory({
-  icd10Code,
-  snomedCode,
-}: ConditionHistoryProps) {
+export function ConditionHistory({ condition }: { condition: ConditionModel }) {
   const [conditions, setConditions] = useState<DataListStackEntries>([]);
   const [loading, setLoading] = useState(true);
-  const { getCTWFhirClient } = useCTW();
+  const [patientUPID, setPatientUPID] = useState("");
+  const [searchParams, setSearchParams] = useState({});
+  const fhirClientRef = useFhirClientRef();
   const { patientPromise } = usePatient();
+  const historyResponse = useQuery(
+    ["conditions", patientUPID, searchParams],
+    getConditionHistory,
+    {
+      enabled: !!patientUPID && !!fhirClientRef,
+      meta: { fhirClientRef },
+    }
+  );
 
   useEffect(() => {
     async function load() {
-      const fhirClient = await getCTWFhirClient();
       const patientTemp = await patientPromise;
+      if (patientTemp.UPID) {
+        setPatientUPID(patientTemp.UPID);
+      }
+      console.log("history", historyResponse);
 
-      const allConditions = await getConditionHistory(
-        fhirClient,
-        patientTemp.UPID
-      );
-      const models = allConditions.map(
-        (condition) => new ConditionModel(condition)
-      );
+      if (historyResponse.data) {
+        const filteredConditions = historyResponse.data.map(
+          (c) => new ConditionModel(c)
+        );
 
-      const filteredConditions = models.filter(
-        (condition) =>
-          (condition.icd10Code === icd10Code &&
-            typeof icd10Code !== "undefined") ||
-          (condition.snomedCode === snomedCode &&
-            typeof snomedCode !== "undefined")
-      );
+        const TagFilter = [];
+        ACCEPTABLE_CODES.forEach((code) => {
+          if (condition[code]) {
+            TagFilter.push(`${condition}|${condition[code]}`);
+          }
+        });
 
-      setConditions(filteredConditions.map((model) => setupData(model)));
-      setLoading(false);
+        // const filteredConditions = models.filter(
+        //   (condition) =>
+        //     (condition.icd10Code === icd10Code &&
+        //       typeof icd10Code !== "undefined") ||
+        //     (condition.snomedCode === snomedCode &&
+        //       typeof snomedCode !== "undefined")
+        // );
+
+        setConditions(filteredConditions.map((model) => setupData(model)));
+        setLoading(false);
+      }
     }
 
     load();
@@ -97,11 +108,11 @@ export function ConditionHistory({
         },
       ];
 
-      if (icd10Code) {
+      if (condition.icd10Code) {
         data = data.concat(ICD10Fields);
       }
 
-      if (snomedCode) {
+      if (condition.snomedCode) {
         data = data.concat(SNOMEDFields);
       }
 
@@ -115,7 +126,7 @@ export function ConditionHistory({
       setConditions([]);
       setLoading(true);
     };
-  }, [getCTWFhirClient, icd10Code, snomedCode, patientPromise]);
+  }, [condition, patientPromise, historyResponse.data]);
 
   if (conditions.length === 0 && !loading) {
     return <div>No history found.</div>;

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -1,4 +1,7 @@
-import { ACCEPTABLE_CODES, getConditionHistory } from "@/fhir/conditions";
+import {
+  getConditionFilterTokens,
+  getConditionHistory,
+} from "@/fhir/conditions";
 import { useFhirClientRef } from "@/fhir/utils";
 import { ConditionModel } from "@/models/conditions";
 import { useQuery } from "@tanstack/react-query";
@@ -13,15 +16,73 @@ import { Spinner } from "../core/spinner";
 
 const CONDITION_HISTORY_LIMIT = 10;
 
+function setupData(condition: ConditionModel): DataListStackEntry {
+  let data = [
+    {
+      label: "Verification Status",
+      value: condition.verificationStatus,
+    },
+    {
+      label: "Clinical Status",
+      value: condition.clinicalStatus,
+    },
+    {
+      label: "Recorded Date",
+      value: condition.recordedDate,
+    },
+  ];
+  const ICD10Fields = [
+    {
+      label: "ICD10 Display",
+      value: condition.icd10Display,
+    },
+    {
+      label: "ICD10 Code",
+      value: condition.icd10Code,
+    },
+    {
+      label: "ICD10 System",
+      value: condition.icd10System,
+    },
+  ];
+  const SNOMEDFields = [
+    {
+      label: "SNOMED Display",
+      value: condition.snomedDisplay,
+    },
+    {
+      label: "SNOMED Code",
+      value: condition.snomedCode,
+    },
+    {
+      label: "SNOMED System",
+      value: condition.snomedSystem,
+    },
+  ];
+
+  if (condition.icd10Code) {
+    data = data.concat(ICD10Fields);
+  }
+
+  if (condition.snomedCode) {
+    data = data.concat(SNOMEDFields);
+  }
+
+  return {
+    id: condition.id,
+    data: [...data],
+  };
+}
+
 export function ConditionHistory({ condition }: { condition: ConditionModel }) {
   const [conditions, setConditions] = useState<DataListStackEntries>([]);
   const [loading, setLoading] = useState(true);
   const [patientUPID, setPatientUPID] = useState("");
-  const [searchParams, setSearchParams] = useState({});
+  const [conditionTokens, setConditionTokens] = useState<string[]>([]);
   const fhirClientRef = useFhirClientRef();
   const { patientPromise } = usePatient();
   const historyResponse = useQuery(
-    ["conditions", patientUPID, searchParams],
+    ["conditions", patientUPID, conditionTokens],
     getConditionHistory,
     {
       enabled: !!patientUPID && !!fhirClientRef,
@@ -31,31 +92,16 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
 
   useEffect(() => {
     async function load() {
+      setConditionTokens(getConditionFilterTokens(condition));
       const patientTemp = await patientPromise;
       if (patientTemp.UPID) {
         setPatientUPID(patientTemp.UPID);
       }
-      console.log("history", historyResponse);
 
       if (historyResponse.data) {
         const filteredConditions = historyResponse.data.map(
           (c) => new ConditionModel(c)
         );
-
-        const TagFilter = [];
-        ACCEPTABLE_CODES.forEach((code) => {
-          if (condition[code]) {
-            TagFilter.push(`${condition}|${condition[code]}`);
-          }
-        });
-
-        // const filteredConditions = models.filter(
-        //   (condition) =>
-        //     (condition.icd10Code === icd10Code &&
-        //       typeof icd10Code !== "undefined") ||
-        //     (condition.snomedCode === snomedCode &&
-        //       typeof snomedCode !== "undefined")
-        // );
 
         setConditions(filteredConditions.map((model) => setupData(model)));
         setLoading(false);
@@ -63,64 +109,6 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
     }
 
     load();
-
-    function setupData(condition: ConditionModel): DataListStackEntry {
-      let data = [
-        {
-          label: "Verification Status",
-          value: condition.verificationStatus,
-        },
-        {
-          label: "Clinical Status",
-          value: condition.clinicalStatus,
-        },
-        {
-          label: "Recorded Date",
-          value: condition.recordedDate,
-        },
-      ];
-      const ICD10Fields = [
-        {
-          label: "ICD10 Display",
-          value: condition.icd10Display,
-        },
-        {
-          label: "ICD10 Code",
-          value: condition.icd10Code,
-        },
-        {
-          label: "ICD10 System",
-          value: condition.icd10System,
-        },
-      ];
-      const SNOMEDFields = [
-        {
-          label: "SNOMED Display",
-          value: condition.snomedDisplay,
-        },
-        {
-          label: "SNOMED Code",
-          value: condition.snomedCode,
-        },
-        {
-          label: "SNOMED System",
-          value: condition.snomedSystem,
-        },
-      ];
-
-      if (condition.icd10Code) {
-        data = data.concat(ICD10Fields);
-      }
-
-      if (condition.snomedCode) {
-        data = data.concat(SNOMEDFields);
-      }
-
-      return {
-        id: condition.id,
-        data: [...data],
-      };
-    }
 
     return function cleanup() {
       setConditions([]);

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -47,60 +47,62 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
         setLoading(false);
       }
 
-      function setupData(condition: ConditionModel): DataListStackEntry {
+      function setupData(
+        conditionForSetup: ConditionModel
+      ): DataListStackEntry {
         let data = [
           {
             label: "Verification Status",
-            value: condition.verificationStatus,
+            value: conditionForSetup.verificationStatus,
           },
           {
             label: "Clinical Status",
-            value: condition.clinicalStatus,
+            value: conditionForSetup.clinicalStatus,
           },
           {
             label: "Recorded Date",
-            value: condition.recordedDate,
+            value: conditionForSetup.recordedDate,
           },
         ];
         const ICD10Fields = [
           {
             label: "ICD10 Display",
-            value: condition.icd10Display,
+            value: conditionForSetup.icd10Display,
           },
           {
             label: "ICD10 Code",
-            value: condition.icd10Code,
+            value: conditionForSetup.icd10Code,
           },
           {
             label: "ICD10 System",
-            value: condition.icd10System,
+            value: conditionForSetup.icd10System,
           },
         ];
         const SNOMEDFields = [
           {
             label: "SNOMED Display",
-            value: condition.snomedDisplay,
+            value: conditionForSetup.snomedDisplay,
           },
           {
             label: "SNOMED Code",
-            value: condition.snomedCode,
+            value: conditionForSetup.snomedCode,
           },
           {
             label: "SNOMED System",
-            value: condition.snomedSystem,
+            value: conditionForSetup.snomedSystem,
           },
         ];
 
-        if (condition.icd10Code) {
+        if (conditionForSetup.icd10Code) {
           data = data.concat(ICD10Fields);
         }
 
-        if (condition.snomedCode) {
+        if (conditionForSetup.snomedCode) {
           data = data.concat(SNOMEDFields);
         }
 
         return {
-          id: condition.id,
+          id: conditionForSetup.id,
           data: [...data],
         };
       }

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -1,7 +1,4 @@
-import {
-  getConditionFilterTokens,
-  getConditionHistory,
-} from "@/fhir/conditions";
+import { getConditionHistory } from "@/fhir/conditions";
 import { useFhirClientRef } from "@/fhir/utils";
 import { ConditionModel } from "@/models/conditions";
 import { useQuery } from "@tanstack/react-query";
@@ -16,73 +13,16 @@ import { Spinner } from "../core/spinner";
 
 const CONDITION_HISTORY_LIMIT = 10;
 
-function setupData(condition: ConditionModel): DataListStackEntry {
-  let data = [
-    {
-      label: "Verification Status",
-      value: condition.verificationStatus,
-    },
-    {
-      label: "Clinical Status",
-      value: condition.clinicalStatus,
-    },
-    {
-      label: "Recorded Date",
-      value: condition.recordedDate,
-    },
-  ];
-  const ICD10Fields = [
-    {
-      label: "ICD10 Display",
-      value: condition.icd10Display,
-    },
-    {
-      label: "ICD10 Code",
-      value: condition.icd10Code,
-    },
-    {
-      label: "ICD10 System",
-      value: condition.icd10System,
-    },
-  ];
-  const SNOMEDFields = [
-    {
-      label: "SNOMED Display",
-      value: condition.snomedDisplay,
-    },
-    {
-      label: "SNOMED Code",
-      value: condition.snomedCode,
-    },
-    {
-      label: "SNOMED System",
-      value: condition.snomedSystem,
-    },
-  ];
-
-  if (condition.icd10Code) {
-    data = data.concat(ICD10Fields);
-  }
-
-  if (condition.snomedCode) {
-    data = data.concat(SNOMEDFields);
-  }
-
-  return {
-    id: condition.id,
-    data: [...data],
-  };
-}
-
 export function ConditionHistory({ condition }: { condition: ConditionModel }) {
   const [conditions, setConditions] = useState<DataListStackEntries>([]);
   const [loading, setLoading] = useState(true);
   const [patientUPID, setPatientUPID] = useState("");
-  const [conditionTokens, setConditionTokens] = useState<string[]>([]);
+  const [conditionForSearch, setConditionForSearch] =
+    useState<ConditionModel>();
   const fhirClientRef = useFhirClientRef();
   const { patientPromise } = usePatient();
   const historyResponse = useQuery(
-    ["conditions", patientUPID, conditionTokens],
+    ["conditions", patientUPID, conditionForSearch],
     getConditionHistory,
     {
       enabled: !!patientUPID && !!fhirClientRef,
@@ -92,7 +32,7 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
 
   useEffect(() => {
     async function load() {
-      setConditionTokens(getConditionFilterTokens(condition));
+      setConditionForSearch(condition);
       const patientTemp = await patientPromise;
       if (patientTemp.UPID) {
         setPatientUPID(patientTemp.UPID);
@@ -105,6 +45,64 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
 
         setConditions(filteredConditions.map((model) => setupData(model)));
         setLoading(false);
+      }
+
+      function setupData(condition: ConditionModel): DataListStackEntry {
+        let data = [
+          {
+            label: "Verification Status",
+            value: condition.verificationStatus,
+          },
+          {
+            label: "Clinical Status",
+            value: condition.clinicalStatus,
+          },
+          {
+            label: "Recorded Date",
+            value: condition.recordedDate,
+          },
+        ];
+        const ICD10Fields = [
+          {
+            label: "ICD10 Display",
+            value: condition.icd10Display,
+          },
+          {
+            label: "ICD10 Code",
+            value: condition.icd10Code,
+          },
+          {
+            label: "ICD10 System",
+            value: condition.icd10System,
+          },
+        ];
+        const SNOMEDFields = [
+          {
+            label: "SNOMED Display",
+            value: condition.snomedDisplay,
+          },
+          {
+            label: "SNOMED Code",
+            value: condition.snomedCode,
+          },
+          {
+            label: "SNOMED System",
+            value: condition.snomedSystem,
+          },
+        ];
+
+        if (condition.icd10Code) {
+          data = data.concat(ICD10Fields);
+        }
+
+        if (condition.snomedCode) {
+          data = data.concat(SNOMEDFields);
+        }
+
+        return {
+          id: condition.id,
+          data: [...data],
+        };
       }
     }
 

--- a/src/components/core/ctw-provider.tsx
+++ b/src/components/core/ctw-provider.tsx
@@ -85,11 +85,11 @@ function CTWProvider({ theme, children, ...ctwState }: CTWProviderProps) {
 
   return (
     <div style={mapToCSSVar(theme?.colors || {})}>
-      <QueryClientProvider client={queryClient}>
-        <CTWStateContext.Provider value={providerState}>
+      <CTWStateContext.Provider value={providerState}>
+        <QueryClientProvider client={queryClient}>
           {children}
-        </CTWStateContext.Provider>
-      </QueryClientProvider>
+        </QueryClientProvider>
+      </CTWStateContext.Provider>
     </div>
   );
 }

--- a/src/fhir/conditions.ts
+++ b/src/fhir/conditions.ts
@@ -8,14 +8,20 @@ import {
   searchCommonRecords,
   searchLensRecords,
 } from "./search-helpers";
+import {
+  SYSTEM_ICD10,
+  SYSTEM_ICD10_CM,
+  SYSTEM_ICD9,
+  SYSTEM_SNOMED,
+} from "./system-urls";
 import { getFhirClientFromQuery } from "./utils";
 
-export const ACCEPTABLE_CODES: (keyof ConditionModel)[] = [
-  "snomedCoding",
-  "icd10Coding",
-  "icd10CMCoding",
-  "icd9Coding",
-  "icd9CMCoding",
+export const CONDITION_CODE_SYSTEMS = [
+  SYSTEM_ICD10,
+  SYSTEM_ICD10_CM,
+  SYSTEM_ICD9,
+  SYSTEM_ICD10_CM,
+  SYSTEM_SNOMED,
 ];
 
 export type ClinicalStatus =
@@ -34,17 +40,8 @@ export type QueryKeyConfirmedConditions = [string, string, ConditionFilters];
 export type QueryKeyLensConditions = [string, string];
 export type QueryKeyConditionHistory = [string, string, string[]];
 
-export const getConditionFilterTokens = (condition: ConditionModel) => {
-  const tokens: string[] = [];
-  ACCEPTABLE_CODES.forEach((code) => {
-    if (condition[code]) {
-      const coding = condition[code] as fhir4.Coding;
-      tokens.push(`${coding.system}|${coding.code}`);
-    }
-  });
-
-  return tokens;
-};
+export const getConditionFilterTokens = (condition: ConditionModel) =>
+  condition.availableCodes.map((coding) => `${coding.system}|${coding.code}`);
 
 export async function getConfirmedConditions(
   queryParams: QueryFunctionContext<QueryKeyConfirmedConditions>

--- a/src/fhir/conditions.ts
+++ b/src/fhir/conditions.ts
@@ -12,14 +12,15 @@ import {
   SYSTEM_ICD10,
   SYSTEM_ICD10_CM,
   SYSTEM_ICD9,
+  SYSTEM_ICD9_CM,
   SYSTEM_SNOMED,
 } from "./system-urls";
 import { getFhirClientFromQuery } from "./utils";
 
 export const CONDITION_CODE_SYSTEMS = [
-  SYSTEM_ICD10,
-  SYSTEM_ICD10_CM,
   SYSTEM_ICD9,
+  SYSTEM_ICD9_CM,
+  SYSTEM_ICD10,
   SYSTEM_ICD10_CM,
   SYSTEM_SNOMED,
 ];
@@ -41,7 +42,7 @@ export type QueryKeyLensConditions = [string, string];
 export type QueryKeyConditionHistory = [string, string, string[]];
 
 export const getConditionFilterTokens = (condition: ConditionModel) =>
-  condition.availableCodes.map((coding) => `${coding.system}|${coding.code}`);
+  condition.knownCodings.map((coding) => `${coding.system}|${coding.code}`);
 
 export async function getConfirmedConditions(
   queryParams: QueryFunctionContext<QueryKeyConfirmedConditions>

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -84,7 +84,7 @@ export async function searchLensRecords<T extends ResourceTypeString>(
 ): Promise<SearchReturn<T>> {
   return searchAllRecords(resourceType, fhirClient, {
     ...searchParams,
-    _tag: [...LENS_TAGS, ...SUMMARY_TAGS].join(","),
+    _tag: LENS_TAGS.join(","),
   });
 }
 
@@ -96,7 +96,7 @@ export async function searchCommonRecords<T extends ResourceTypeString>(
 ): Promise<SearchReturn<T>> {
   return searchAllRecords(resourceType, fhirClient, {
     ...searchParams,
-    "_tag:not": LENS_TAGS.join(","),
+    "_tag:not": [...LENS_TAGS, ...SUMMARY_TAGS].join(","),
   });
 }
 

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -26,6 +26,8 @@ const LENS_TAGS = [
   `${SYSTEM_SUMMARY}|Common`,
 ];
 
+const SUMMARY_TAGS = [`${SYSTEM_SUMMARY}|Common`];
+
 export type SearchReturn<T extends ResourceTypeString> = {
   bundle: fhir4.Bundle;
   total: number;
@@ -82,7 +84,7 @@ export async function searchLensRecords<T extends ResourceTypeString>(
 ): Promise<SearchReturn<T>> {
   return searchAllRecords(resourceType, fhirClient, {
     ...searchParams,
-    _tag: LENS_TAGS.join(","),
+    _tag: [...LENS_TAGS, ...SUMMARY_TAGS].join(","),
   });
 }
 

--- a/src/fhir/system-urls.ts
+++ b/src/fhir/system-urls.ts
@@ -1,13 +1,19 @@
 export const SYSTEM_CCS =
   "https://www.hcup-us.ahrq.gov/toolssoftware/ccsr/dxccsr.jsp";
 
-export const SYSTEM_CONDITION_VERIFICATION_STATUS =
-  "http://terminology.hl7.org/CodeSystem/condition-ver-status";
-
 export const SYSTEM_CONDITION_CLINICAL =
   "http://terminology.hl7.org/CodeSystem/condition-clinical";
 
+export const SYSTEM_CONDITION_VERIFICATION_STATUS =
+  "http://terminology.hl7.org/CodeSystem/condition-ver-status";
+
+export const SYSTEM_ICD9 = "http://hl7.org/fhir/sid/icd-9";
+
+export const SYSTEM_ICD9_CM = "http://hl7.org/fhir/sid/icd-9-cm";
+
 export const SYSTEM_ICD10 = "http://hl7.org/fhir/sid/icd-10";
+
+export const SYSTEM_ICD10_CM = "http://hl7.org/fhir/sid/icd-10-cm";
 
 export const SYSTEM_MARITAL_STATUS =
   "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus";

--- a/src/models/conditions.ts
+++ b/src/models/conditions.ts
@@ -37,14 +37,6 @@ export class ConditionModel {
     return this.resource.asserter?.display;
   }
 
-  get knownCodings(): fhir4.Coding[] {
-    return compact(
-      CONDITION_CODE_SYSTEMS.map((system) =>
-        findCoding(system, this.resource.code)
-      )
-    );
-  }
-
   get bodySites(): string[] {
     return (
       this.resource.bodySite?.map((bodySite) =>
@@ -59,6 +51,10 @@ export class ConditionModel {
         codeableConceptLabel(category)
       ) || []
     );
+  }
+
+  get ccsGrouping(): string | undefined {
+    return findCoding(SYSTEM_CCS, this.resource.code)?.display;
   }
 
   get clinicalStatus(): string {
@@ -81,14 +77,6 @@ export class ConditionModel {
     );
   }
 
-  get knownCodings(): fhir4.Coding[] {
-    return compact(
-      CONDITION_CODE_SYSTEMS.map((system) =>
-        findCoding(system, this.resource.code)
-      )
-    );
-  }
-
   get icd10Code(): string | undefined {
     return findCoding(SYSTEM_ICD10, this.resource.code)?.code;
   }
@@ -101,12 +89,16 @@ export class ConditionModel {
     return findCoding(SYSTEM_ICD10, this.resource.code)?.display;
   }
 
-  get ccsGrouping(): string | undefined {
-    return findCoding(SYSTEM_CCS, this.resource.code)?.display;
-  }
-
   get id(): string {
     return this.resource.id || "";
+  }
+
+  get knownCodings(): fhir4.Coding[] {
+    return compact(
+      CONDITION_CODE_SYSTEMS.map((system) =>
+        findCoding(system, this.resource.code)
+      )
+    );
   }
 
   get notes(): string[] {

--- a/src/models/conditions.ts
+++ b/src/models/conditions.ts
@@ -37,7 +37,7 @@ export class ConditionModel {
     return this.resource.asserter?.display;
   }
 
-  get availableCodes(): fhir4.Coding[] {
+  get knownCodings(): fhir4.Coding[] {
     return compact(
       CONDITION_CODE_SYSTEMS.map((system) =>
         findCoding(system, this.resource.code)

--- a/src/models/conditions.ts
+++ b/src/models/conditions.ts
@@ -1,3 +1,5 @@
+import { CONDITION_CODE_SYSTEMS } from "@/fhir/conditions";
+import { compact } from "lodash";
 import { codeableConceptLabel, findCoding } from "../fhir/codeable-concept";
 import { formatDateISOToLocal } from "../fhir/formatters";
 import {
@@ -40,6 +42,14 @@ export class ConditionModel {
 
   get asserter(): string | undefined {
     return this.resource.asserter?.display;
+  }
+
+  get availableCodes(): fhir4.Coding[] {
+    return compact(
+      CONDITION_CODE_SYSTEMS.map((system) =>
+        findCoding(system, this.resource.code)
+      )
+    );
   }
 
   get bodySites(): string[] {

--- a/src/models/conditions.ts
+++ b/src/models/conditions.ts
@@ -1,6 +1,13 @@
 import { codeableConceptLabel, findCoding } from "../fhir/codeable-concept";
 import { formatDateISOToLocal } from "../fhir/formatters";
-import { SYSTEM_CCS, SYSTEM_ICD10, SYSTEM_SNOMED } from "../fhir/system-urls";
+import {
+  SYSTEM_CCS,
+  SYSTEM_ICD10,
+  SYSTEM_ICD10_CM,
+  SYSTEM_ICD9,
+  SYSTEM_ICD9_CM,
+  SYSTEM_SNOMED,
+} from "../fhir/system-urls";
 
 export class ConditionModel {
   public resource: fhir4.Condition;
@@ -71,7 +78,27 @@ export class ConditionModel {
     );
   }
 
+  get icd9Code(): string | undefined {
+    return findCoding(SYSTEM_ICD9, this.resource.code)?.code;
+  }
+
+  get icd9CMCode(): string | undefined {
+    return findCoding(SYSTEM_ICD9_CM, this.resource.code)?.code;
+  }
+
+  get icd10CMCode(): string | undefined {
+    return findCoding(SYSTEM_ICD10_CM, this.resource.code)?.code;
+  }
+
+  get icd10Coding(): fhir4.Coding | undefined {
+    return findCoding(SYSTEM_ICD10, this.resource.code);
+  }
+
   get icd10Code(): string | undefined {
+    console.log(
+      "findCoding(SYSTEM_ICD10, this.resource.code)",
+      findCoding(SYSTEM_ICD10, this.resource.code)
+    );
     return findCoding(SYSTEM_ICD10, this.resource.code)?.code;
   }
 

--- a/src/models/conditions.ts
+++ b/src/models/conditions.ts
@@ -78,16 +78,16 @@ export class ConditionModel {
     );
   }
 
-  get icd9Code(): string | undefined {
-    return findCoding(SYSTEM_ICD9, this.resource.code)?.code;
+  get icd9CMCoding(): fhir4.Coding | undefined {
+    return findCoding(SYSTEM_ICD9_CM, this.resource.code);
   }
 
-  get icd9CMCode(): string | undefined {
-    return findCoding(SYSTEM_ICD9_CM, this.resource.code)?.code;
+  get icd9Coding(): fhir4.Coding | undefined {
+    return findCoding(SYSTEM_ICD9, this.resource.code);
   }
 
-  get icd10CMCode(): string | undefined {
-    return findCoding(SYSTEM_ICD10_CM, this.resource.code)?.code;
+  get icd10CMCoding(): fhir4.Coding | undefined {
+    return findCoding(SYSTEM_ICD10_CM, this.resource.code);
   }
 
   get icd10Coding(): fhir4.Coding | undefined {
@@ -95,10 +95,6 @@ export class ConditionModel {
   }
 
   get icd10Code(): string | undefined {
-    console.log(
-      "findCoding(SYSTEM_ICD10, this.resource.code)",
-      findCoding(SYSTEM_ICD10, this.resource.code)
-    );
     return findCoding(SYSTEM_ICD10, this.resource.code)?.code;
   }
 
@@ -158,6 +154,10 @@ export class ConditionModel {
 
   get severity(): string {
     return codeableConceptLabel(this.resource.severity);
+  }
+
+  get snomedCoding(): fhir4.Coding | undefined {
+    return findCoding(SYSTEM_SNOMED, this.resource.code);
   }
 
   get snomedCode(): string | undefined {

--- a/src/models/conditions.ts
+++ b/src/models/conditions.ts
@@ -2,14 +2,7 @@ import { CONDITION_CODE_SYSTEMS } from "@/fhir/conditions";
 import { compact } from "lodash";
 import { codeableConceptLabel, findCoding } from "../fhir/codeable-concept";
 import { formatDateISOToLocal } from "../fhir/formatters";
-import {
-  SYSTEM_CCS,
-  SYSTEM_ICD10,
-  SYSTEM_ICD10_CM,
-  SYSTEM_ICD9,
-  SYSTEM_ICD9_CM,
-  SYSTEM_SNOMED,
-} from "../fhir/system-urls";
+import { SYSTEM_CCS, SYSTEM_ICD10, SYSTEM_SNOMED } from "../fhir/system-urls";
 
 export class ConditionModel {
   public resource: fhir4.Condition;
@@ -88,22 +81,6 @@ export class ConditionModel {
     );
   }
 
-  get icd9CMCoding(): fhir4.Coding | undefined {
-    return findCoding(SYSTEM_ICD9_CM, this.resource.code);
-  }
-
-  get icd9Coding(): fhir4.Coding | undefined {
-    return findCoding(SYSTEM_ICD9, this.resource.code);
-  }
-
-  get icd10CMCoding(): fhir4.Coding | undefined {
-    return findCoding(SYSTEM_ICD10_CM, this.resource.code);
-  }
-
-  get icd10Coding(): fhir4.Coding | undefined {
-    return findCoding(SYSTEM_ICD10, this.resource.code);
-  }
-
   get icd10Code(): string | undefined {
     return findCoding(SYSTEM_ICD10, this.resource.code)?.code;
   }
@@ -164,10 +141,6 @@ export class ConditionModel {
 
   get severity(): string {
     return codeableConceptLabel(this.resource.severity);
-  }
-
-  get snomedCoding(): fhir4.Coding | undefined {
-    return findCoding(SYSTEM_SNOMED, this.resource.code);
   }
 
   get snomedCode(): string | undefined {


### PR DESCRIPTION
Manage inconsistent coding in Conditions History Panel. Now supports SNOMED, ICD-10, ICD-10CM, ICD-9, ICD-9CM for code matching. Will now filter out summary and lens tags as well. Also now uses react query for history searches for faster performance when going back to already visited history searches. 