### PR TITLE
Fix Condition Name Selector

### DIFF
--- a/.changeset/calm-experts-speak.md
+++ b/.changeset/calm-experts-speak.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix the bug that causes the Condition add/edit form to not recognize a selected condition name.

--- a/src/components/core/form/combobox-field.tsx
+++ b/src/components/core/form/combobox-field.tsx
@@ -59,7 +59,7 @@ export const ComboboxField = <T,>({
         placeholder="Type to search"
       />
 
-      <input hidden name={name} defaultValue={inputValueParsed as string} />
+      <input hidden name={name} value={inputValueParsed as string} />
       <Combobox.Options className="ctw-listbox ctw-max-h-60 ctw-overflow-auto ctw-rounded-md ctw-bg-white ctw-py-1 ctw-text-base ctw-shadow-lg ctw-ring-1 ctw-ring-black ctw-ring-opacity-5 focus:ctw-outline-none sm:ctw-text-sm">
         <ComboboxOptions options={options} query={searchTerm} />
       </Combobox.Options>


### PR DESCRIPTION
No longer get the the error that you need to select a condition name when you have selected one.