### PR TITLE
Condition History Detail and Summary Spacing fix

### DIFF
--- a/.changeset/gold-bears-shop.md
+++ b/.changeset/gold-bears-shop.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Condition history detail card and summary card now have a space between them.

--- a/src/components/core/collapsible-data-list.tsx
+++ b/src/components/core/collapsible-data-list.tsx
@@ -25,7 +25,7 @@ export const CollapsibleDataList = ({
   const [isDetailShown, setIsDetailShown] = useState(false);
 
   return (
-    <div className="space-y-3">
+    <div className="ctw-space-y-3">
       <DetailSummary
         date={date}
         title={title}

--- a/src/components/core/collapsible-data-list.tsx
+++ b/src/components/core/collapsible-data-list.tsx
@@ -25,7 +25,7 @@ export const CollapsibleDataList = ({
   const [isDetailShown, setIsDetailShown] = useState(false);
 
   return (
-    <div>
+    <div className="space-y-3">
       <DetailSummary
         date={date}
         title={title}


### PR DESCRIPTION
This PR fixes the spacing between detail and summary card. 
![Screen Shot 2022-10-04 at 3 38 36 PM](https://user-images.githubusercontent.com/98342697/193922491-6ff78688-77a8-4c0e-8976-95e75a44ca54.png)
