### PR TITLE
Condition updates to the history panel

### DIFF
--- a/.changeset/five-peas-live.md
+++ b/.changeset/five-peas-live.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Fix sorting and styling of dates and labels within the condition history panel.

--- a/.changeset/five-peas-live.md
+++ b/.changeset/five-peas-live.md
@@ -1,5 +1,5 @@
 ---
-"@zus-health/ctw-component-library": minor
+"@zus-health/ctw-component-library": patch
 ---
 
 Fix sorting and styling of dates and labels within the condition history panel.

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -1,6 +1,6 @@
 import { getIncludedResources } from "@/fhir/bundle";
 import { getConditionHistory } from "@/fhir/conditions";
-import { sortDate } from "@/fhir/formatters";
+import { convertDatetoString } from "@/fhir/formatters";
 import { useFhirClientRef } from "@/fhir/utils";
 import { ConditionModel } from "@/models/conditions";
 import { useQuery } from "@tanstack/react-query";
@@ -100,7 +100,7 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
 
         const sortedConditions = orderBy(
           conditionModels,
-          (c) => sortDate(c.recordedDate) ?? "",
+          (c) => convertDatetoString(c.recordedDate) ?? "",
           "desc"
         );
 

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -1,5 +1,6 @@
 import { getIncludedResources } from "@/fhir/bundle";
 import { getConditionHistory } from "@/fhir/conditions";
+import { sortDate } from "@/fhir/formatters";
 import { useFhirClientRef } from "@/fhir/utils";
 import { ConditionModel } from "@/models/conditions";
 import { useQuery } from "@tanstack/react-query";
