### PR TITLE
CTW-333: Filter out non-builder records using the builder ID in the JWT

### DIFF
--- a/.changeset/smooth-kiwis-dream.md
+++ b/.changeset/smooth-kiwis-dream.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Continue enforcing the rule of only showing builder-owned records as confirmed, by covering the new edge case where there are shared resources with other builders. Clients will not need to make any changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "0.10.0",
+  "version": "0.10.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "0.10.0",
+      "version": "0.10.3",
       "dependencies": {
         "@headlessui-float/react": "^0.9.1",
         "@headlessui/react": "^1.6.6",
@@ -16,6 +16,7 @@
         "@tanstack/react-query": "^4.3.9",
         "date-fns": "^2.29.1",
         "fhir-kit-client": "^1.9.1",
+        "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
         "zod": "^3.19.0"
       },
@@ -6863,6 +6864,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -15810,6 +15816,11 @@
         "array-includes": "^3.1.5",
         "object.assign": "^4.1.3"
       }
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "kind-of": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@tanstack/react-query": "^4.3.9",
     "date-fns": "^2.29.1",
     "fhir-kit-client": "^1.9.1",
+    "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
     "zod": "^3.19.0"
   }

--- a/src/fhir/client.ts
+++ b/src/fhir/client.ts
@@ -28,7 +28,7 @@ export type ZusJWT = {
   [key: string]: string | string[];
 };
 
