### PR TITLE
Primarily alphabetize by CCS Grouping

### DIFF
--- a/.changeset/breezy-cobras-remember.md
+++ b/.changeset/breezy-cobras-remember.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Alphabetize conditions primarily by CCS grouping and secondarily the condition name so that users can quickly find the conditions by their category.

--- a/src/fhir/conditions.ts
+++ b/src/fhir/conditions.ts
@@ -128,7 +128,10 @@ export async function getConditionHistory(
 function filterAndSort(conditions: fhir4.Condition[]) {
   return sortBy(
     conditions.filter((condition) => condition.asserter?.type !== "Patient"),
-    (condition) => new ConditionModel(condition).display
+    (condition) => {
+      const model = new ConditionModel(condition);
+      return model.ccsGrouping || model.display;
+    }
   );
 }
 

--- a/src/fhir/conditions.ts
+++ b/src/fhir/conditions.ts
@@ -130,7 +130,7 @@ function filterAndSort(conditions: fhir4.Condition[]) {
     conditions.filter((condition) => condition.asserter?.type !== "Patient"),
     (condition) => {
       const model = new ConditionModel(condition);
-      return model.ccsGrouping || model.display;
+      return model.ccsGrouping || "" + model.display || "";
     }
   );
 }

--- a/src/fhir/conditions.ts
+++ b/src/fhir/conditions.ts
@@ -128,10 +128,8 @@ export async function getConditionHistory(
 function filterAndSort(conditions: fhir4.Condition[]) {
   return sortBy(
     conditions.filter((condition) => condition.asserter?.type !== "Patient"),
-    (condition) => {
-      const model = new ConditionModel(condition);
-      return model.ccsGrouping || "" + model.display || "";
-    }
+    (condition) => new ConditionModel(condition).ccsGrouping,
+    (condition) => new ConditionModel(condition).display
   );
 }
 


### PR DESCRIPTION
Alphabetize conditions primarily by CCS grouping and secondarily the condition name so that users can quickly find the conditions by their category.

Example:
<img width="606" alt="image" src="https://user-images.githubusercontent.com/33408946/194120727-ae6f034f-fb1b-4f56-86f1-52e19646d66c.png">
