### PR TITLE
CTW-418 Add builder filter to lens request

### DIFF
--- a/.changeset/weak-yaks-hear.md
+++ b/.changeset/weak-yaks-hear.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Limiting lens requests to resources tagged with the callers builder.

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -9,7 +9,7 @@ import {
   SYSTEM_ZUS_LENS,
   SYSTEM_ZUS_OWNER,
   SYSTEM_ZUS_THIRD_PARTY,
-  SYSTEM_ZUS_UNIVERSAL_ID
+  SYSTEM_ZUS_UNIVERSAL_ID,
 } from "./system-urls";
 import { ResourceType, ResourceTypeString } from "./types";
 
@@ -87,7 +87,10 @@ export async function searchLensRecords<T extends ResourceTypeString>(
   searchParams?: SearchParams
 ): Promise<SearchReturn<T>> {
   const claims = getClaims(fhirClient);
-  const tagFilter = [SUMMARY_TAGS.join(","),`${SYSTEM_ZUS_OWNER}|builder/${claims[SYSTEM_ZUS_BUILDER_ID]}`];
+  const tagFilter = [
+    SUMMARY_TAGS.join(","),
+    `${SYSTEM_ZUS_OWNER}|builder/${claims[SYSTEM_ZUS_BUILDER_ID]}`,
+  ];
   return searchAllRecords(resourceType, fhirClient, {
     ...searchParams,
     _tag: tagFilter,

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -9,8 +9,7 @@ import {
   SYSTEM_ZUS_LENS,
   SYSTEM_ZUS_OWNER,
   SYSTEM_ZUS_THIRD_PARTY,
-  SYSTEM_ZUS_UNIVERSAL_ID,
-  SYSTEM_ZUS_USER_TYPE
+  SYSTEM_ZUS_UNIVERSAL_ID
 } from "./system-urls";
 import { ResourceType, ResourceTypeString } from "./types";
 
@@ -88,10 +87,7 @@ export async function searchLensRecords<T extends ResourceTypeString>(
   searchParams?: SearchParams
 ): Promise<SearchReturn<T>> {
   const claims = getClaims(fhirClient);
-  const tagFilter = [SUMMARY_TAGS.join(",")];
-  if (claims[SYSTEM_ZUS_USER_TYPE]?.toString().toLowerCase() !== "zus") {
-    tagFilter.push(`${SYSTEM_ZUS_OWNER}|builder/${claims[SYSTEM_ZUS_BUILDER_ID]}`);
-  }
+  const tagFilter = [SUMMARY_TAGS.join(","),`${SYSTEM_ZUS_OWNER}|builder/${claims[SYSTEM_ZUS_BUILDER_ID]}`];
   return searchAllRecords(resourceType, fhirClient, {
     ...searchParams,
     _tag: tagFilter,

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -10,6 +10,7 @@ import {
   SYSTEM_ZUS_OWNER,
   SYSTEM_ZUS_THIRD_PARTY,
   SYSTEM_ZUS_UNIVERSAL_ID,
+  SYSTEM_ZUS_USER_TYPE
 } from "./system-urls";
 import { ResourceType, ResourceTypeString } from "./types";
 
@@ -86,9 +87,14 @@ export async function searchLensRecords<T extends ResourceTypeString>(
   fhirClient: Client,
   searchParams?: SearchParams
 ): Promise<SearchReturn<T>> {
+  const claims = getClaims(fhirClient);
+  const tagFilter = [SUMMARY_TAGS.join(",")];
+  if (claims[SYSTEM_ZUS_USER_TYPE]?.toString().toLowerCase() !== "zus") {
+    tagFilter.push(`${SYSTEM_ZUS_OWNER}|builder/${claims[SYSTEM_ZUS_BUILDER_ID]}`);
+  }
   return searchAllRecords(resourceType, fhirClient, {
     ...searchParams,
-    _tag: SUMMARY_TAGS.join(","),
+    _tag: tagFilter,
   });
 }
 

--- a/src/fhir/system-urls.ts
+++ b/src/fhir/system-urls.ts
@@ -33,6 +33,7 @@ export const SYSTEM_TASK_STATUS =
   "https://www.hl7.org/fhir/codesystem-task-status.html";
 
 export const SYSTEM_ZUS_BUILDER_ID = "https://zusapi.com/builder_id";
+export const SYSTEM_ZUS_USER_TYPE = "https://zusapi.com/user_type";
 export const SYSTEM_ZUS_LENS = "https://zusapi.com/lens";
 export const SYSTEM_ZUS_OWNER = "https://zusapi.com/accesscontrol/owner";
 export const SYSTEM_ZUS_THIRD_PARTY = "https://zusapi.com/thirdparty/source";


### PR DESCRIPTION
When a patient exists across multiple builders lens output is written redundantly across all of those builders. When the Common Patient Record (CPR) is enabled (as it is in dev) this is causing all of those redundant lens resources to be returned. A simple fix for this in the immediate term is to update the lens requests to additionally filter by the caller’s builder.