### PR TITLE
Add aria-required attribute to the form fields

### DIFF
--- a/.changeset/four-shirts-hide.md
+++ b/.changeset/four-shirts-hide.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Remove required attributes from input fields and add an aria-required attribute to the form fields when adding/editing conditions.
+Remove required attributes from input fields and add aria-required attribute to those input fields when adding/editing conditions.

--- a/.changeset/four-shirts-hide.md
+++ b/.changeset/four-shirts-hide.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Add an aria-required attribute to the form fields when adding/editing conditions.
+Remove required attributes from input fields and add an aria-required attribute to the form fields when adding/editing conditions.

--- a/.changeset/four-shirts-hide.md
+++ b/.changeset/four-shirts-hide.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Add an aria-required attribute to the form fields when adding/editing conditions.

--- a/src/components/content/conditions-table-base.tsx
+++ b/src/components/content/conditions-table-base.tsx
@@ -8,14 +8,14 @@ export type ConditionsTableBaseProps = {
   className?: string;
   conditions: ConditionModel[];
   rowActions: (condition: ConditionModel) => MenuItems[];
-  hideMenu?: boolean;
+  hideMenu: boolean;
 } & TableBaseProps<ConditionModel>;
 
 export function ConditionsTableBase({
   className,
   conditions,
   rowActions,
-  hideMenu = false,
+  hideMenu,
   ...tableProps
 }: ConditionsTableBaseProps) {
   const columns: TableColumn<ConditionModel>[] = [

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -214,6 +214,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
             stacked={breakpoints.sm}
             conditions={patientRecords}
             isLoading={patientRecordsResponse.isLoading}
+            hideMenu={readOnly}
             message={
               <>
                 {patientRecordsMessage}
@@ -253,6 +254,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
               OtherProviderRecordsResponse.isLoading ||
               patientRecordsResponse.isLoading
             }
+            hideMenu={readOnly}
             message={otherProviderRecordMessage}
             rowActions={(condition) => [
               {

--- a/src/components/content/forms/drawer-form-with-fields.tsx
+++ b/src/components/content/forms/drawer-form-with-fields.tsx
@@ -71,6 +71,7 @@ export const DrawerFormWithFields = <T,>({
               <div
                 key={label}
                 className="ctw-space-y-1.5 ctw-text-sm ctw-font-medium ctw-text-content-black"
+                aria-required
               >
                 <div className="ctw-flex ctw-justify-between">
                   <label
@@ -78,7 +79,7 @@ export const DrawerFormWithFields = <T,>({
                   >
                     {label}
                   </label>
-                  {!inputProps(field).required && (
+                  {!inputProps(field)["aria-required"] && (
                     <span className="ctw-right-0 ctw-inline-block ctw-text-xs ctw-text-content-black">
                       Optional
                     </span>

--- a/src/components/content/forms/drawer-form-with-fields.tsx
+++ b/src/components/content/forms/drawer-form-with-fields.tsx
@@ -71,7 +71,6 @@ export const DrawerFormWithFields = <T,>({
               <div
                 key={label}
                 className="ctw-space-y-1.5 ctw-text-sm ctw-font-medium ctw-text-content-black"
-                aria-required
               >
                 <div className="ctw-flex ctw-justify-between">
                   <label

--- a/src/utils/form-helper.ts
+++ b/src/utils/form-helper.ts
@@ -179,6 +179,7 @@ export type InputPropType = {
   name: string;
   type: string;
   required?: boolean;
+  "aria-required"?: boolean;
   min?: number;
   max?: number;
   minLength?: number;
@@ -241,7 +242,10 @@ export function getInputProps(
     options,
   };
 
-  if (!(def instanceof ZodOptional)) inputProps.required = true;
+  if (!(def instanceof ZodOptional)) {
+    inputProps.required = false;
+    inputProps["aria-required"] = true;
+  }
   if (min) inputProps.min = min;
   if (max) inputProps.max = max;
   if (minlength && Number.isFinite(minlength)) inputProps.minLength = minlength;


### PR DESCRIPTION
This PR removes the fill out the field tooltip and adds aria-required attribute to the form fields that are required.
![Screen Shot 2022-10-19 at 2 06 19 PM](https://user-images.githubusercontent.com/98342697/196783302-de37f085-bd92-46cf-87f4-999a5ff8cc6c.png)

Also: fixed hidemenu to reflect readonly for the meatball menu when it is present in App.tsx