### PR TITLE
CTW Misc Fixes

### DIFF
--- a/.changeset/pink-planets-fail.md
+++ b/.changeset/pink-planets-fail.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fixes the font color styling of the status column.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "0.19.5",
+  "version": "0.21.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "0.19.5",
+      "version": "0.21.0",
       "dependencies": {
         "@headlessui/react": "^1.7.3",
         "@heroicons/react": "^1.0.6",
@@ -62,6 +62,9 @@
         "vite": "^3.0.0",
         "vite-tsconfig-paths": "^3.5.1",
         "vitest": "^0.23.4"
+      },
+      "engines": {
+        "node": "18.11.0"
       },
       "peerDependencies": {
         "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@zus-health/ctw-component-library",
   "version": "0.21.0",
   "type": "module",
+  "engines": {
+    "node": "18.11.0"
+  },
   "main": "dist/index.cjs",
   "module": "dist/index.es.js",
   "typings": "dist/src/index.d.ts",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import { CTWProvider } from "./components/core/ctw-provider";
 import { PatientProvider } from "./components/core/patient-provider";
 import { ErrorBoundary } from "./error-boundary";
 import { SecuredApp } from "./SecuredApp";
-import { Theme } from "./styles/tailwind.theme";
 
 const {
   VITE_SYSTEM_URL,
@@ -19,31 +18,8 @@ const {
   VITE_AUTH0_CALLBACK_PATH,
 } = import.meta.env;
 
-const theme: Theme = {
-  colors: {
-    primary: {
-      light: "#F2F6FD",
-      main: "#5C8EDC",
-      dark: "#3E6197",
-    },
-    content: {
-      black: "#1A2848",
-      light: "#4A4A4A",
-      lighter: "#999999",
-    },
-    bg: {
-      light: "#F1F1F1",
-    },
-  },
-};
-
 const DemoApp = ({ accessToken = "" }) => (
-  <CTWProvider
-    env="dev"
-    authToken={accessToken}
-    theme={theme}
-    builderId={VITE_BUILDER_ID}
-  >
+  <CTWProvider env="dev" authToken={accessToken} builderId={VITE_BUILDER_ID}>
     <PatientProvider patientID={VITE_PATIENT_ID} systemURL={VITE_SYSTEM_URL}>
       <div className="App">
         <h1>CTW Component Library</h1>

--- a/src/components/content/conditions-table-base.tsx
+++ b/src/components/content/conditions-table-base.tsx
@@ -35,10 +35,10 @@ export function ConditionsTableBase({
       title: "Status",
       render: (condition) => (
         <div className="ctw-capitalize">
-          <p className="ctw-m-0">{condition.clinicalStatus}</p>
-          <p className="ctw-m-0 ctw-text-content-lighter">
-            {condition.verificationStatus}
-          </p>
+          <div className="ctw-text-content-black">
+            {condition.clinicalStatus}
+          </div>
+          <div>{condition.verificationStatus}</div>
         </div>
       ),
       widthPercent: 17.5,

--- a/src/components/core/stacked-list.tsx
+++ b/src/components/core/stacked-list.tsx
@@ -22,12 +22,12 @@ export const StackedList = ({ entries }: StackedListProps) => (
         >
           {render || (
             <div className="ctw-min-w-0 ctw-flex-1">
-              <p className="ctw-hover:text-primary-700 ctw-truncate ctw-text-sm ctw-font-medium">
+              <div className="ctw-hover:text-primary-700 ctw-truncate ctw-text-sm ctw-font-medium">
                 {title || ""}
-              </p>
-              <p className="ctw-text-gray-500 ctw-truncate ctw-text-sm">
+              </div>
+              <div className="ctw-text-gray-500 ctw-truncate ctw-text-sm">
                 {description || ""}
-              </p>
+              </div>
             </div>
           )}
         </button>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,11 +22,5 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src", "scripts"],
-  "exclude": [
-    "src/main.tsx",
-    "src/App.tsx",
-    "src/SecuredApp.tsx",
-    "src/error-boundary.tsx"
-  ]
+  "include": ["src", "scripts"]
 }


### PR DESCRIPTION
- Fixes some red underlines on the dev side.
- Fixes the coloring of the fonts of the verification column to match the Figma.
- Uses divs instead of p's to prevent unwanted styling.
- The custom theme object was removed so that devs see the colors used in the tailwind config (which match the Figma).
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/33408946/199570426-822b9ecd-5f07-469c-91f9-99508cec099d.png">
