### PR TITLE
Add Records with no date in a separate format in condition history

### DIFF
--- a/.changeset/quiet-eyes-buy.md
+++ b/.changeset/quiet-eyes-buy.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Condition History has a header that subdivides the condition entries to sort by date otherwise group the entries with no dates.

--- a/.changeset/quiet-eyes-buy.md
+++ b/.changeset/quiet-eyes-buy.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Condition History has a header that subdivides the condition entries to sort by date otherwise group the entries with no dates.
+Add “Records with no date” section to condition history.

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -133,8 +133,8 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
   function conditionHistoryDisplay() {
     if (
       conditionsWithDate.length === 0 &&
-      !loading &&
-      conditionsWithoutDate.length === 0
+      conditionsWithoutDate.length === 0 &&
+      !loading
     ) {
       return <div>No history found.</div>;
     }
@@ -161,14 +161,18 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
           entries={conditionsWithDate}
           limit={CONDITION_HISTORY_LIMIT}
         />
-        <div className="ctw-space-y-2 ctw-text-base">
+        <div className="ctw-space-y-2">
           {conditionsWithoutDate.length !== 0 && (
-            <div className="ctw-space-y-2">Records with no date:</div>
+            <>
+              <div className="ctw-pl-4 ctw-font-medium">
+                Records with no date:
+              </div>
+              <CollapsibleDataListStack
+                entries={conditionsWithoutDate}
+                limit={CONDITION_HISTORY_LIMIT}
+              />
+            </>
           )}
-          <CollapsibleDataListStack
-            entries={conditionsWithoutDate}
-            limit={CONDITION_HISTORY_LIMIT}
-          />
         </div>
       </div>
     );

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -161,9 +161,9 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
           entries={conditionsWithDate}
           limit={CONDITION_HISTORY_LIMIT}
         />
-        <div className="ctw-space-y-2">
-          {conditionsWithoutDate.length !== 0 && (
-            <>
+        {conditionsWithoutDate.length !== 0 && (
+          <>
+            <div className="ctw-space-y-2">
               <div className="ctw-pl-4 ctw-font-medium">
                 Records with no date:
               </div>
@@ -171,9 +171,9 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
                 entries={conditionsWithoutDate}
                 limit={CONDITION_HISTORY_LIMIT}
               />
-            </>
-          )}
-        </div>
+            </div>
+          </>
+        )}
       </div>
     );
   }

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -54,7 +54,7 @@ function setupData(condition: ConditionModel): CollapsibleDataListProps {
 
   return {
     id: condition.id,
-    date: condition.recordedDate || "",
+    date: condition.recordedDate,
     title: condition.snomedDisplay || condition.icd10Display,
     subTitle: condition.patient?.organization?.name,
     data: detailData,
@@ -62,9 +62,10 @@ function setupData(condition: ConditionModel): CollapsibleDataListProps {
 }
 
 export function ConditionHistory({ condition }: { condition: ConditionModel }) {
-  const [conditions, setConditions] = useState<CollapsibleDataListStackEntries>(
-    []
-  );
+  const [conditionsWithDate, setConditionsWithDate] =
+    useState<CollapsibleDataListStackEntries>([]);
+  const [conditionsWithoutDate, setConditionsWithoutDate] =
+    useState<CollapsibleDataListStackEntries>([]);
   const [loading, setLoading] = useState(true);
   const [patientUPID, setPatientUPID] = useState("");
   const [conditionForSearch, setConditionForSearch] =
@@ -102,7 +103,20 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
           "desc"
         );
 
-        setConditions(sortedConditions.map((model) => setupData(model)));
+        const conditionsFilteredWithDate = sortedConditions.filter(
+          (c) => c.recordedDate
+        );
+        const conditionsFilteredWithoutDate = sortedConditions.filter(
+          (c) => !c.recordedDate
+        );
+
+        setConditionsWithDate(
+          conditionsFilteredWithDate.map((model) => setupData(model))
+        );
+
+        setConditionsWithoutDate(
+          conditionsFilteredWithoutDate.map((model) => setupData(model))
+        );
         setLoading(false);
       }
     }
