### PR TITLE
move context out of provider file to avoid refresh bug

### DIFF
--- a/.changeset/purple-parents-jog.md
+++ b/.changeset/purple-parents-jog.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Move ctw provider and context into separate files to avoid bug outlined in https://github.com/vitejs/vite/pull/10239

--- a/src/components/core/ctw-context.tsx
+++ b/src/components/core/ctw-context.tsx
@@ -1,0 +1,24 @@
+import { Theme } from "@/styles/tailwind.theme";
+import { createContext } from "react";
+import type { Env } from "./ctw-provider";
+
+export type CTWToken = {
+  accessToken: string;
+  issuedTokenType: string;
+  tokenType: string;
+  expiresAt: number;
+};
+
+export type CTWState = {
+  env: Env;
+  authToken?: string;
+  headers?: HeadersInit;
+  authTokenURL?: string;
+  theme?: Theme;
+  token?: CTWToken;
+  actions: {
+    handleAuth: () => Promise<string>;
+  };
+};
+
+export const CTWStateContext = createContext<CTWState | undefined>(undefined);

--- a/src/components/core/ctw-provider.tsx
+++ b/src/components/core/ctw-provider.tsx
@@ -3,38 +3,13 @@ import { DefaultTheme, mapToCSSVar, Theme } from "@/styles/tailwind.theme";
 import { queryClient } from "@/utils/request";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { merge } from "lodash";
-import {
-  createContext,
-  ReactNode,
-  useCallback,
-  useContext,
-  useMemo,
-  useState,
-} from "react";
+import { ReactNode, useCallback, useContext, useMemo, useState } from "react";
+import { CTWState, CTWStateContext, CTWToken } from "./ctw-context";
 import "./main.scss";
 
 export type Env = "dev" | "sandbox" | "production";
 
 const EXPIRY_PADDING_MS = 60000;
-
-type CTWToken = {
-  accessToken: string;
-  issuedTokenType: string;
-  tokenType: string;
-  expiresAt: number;
-};
-
-type CTWState = {
-  env: Env;
-  authToken?: string;
-  headers?: HeadersInit;
-  authTokenURL?: string;
-  theme?: Theme;
-  token?: CTWToken;
-  actions: {
-    handleAuth: () => Promise<string>;
-  };
-};
 
 type AuthTokenSpecified = { authToken: string; authTokenURL?: never };
 type AuthTokenURLSpecified = { authToken?: never; authTokenURL: string };
@@ -45,8 +20,6 @@ type CTWProviderProps = {
   theme?: Theme;
   headers?: HeadersInit;
 } & (AuthTokenSpecified | AuthTokenURLSpecified);
-
-const CTWStateContext = createContext<CTWState | undefined>(undefined);
 
 function CTWProvider({ theme, children, ...ctwState }: CTWProviderProps) {
   const [token, setToken] = useState<CTWToken>();


### PR DESCRIPTION
Moving the CTW Context and provider into separate files to avoid issues when changing certain files it errors out and  says context is not defined. This is caused by a bug in vite which there is a current open pr on.. https://github.com/vitejs/vite/pull/10239, which should solve this. Being that this bug is annoying enough in dev i am splitting context and provider into separate files to avoid this bug. 