### PR TITLE
CTW-365/update names

### DIFF
--- a/.changeset/fair-rabbits-cough.md
+++ b/.changeset/fair-rabbits-cough.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Update column header names for Patient Record and Other Provider Record tables.

--- a/src/components/content/conditions-table-base.tsx
+++ b/src/components/content/conditions-table-base.tsx
@@ -26,19 +26,19 @@ export function ConditionsTableBase({
       minWidth: 320,
     },
     {
-      title: "Group",
+      title: "Category",
       dataIndex: "ccsGrouping",
       widthPercent: 25,
       minWidth: 192,
     },
     {
-      title: "Status",
+      title: "Latest Status",
       dataIndex: "clinicalStatus",
       widthPercent: 17.5,
       minWidth: 128,
     },
     {
-      title: "Recorded Date",
+      title: "Last Recorded",
       dataIndex: "recordedDate",
       widthPercent: 17.5,
       minWidth: 132,


### PR DESCRIPTION
[CTW-365](https://zeushealth.atlassian.net/jira/software/projects/CTW/boards/49?selectedIssue=CTW-365)

This PR updates the column header names in both tables. 

![Screen Shot 2022-10-25 at 1 14 34 PM](https://user-images.githubusercontent.com/98342697/197850316-99cf89f8-ae7d-4290-a8d4-ff9d1d05e6f0.png)
