### PR TITLE
Show verification status

### DIFF
--- a/.changeset/rude-balloons-hug.md
+++ b/.changeset/rude-balloons-hug.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+For the conditions table, the status column now shows both the clinical status and the verification status for faster viewing.

--- a/src/components/content/conditions-table-base.tsx
+++ b/src/components/content/conditions-table-base.tsx
@@ -32,8 +32,16 @@ export function ConditionsTableBase({
       minWidth: 192,
     },
     {
-      title: "Latest Status",
-      dataIndex: "clinicalStatus",
+      title: "Status",
+      render: (row) => (
+        <div className="ctw-capitalize">
+          {row.clinicalStatus}
+          <br />
+          <span className="ctw-text-content-lighter">
+            {row.verificationStatus}
+          </span>
+        </div>
+      ),
       widthPercent: 17.5,
       minWidth: 128,
     },

--- a/src/components/core/table/table-data-cell.tsx
+++ b/src/components/core/table/table-data-cell.tsx
@@ -13,7 +13,7 @@ export const TableDataCell = <T extends MinRecordItem>({
   column,
   record,
   index,
-}: TableColumnProps<T>) => {
+}: TableColumnProps<T>): JSX.Element => {
   const value = column.dataIndex
     ? (record[column.dataIndex] as unknown as ReactNode)
     : undefined;


### PR DESCRIPTION
For the conditions table, the status column now shows both the clinical status and the verification status for faster viewing. 

Additionally renames the "Latest Status" column to "Status" and capitalizes the first letter of the status.

<img width="1010" alt="CTW Component Library" src="https://user-images.githubusercontent.com/33408946/199325441-54acbac5-0b23-4922-8d6a-61215dc61eb8.png">

