### PR TITLE
Add sorting to condition history page

### DIFF
--- a/.changeset/dull-taxis-attack.md
+++ b/.changeset/dull-taxis-attack.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Condition History page now sorts by date and the entries without a date are filtered to the end.

--- a/.changeset/dull-taxis-attack.md
+++ b/.changeset/dull-taxis-attack.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Condition History page now sorts by date and the entries without a date are filtered to the end.
+Condition History now sorts by date and the entries without a date are filtered to the end.

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -92,12 +92,12 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
         const includedResources = getIncludedResources(
           historyResponse.data.bundle
         );
-        const filteredConditions = historyResponse.data.conditions.map(
+        const historyConditions = historyResponse.data.conditions.map(
           (c) => new ConditionModel(c, includedResources)
         );
 
         const sortedConditions = orderBy(
-          filteredConditions,
+          historyConditions,
           (c) => c.recordedDate ?? "",
           "desc"
         );

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -92,12 +92,12 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
         const includedResources = getIncludedResources(
           historyResponse.data.bundle
         );
-        const historyConditions = historyResponse.data.conditions.map(
+        const conditionModels = historyResponse.data.conditions.map(
           (c) => new ConditionModel(c, includedResources)
         );
 
         const sortedConditions = orderBy(
-          historyConditions,
+          conditionModels,
           (c) => c.recordedDate ?? "",
           "desc"
         );

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -3,6 +3,7 @@ import { getConditionHistory } from "@/fhir/conditions";
 import { useFhirClientRef } from "@/fhir/utils";
 import { ConditionModel } from "@/models/conditions";
 import { useQuery } from "@tanstack/react-query";
+import { orderBy } from "lodash";
 import { useEffect, useState } from "react";
 import { CodingList } from "../core/coding-list";
 import { CollapsibleDataListProps } from "../core/collapsible-data-list";
@@ -53,7 +54,7 @@ function setupData(condition: ConditionModel): CollapsibleDataListProps {
 
   return {
     id: condition.id,
-    date: condition.recordedDate,
+    date: condition.recordedDate || "",
     title: condition.snomedDisplay || condition.icd10Display,
     subTitle: condition.patient?.organization?.name,
     data: detailData,
@@ -95,7 +96,13 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
           (c) => new ConditionModel(c, includedResources)
         );
 
-        setConditions(filteredConditions.map((model) => setupData(model)));
+        const sortedConditions = orderBy(
+          filteredConditions,
+          (c) => c.recordedDate ?? "",
+          "desc"
+        );
+
+        setConditions(sortedConditions.map((model) => setupData(model)));
         setLoading(false);
       }
     }


### PR DESCRIPTION
This PR just updates sorting for the history panel page to now sort by date and then move the empty dates to the end. 
![Screen Shot 2022-10-06 at 11 43 44 AM](https://user-images.githubusercontent.com/98342697/194371010-7f3331ee-fb5d-45b3-953f-c42aab389ac0.png)
