### PR TITLE
CTW-491/fix condition autocomplete

### DIFF
--- a/.changeset/gold-ways-exercise.md
+++ b/.changeset/gold-ways-exercise.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix condition autocomplete to work with proxied auth tokens.

--- a/src/components/content/forms/conditions-autocomplete.tsx
+++ b/src/components/content/forms/conditions-autocomplete.tsx
@@ -22,10 +22,13 @@ export const ConditionsAutoComplete = ({
   readonly,
   ...inputProps
 }: AutoCompleteComboboxProps) => {
-  const { authToken, env } = useCTW();
+  const { getRequestContext } = useCTW();
+  const [isLoading, setIsLoading] = useState(false);
   const [options, setOptions] = useState<ComboxboxFieldOption[]>();
 
   const handleSearchChange = async (query: string) => {
+    setIsLoading(true);
+    const { authToken, env } = await getRequestContext();
     const conditions = await getAutoCompleteConditions(authToken, env, query);
 
     if (conditions) {
@@ -36,18 +39,19 @@ export const ConditionsAutoComplete = ({
         })) as ComboxboxFieldOption[]
       );
     }
+
+    setIsLoading(false);
   };
 
   return (
-    <>
-      <ComboboxField
-        options={options || []}
-        name={`${inputProps.name}`}
-        defaultSearchTerm={inputProps.defaultValue as string}
-        readonly={readonly}
-        onSearchChange={handleSearchChange}
-        defaultValue={defaultCoding}
-      />
-    </>
+    <ComboboxField
+      options={options || []}
+      isLoading={isLoading}
+      name={`${inputProps.name}`}
+      defaultSearchTerm={inputProps.defaultValue as string}
+      readonly={readonly}
+      onSearchChange={handleSearchChange}
+      defaultValue={defaultCoding}
+    />
   );
 };

--- a/src/components/core/ctw-provider.tsx
+++ b/src/components/core/ctw-provider.tsx
@@ -126,8 +126,6 @@ function useCTW() {
   return {
     getRequestContext,
     theme: context.theme as Required<Theme>,
-    authToken: context.authToken as string,
-    env: context.env,
     ctwProviderRef: context.ctwProviderRef,
   };
 }

--- a/src/components/core/form/combobox-field.tsx
+++ b/src/components/core/form/combobox-field.tsx
@@ -6,6 +6,7 @@ export type ComboxboxFieldOption = { value: unknown; label: string };
 
 export type ComboboxFieldProps<T> = {
   options: ComboxboxFieldOption[];
+  isLoading: boolean;
   name: string;
   defaultValue: T;
   defaultSearchTerm: string;
@@ -15,6 +16,7 @@ export type ComboboxFieldProps<T> = {
 
 export const ComboboxField = <T,>({
   options,
+  isLoading,
   name,
   defaultSearchTerm,
   defaultValue,
@@ -54,6 +56,9 @@ export const ComboboxField = <T,>({
       <Combobox.Input
         className="ctw-listbox-input ctw-w-full"
         onChange={(e) => {
+          // Due to debounce, we have to persist the event.
+          // https://reactjs.org/docs/legacy-event-pooling.html
+          e.persist();
           debouncedSearchInputChange(e);
         }}
         placeholder="Type to search"
@@ -61,20 +66,33 @@ export const ComboboxField = <T,>({
 
       <input hidden name={name} value={inputValueParsed as string} readOnly />
       <Combobox.Options className="ctw-listbox ctw-max-h-60 ctw-overflow-auto ctw-rounded-md ctw-bg-white ctw-py-1 ctw-text-base ctw-shadow-lg ctw-ring-1 ctw-ring-opacity-5 focus:ctw-outline-none sm:ctw-text-sm">
-        <ComboboxOptions options={options} query={searchTerm} />
+        <ComboboxOptions
+          options={options}
+          query={searchTerm}
+          isLoading={isLoading}
+        />
       </Combobox.Options>
     </Combobox>
   );
 };
 
 type RenderCorrectOptionsProps = {
+  isLoading: boolean;
   options: ComboxboxFieldOption[];
   query: string;
 };
 
-const ComboboxOptions = ({ options, query }: RenderCorrectOptionsProps) => {
+const ComboboxOptions = ({
+  options,
+  query,
+  isLoading,
+}: RenderCorrectOptionsProps) => {
   if (query.length === 0) {
     return <ComboboxOption option={{ value: "", label: "Type to search" }} />;
+  }
+
+  if (isLoading) {
+    return <ComboboxOption option={{ value: "", label: "Loading..." }} />;
   }
 
   if (query.length < 2) {


### PR DESCRIPTION
This fixes a bug where our condition autocomplete was grabbing the `authToken` from `getCTW`. This auth token was only set if the app passed in `authToken` to `CTWProvider`. Instead, everything should go through the `getRequestContext` which will correctly grab and ensure a non-expired authToken.

Additionally:
* Persist autocomplete search event as the use of debounce causes react to garbage collect the event.
* Add an `isLoading` to fix a bug where autocomplete would briefly say no results found while the search was running.