### PR TITLE
Fix theming issue with drawer + dropdown menu

### DIFF
--- a/.changeset/stupid-moose-warn.md
+++ b/.changeset/stupid-moose-warn.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Adjust use of portals to inherit proper CSS vars setup by CTWProvider. This fixes a theming bug where drawer and dropdown-menu were not properly themed.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,31 @@ import "./App.css";
 import { Conditions } from "./components/content/conditions";
 import { CTWProvider } from "./components/core/ctw-provider";
 import { PatientProvider } from "./components/core/patient-provider";
+import { Theme } from "./styles/tailwind.theme";
 
 const { VITE_SYSTEM_URL, VITE_AUTH_TOKEN, VITE_PATIENT_ID } = import.meta.env;
 
+const theme: Theme = {
+  colors: {
+    primary: {
+      light: "#F2F6FD",
+      main: "#5C8EDC",
+      dark: "#3E6197",
+    },
+    content: {
+      black: "#1A2848",
+      light: "#4A4A4A",
+      lighter: "#999999",
+    },
+    bg: {
+      light: "#F1F1F1",
+    },
+  },
+};
+
 function App() {
   return (
-    <CTWProvider env="dev" authToken={VITE_AUTH_TOKEN} theme={{}}>
+    <CTWProvider env="dev" authToken={VITE_AUTH_TOKEN} theme={theme}>
       <PatientProvider patientID={VITE_PATIENT_ID} systemURL={VITE_SYSTEM_URL}>
         <div className="App ctw-space-y-5">
           <h1>CTW Component Library</h1>

--- a/src/components/content/forms/drawer-form-with-fields.tsx
+++ b/src/components/content/forms/drawer-form-with-fields.tsx
@@ -79,9 +79,9 @@ export const DrawerFormWithFields = <T,>({
                     {label}
                   </label>
                   {!inputProps(field).required && (
-                    <p className="ctw-right-0 ctw-inline-block ctw-text-xs ctw-text-content-black">
+                    <span className="ctw-right-0 ctw-inline-block ctw-text-xs ctw-text-content-black">
                       Optional
-                    </p>
+                    </span>
                   )}
                 </div>
 

--- a/src/components/core/ctw-context.tsx
+++ b/src/components/core/ctw-context.tsx
@@ -1,5 +1,5 @@
 import { Theme } from "@/styles/tailwind.theme";
-import { createContext } from "react";
+import { createContext, RefObject } from "react";
 import type { Env } from "./ctw-provider";
 
 export type CTWToken = {
@@ -15,6 +15,7 @@ export type CTWState = {
   headers?: HeadersInit;
   authTokenURL?: string;
   theme?: Theme;
+  ctwProviderRef: RefObject<HTMLDivElement>;
   token?: CTWToken;
   actions: {
     handleAuth: () => Promise<string>;

--- a/src/components/core/drawer.tsx
+++ b/src/components/core/drawer.tsx
@@ -63,7 +63,7 @@ export function Drawer({
                 <Dialog.Panel className="ctw-pointer-events-auto ctw-w-screen ctw-max-w-xl">
                   <div className="ctw-flex ctw-h-full ctw-flex-col ctw-bg-white ctw-shadow-xl">
                     <div className="ctw-mx-6 ctw-flex ctw-h-14 ctw-flex-shrink-0 ctw-items-center ctw-justify-between ctw-border-0 ctw-border-b ctw-border-solid ctw-border-content-lighter">
-                      <Dialog.Title className="ctw-text-lg ctw-font-semibold ctw-uppercase">
+                      <Dialog.Title className="ctw-text-lg ctw-font-semibold ctw-uppercase ctw-text-content-black">
                         {title}
                       </Dialog.Title>
                       <div className="ctw-ml-3 ctw-flex ctw-h-7 ctw-items-center">

--- a/src/components/core/dropdown-menu.scss
+++ b/src/components/core/dropdown-menu.scss
@@ -3,7 +3,7 @@
 }
 
 .ctw-dropdown-menu-item {
-  @apply ctw-flex ctw-w-full ctw-cursor-pointer ctw-p-2 ctw-text-primary-main ctw-outline-none;
+  @apply ctw-flex ctw-w-full ctw-cursor-pointer ctw-p-2 ctw-text-primary-dark ctw-outline-none;
 
   &[data-highlighted] {
     @apply ctw-bg-primary-light;

--- a/src/components/core/dropdown-menu.tsx
+++ b/src/components/core/dropdown-menu.tsx
@@ -2,6 +2,7 @@ import { Menu } from "@headlessui/react";
 import * as RadixDropdownMenu from "@radix-ui/react-dropdown-menu";
 import cx from "classnames";
 import { ReactNode } from "react";
+import { useCTW } from "./ctw-provider";
 import "./dropdown-menu.scss";
 
 export type MenuItems = {
@@ -16,6 +17,8 @@ export type DropdownMenuProps = {
 };
 
 export function DropdownMenu({ children, menuItems }: DropdownMenuProps) {
+  const { ctwProviderRef } = useCTW();
+
   return (
     <Menu>
       <RadixDropdownMenu.Root modal={false}>
@@ -23,7 +26,7 @@ export function DropdownMenu({ children, menuItems }: DropdownMenuProps) {
           {children}
         </RadixDropdownMenu.Trigger>
 
-        <RadixDropdownMenu.Portal>
+        <RadixDropdownMenu.Portal container={ctwProviderRef.current}>
           <RadixDropdownMenu.Content
             className="ctw-dropdown-menu-container"
             collisionPadding={10}

--- a/src/components/core/main.scss
+++ b/src/components/core/main.scss
@@ -65,7 +65,7 @@
   }
 
   .ctw-title {
-    @apply ctw-text-xs ctw-font-semibold ctw-uppercase ctw-text-black;
+    @apply ctw-text-xs ctw-font-semibold ctw-uppercase ctw-text-content-black;
     letter-spacing: 0.2rem;
   }
 

--- a/src/styles/tailwind.theme.ts
+++ b/src/styles/tailwind.theme.ts
@@ -14,7 +14,6 @@ export const TailwindTheme = {
     white: "#fff",
     black: "#000",
     primary: {
-      lighter: "#FAF5FF",
       light: "#F3E8FF",
       main: "#A855F7",
       dark: "#7E22CE",
@@ -32,7 +31,6 @@ export const TailwindTheme = {
       black: "#111827",
       light: "#6B7280",
       lighter: "#9CA3AF",
-      reverse: "#FFFFFF",
     },
     error: {
       main: "#EF4444",


### PR DESCRIPTION
* Added manual headlessui-portal-root to get drawer added within CTWProvider which defines theme CSS vars.
* Added a CTWProviderRef to the useCTW context and explicitly told dropdown-menu to use that for portal placement.
* Added custom theme example to App.tsx
* Fixed a few minor theming issues with colors in a few spots.

![Screen Shot 2022-10-07 at 3 24 25 PM](https://user-images.githubusercontent.com/1568246/194638911-7c3df6b7-a00f-49d3-8946-14fd2dadd68e.png)
![Screen Shot 2022-10-07 at 3 24 43 PM](https://user-images.githubusercontent.com/1568246/194638926-438f6f45-c764-445d-b10f-68816623b2ba.png)


![Screen Shot 2022-10-07 at 3 25 19 PM](https://user-images.githubusercontent.com/1568246/194638884-e1acd010-c50b-459d-8e28-292cb300b944.png)