@@ -110,13 +124,18 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
     load();
 
     return function cleanup() {
-      setConditions([]);
+      setConditionsWithDate([]);
+      setConditionsWithoutDate([]);
       setLoading(true);
     };
   }, [condition, patientResponse.data, historyResponse.data]);
 
   function conditionHistoryDisplay() {
-    if (conditions.length === 0 && !loading) {
+    if (
+      conditionsWithDate.length === 0 &&
+      !loading &&
+      conditionsWithoutDate.length === 0
+    ) {
       return <div>No history found.</div>;
     }
     if (loading) {
@@ -129,6 +148,7 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
         </div>
       );
     }
+
     return (
       <div className="ctw-space-y-6">
         <div>
@@ -138,9 +158,18 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
           <div className="ctw-text-sm">{condition.ccsGrouping}</div>
         </div>
         <CollapsibleDataListStack
-          entries={conditions}
+          entries={conditionsWithDate}
           limit={CONDITION_HISTORY_LIMIT}
         />
+        <div className="ctw-space-y-2 ctw-text-base">
+          {conditionsWithoutDate.length !== 0 && (
+            <div className="ctw-space-y-2">Records with no date:</div>
+          )}
+          <CollapsibleDataListStack
+            entries={conditionsWithoutDate}
+            limit={CONDITION_HISTORY_LIMIT}
+          />
+        </div>
       </div>
     );
   }

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -162,17 +162,15 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
           limit={CONDITION_HISTORY_LIMIT}
         />
         {conditionsWithoutDate.length !== 0 && (
-          <>
-            <div className="ctw-space-y-2">
-              <div className="ctw-pl-4 ctw-font-medium">
-                Records with no date:
-              </div>
-              <CollapsibleDataListStack
-                entries={conditionsWithoutDate}
-                limit={CONDITION_HISTORY_LIMIT}
-              />
+          <div className="ctw-space-y-2">
+            <div className="ctw-pl-4 ctw-font-medium">
+              Records with no date:
             </div>
-          </>
+            <CollapsibleDataListStack
+              entries={conditionsWithoutDate}
+              limit={CONDITION_HISTORY_LIMIT}
+            />
+          </div>
         )}
       </div>
     );

--- a/src/components/core/collapsible-data-list.tsx
+++ b/src/components/core/collapsible-data-list.tsx
@@ -58,7 +58,7 @@ const DetailSummary = ({
   >
     <div className="ctw-flex ctw-items-center ctw-justify-between ctw-rounded-lg ctw-bg-bg-lighter ctw-p-3 ctw-text-left">
       <div className="ctw-flex ctw-space-x-3">
-        <div className="ctw-min-w-[5rem]">{date}</div>
+        {date && <div className="ctw-min-w-[5rem]">{date}</div>}
         <div>
           <div className="ctw-text-primary-dark">{title}</div>
           <div className="ctw-text-content-light">{subTitle}</div>


### PR DESCRIPTION
This PR adds a separate section for records with no date. If there is no entry, then no section will show up. 

With Both Date and No Date: 
![Screen Shot 2022-10-06 at 2 16 13 PM](https://user-images.githubusercontent.com/98342697/194399670-5e6d1cb7-981c-440e-a7a7-d2970a695df0.png)

With only Dates:
![Screen Shot 2022-10-06 at 2 19 17 PM](https://user-images.githubusercontent.com/98342697/194400198-261efc3a-42b1-41fd-af23-8f9360970929.png)

With only no Dates: 
![Screen Shot 2022-10-06 at 2 20 09 PM](https://user-images.githubusercontent.com/98342697/194400369-a9c7b563-2112-4d8d-ac6e-ba5bccd36291.png)

