### PR TITLE
Update sort by year and then move null to bottom

### DIFF
--- a/.changeset/early-suns-fly.md
+++ b/.changeset/early-suns-fly.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Update the sort to sort by year first and move the records with no date to the bottom.

--- a/src/fhir/conditions.ts
+++ b/src/fhir/conditions.ts
@@ -166,7 +166,7 @@ function filterAndSort(conditions: fhir4.Condition[]) {
   return orderBy(
     conditions.filter((condition) => condition.asserter?.type !== "Patient"),
     [
-      (condition) => new ConditionModel(condition).recordedDate,
+      (condition) => new ConditionModel(condition).resource.recordedDate ?? "",
       (condition) => new ConditionModel(condition).display,
     ],
     ["desc"]


### PR DESCRIPTION
This PR fixes the sort to move null to the bottom and sort by alphabetical order and sorts by year first. 
![Screen Shot 2022-10-27 at 8 49 14 AM](https://user-images.githubusercontent.com/98342697/198302580-61e1afe9-f182-456c-baaf-271e2b1c0238.png)
