### PR TITLE
Entered-in-error Status

### DIFF
--- a/.changeset/khaki-peas-switch.md
+++ b/.changeset/khaki-peas-switch.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix the condition form to let users set a condition's verification status to "entered-in-error".

--- a/src/components/content/forms/conditions.ts
+++ b/src/components/content/forms/conditions.ts
@@ -122,6 +122,10 @@ export const createOrEditCondition = async (
     note: result.data.note ? [{ text: result.data.note }] : undefined,
   };
 
+  if (result.data.verificationStatus === "entered-in-error") {
+    fhirCondition.clinicalStatus = undefined;
+  }
+
   const response = await createOrEditFhirResource(
     fhirCondition,
     requestContext.fhirClient


### PR DESCRIPTION
Fix the condition form to let users set a condition's verification status to "entered-in-error".

https://user-images.githubusercontent.com/33408946/199092912-8c15681f-16bf-4e38-be9a-6d5a4384923d.mov