-export function getJWT(fhirClient: Client): ZusJWT {
+export function getClaims(fhirClient: Client): ZusJWT {
   // Cast to access an unexposed property.
   const authHeader = (fhirClient as ClientAuth).httpClient.authHeader
     .authorization;

--- a/src/fhir/client.ts
+++ b/src/fhir/client.ts
@@ -25,8 +25,6 @@ export type ClientAuth = {
 } & Client;
 
 export type ZusJWT = {
-  SYSTEM_ZUS_BUILDER_ID: string;
-  // We only use the above properties. Others can be any key with any type.
   [key: string]: string | string[];
 };
 

--- a/src/fhir/client.ts
+++ b/src/fhir/client.ts
@@ -1,4 +1,5 @@
 import Client from "fhir-kit-client";
+import jwt_decode from "jwt-decode";
 
 import { Env } from "@/components/core/ctw-provider";
 
@@ -8,13 +9,33 @@ export function getFhirClient(env: Env, accessToken: string) {
       ? `https://api.zusapi.com/fhir`
       : `https://api.${env}.zusapi.com/fhir`;
 
-  return new Client({
+  const client = new Client({
     baseUrl: url,
     bearerToken: accessToken,
     customHeaders: {
       "User-Agent": "zus_ctw_component_library fhirclient",
     },
   });
+
+  return client;
+}
+
+export type ZusJWT = {
+  SYSTEM_ZUS_BUILDER_ID: string;
+  // We only use the above properties. Others can be any key with any type.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+};
+
+export function getJWT(fhirClient: Client): ZusJWT {
+  // To access an unexposed property, cast as any.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const authHeader = (fhirClient as any).httpClient.authHeader
+    .authorization as string;
+  const bearerToken = authHeader.substring(7);
+  // Cast because a decoded JWT is an unknown.
+  const jwt = jwt_decode(bearerToken) as ZusJWT;
+  return jwt;
 }
 
 // Returns a new value with all empty arrays replaced with "undefined".

--- a/src/fhir/client.ts
+++ b/src/fhir/client.ts
@@ -9,29 +9,31 @@ export function getFhirClient(env: Env, accessToken: string) {
       ? `https://api.zusapi.com/fhir`
       : `https://api.${env}.zusapi.com/fhir`;
 
-  const client = new Client({
+  return new Client({
     baseUrl: url,
     bearerToken: accessToken,
     customHeaders: {
       "User-Agent": "zus_ctw_component_library fhirclient",
     },
   });
-
-  return client;
 }
+
+export type ClientAuth = {
+  httpClient: {
+    authHeader: { authorization: string };
+  };
+} & Client;
 
 export type ZusJWT = {
   SYSTEM_ZUS_BUILDER_ID: string;
   // We only use the above properties. Others can be any key with any type.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+  [key: string]: string | string[];
 };
 
 export function getJWT(fhirClient: Client): ZusJWT {
-  // To access an unexposed property, cast as any.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const authHeader = (fhirClient as any).httpClient.authHeader
-    .authorization as string;
+  // Cast to access an unexposed property.
+  const authHeader = (fhirClient as ClientAuth).httpClient.authHeader
+    .authorization;
   const bearerToken = authHeader.substring(7);
   // Cast because a decoded JWT is an unknown.
   const jwt = jwt_decode(bearerToken) as ZusJWT;

--- a/src/fhir/client.ts
+++ b/src/fhir/client.ts
@@ -18,13 +18,13 @@ export function getFhirClient(env: Env, accessToken: string) {
   });
 }
 
-export type ClientAuth = {
+type ClientAuth = {
   httpClient: {
     authHeader: { authorization: string };
   };
 } & Client;
 
-export type ZusJWT = {
+type ZusJWT = {
   [key: string]: string | string[];
 };
 

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -69,11 +69,13 @@ export async function searchBuilderRecords<T extends ResourceTypeString>(
   fhirClient: Client,
   searchParams?: SearchParams
 ): Promise<SearchReturn<T>> {
+  const nonBuilderTags = [...THIRD_PARTY_TAGS, ...LENS_TAGS];
   const jwt = getJWT(fhirClient);
   const builderTag = `${SYSTEM_ZUS_OWNER}|builder/${jwt[SYSTEM_ZUS_BUILDER_ID]}`;
   return searchAllRecords(resourceType, fhirClient, {
     ...searchParams,
     _tag: builderTag,
+    "_tag:not": nonBuilderTags.join(","),
   });
 }
 

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -2,7 +2,7 @@ import Client, { SearchParams } from "fhir-kit-client";
 import { find, mapValues } from "lodash";
 
 import { getResources } from "./bundle";
-import { getJWT } from "./client";
+import { getClaims } from "./client";
 import {
   SYSTEM_SUMMARY,
   SYSTEM_ZUS_BUILDER_ID,
@@ -70,7 +70,7 @@ export async function searchBuilderRecords<T extends ResourceTypeString>(
   searchParams?: SearchParams
 ): Promise<SearchReturn<T>> {
   const nonBuilderTags = [...THIRD_PARTY_TAGS, ...LENS_TAGS];
-  const jwt = getJWT(fhirClient);
+  const jwt = getClaims(fhirClient);
   const builderTag = `${SYSTEM_ZUS_OWNER}|builder/${jwt[SYSTEM_ZUS_BUILDER_ID]}`;
   return searchAllRecords(resourceType, fhirClient, {
     ...searchParams,

--- a/src/fhir/system-urls.ts
+++ b/src/fhir/system-urls.ts
@@ -24,7 +24,9 @@ export const SYSTEM_SUMMARY = "https://zusapi.com/summary";
 export const SYSTEM_TASK_STATUS =
   "https://www.hl7.org/fhir/codesystem-task-status.html";
 
+export const SYSTEM_ZUS_BUILDER_ID = "https://zusapi.com/builder_id";
 export const SYSTEM_ZUS_LENS = "https://zusapi.com/lens";
+export const SYSTEM_ZUS_OWNER = "https://zusapi.com/accesscontrol/owner";
 export const SYSTEM_ZUS_THIRD_PARTY = "https://zusapi.com/thirdparty/source";
 export const SYSTEM_ZUS_UNIVERSAL_ID =
   "https://zusapi.com/fhir/identifier/universal-id";


### PR DESCRIPTION
Components that were meant to display only records owned by the builder now address the case of shared records between builders. Rather than filtering out by non-builder tags, the query filters for the ownership tag of the specific builder.