@@ -31,7 +32,7 @@ function setupData(condition: ConditionModel): CollapsibleDataListProps {
       value: condition.recordedDate,
     },
     {
-      label: "Categories",
+      label: "Category",
       value: condition.categories[0],
     },
     {
@@ -99,7 +100,7 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
 
         const sortedConditions = orderBy(
           conditionModels,
-          (c) => c.recordedDate ?? "",
+          (c) => sortDate(c.recordedDate) ?? "",
           "desc"
         );
 
@@ -163,9 +164,7 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
         />
         {conditionsWithoutDate.length !== 0 && (
           <div className="ctw-space-y-2">
-            <div className="ctw-pl-4 ctw-font-medium">
-              Records with no date:
-            </div>
+            <div className="ctw-font-medium">Records with no date:</div>
             <CollapsibleDataListStack
               entries={conditionsWithoutDate}
               limit={CONDITION_HISTORY_LIMIT}

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -114,7 +114,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
     );
   };
 
-  const addCondtiotnBtn = (
+  const addConditionBtn = (
     <button
       className="ctw-btn-primary"
       type="button"
@@ -218,7 +218,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
               <>
                 {patientRecordsMessage}
                 {!patientRecordsResponse.isError && (
-                  <div className="ctw-my-5">{addCondtiotnBtn}</div>
+                  <div className="ctw-my-5">{addConditionBtn}</div>
                 )}
               </>
             }

--- a/src/fhir/formatters.ts
+++ b/src/fhir/formatters.ts
@@ -65,7 +65,7 @@ export function formatPhoneNumber(phoneNumber?: string): string | undefined {
   return match ? `${match[1]}-${match[2]}-${match[3]}` : phoneNumber;
 }
 
-// Formats the date from MM/DD/YYYY to yyyyMMDD
+// Formats the date from MM/DD/YYYY to yyyyMMDD.
 export function sortDate(date?: string): string | undefined {
   if (!date) return undefined;
   const arr = date.split("/").reverse();

--- a/src/fhir/formatters.ts
+++ b/src/fhir/formatters.ts
@@ -38,10 +38,11 @@ export function formatDateLocalToISO(dateStr?: string): string | undefined {
 export function formatStringToDate(dateStr?: string): string | undefined {
   if (!dateStr) return undefined;
 
-  return `${dateStr.substring(4, 6)}/${dateStr.substring(
-    6,
-    8
-  )}/${dateStr.substring(0, 4)}`;
+  const month = dateStr.substring(4, 6);
+  const day = dateStr.substring(6, 8);
+  const year = dateStr.substring(0, 4);
+
+  return `${month}/${day}/${year}`;
 }
 
 // Returns the ISO string (YYYY-MM-DD) for a given date.

--- a/src/fhir/formatters.ts
+++ b/src/fhir/formatters.ts
@@ -34,14 +34,14 @@ export function formatDateLocalToISO(dateStr?: string): string | undefined {
   return date;
 }
 
-// Formats a string yyyymmdd or yyyyMMddHHmmss into YYYY-MM-DD.
+// Formats a string yyyymmdd or yyyyMMddHHmmss into MM/DD/YYYY.
 export function formatStringToDate(dateStr?: string): string | undefined {
   if (!dateStr) return undefined;
 
-  return `${dateStr.substring(0, 4)}-${dateStr.substring(
-    4,
-    6
-  )}-${dateStr.substring(6, 8)}`;
+  return `${dateStr.substring(4, 6)}/${dateStr.substring(
+    6,
+    8
+  )}/${dateStr.substring(0, 4)}`;
 }
 
 // Returns the ISO string (YYYY-MM-DD) for a given date.

--- a/src/fhir/formatters.ts
+++ b/src/fhir/formatters.ts
@@ -66,7 +66,7 @@ export function formatPhoneNumber(phoneNumber?: string): string | undefined {
 }
 
 // Formats the date from MM/DD/YYYY to yyyyMMDD.
-export function sortDate(date?: string): string | undefined {
+export function convertDatetoString(date?: string): string | undefined {
   if (!date) return undefined;
   const arr = date.split("/").reverse();
   return `${arr[0]}${arr[2]}${arr[1]}`;

--- a/src/fhir/formatters.ts
+++ b/src/fhir/formatters.ts
@@ -34,6 +34,16 @@ export function formatDateLocalToISO(dateStr?: string): string | undefined {
   return date;
 }
 
+// Formats a string yyyymmdd or yyyyMMddHHmmss into YYYY-MM-DD.
+export function formatStringToDate(dateStr?: string): string | undefined {
+  if (!dateStr) return undefined;
+
+  return `${dateStr.substring(0, 4)}-${dateStr.substring(
+    4,
+    6
+  )}-${dateStr.substring(6, 8)}`;
+}
+
 // Returns the ISO string (YYYY-MM-DD) for a given date.
 // We avoid using date-fn's format method to avoid timezone issues.
 export function dateToISO(date: Date) {
@@ -53,4 +63,11 @@ export function formatPhoneNumber(phoneNumber?: string): string | undefined {
   // Return the new format OR the original if we don't have a match.
   // This would happen if we didn't have the expected 10 digits.
   return match ? `${match[1]}-${match[2]}-${match[3]}` : phoneNumber;
+}
+
+// Formats the date from MM/DD/YYYY to yyyyMMDD
+export function sortDate(date?: string): string | undefined {
+  if (!date) return undefined;
+  const arr = date.split("/").reverse();
+  return `${arr[0]}${arr[2]}${arr[1]}`;
 }

--- a/src/models/conditions.ts
+++ b/src/models/conditions.ts
@@ -3,7 +3,7 @@ import { findReference } from "@/fhir/resource-helper";
 import { ResourceMap } from "@/fhir/types";
 import { compact } from "lodash";
 import { codeableConceptLabel, findCoding } from "../fhir/codeable-concept";
-import { formatDateISOToLocal } from "../fhir/formatters";
+import { formatDateISOToLocal, formatStringToDate } from "../fhir/formatters";
 import { SYSTEM_CCS, SYSTEM_ICD10, SYSTEM_SNOMED } from "../fhir/system-urls";
 import { PatientModel } from "./patients";
 
@@ -130,7 +130,7 @@ export class ConditionModel {
       );
     }
 
-    return this.resource.onsetString;
+    return formatStringToDate(this.resource.onsetString);
   }
 
   get patient(): PatientModel | undefined {


### PR DESCRIPTION
This PR updates the condition history panel with a few updates: 

1. Sorts the history panel by date (starting with year, month, then day) and Records with no Date is left aligned
![Screen Shot 2022-10-19 at 10 58 55 AM](https://user-images.githubusercontent.com/98342697/196749108-7f83b884-b226-475b-b31c-79b653e82b77.png)

2. Categories relabeled to Category
![Screen Shot 2022-10-19 at 11 27 02 AM](https://user-images.githubusercontent.com/98342697/196749748-dac6abcf-199f-40fb-b826-b02a8a8df2c2.png)

3. takes any date in the yyyyMMDDetc... format and converts into MM/DD/YYYY format. 
![Screen Shot 2022-10-19 at 11 35 14 AM](https://user-images.githubusercontent.com/98342697/196751449-4bb4a834-3ae4-4bd0-a421-047f5c42945c.png)
![Screen Shot 2022-10-19 at 11 33 43 AM](https://user-images.githubusercontent.com/98342697/196751143-5f7d5a26-e7b0-4cdf-a828-d955799c935a.png)
