### PR TITLE
Update lens extension "aggregated from" system url

### DIFF
--- a/.changeset/quick-rivers-leave.md
+++ b/.changeset/quick-rivers-leave.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Update aggregated from extension system url from http to https

--- a/src/fhir/system-urls.ts
+++ b/src/fhir/system-urls.ts
@@ -56,4 +56,4 @@ export const LENS_EXTENSION_MEDICATION_REFILLS =
 export const LENS_EXTENSION_MEDICATION_LAST_PRESCRIBER =
   "https://zusapi.com/lens/extension/medicationLastPrescriber";
 export const LENS_EXTENSION_AGGREGATED_FROM =
-  "http://zusapi.com/lens/extension/aggregatedFrom";
+  "https://zusapi.com/lens/extension/aggregatedFrom";


### PR DESCRIPTION
This just updates the system url for aggregated from `"http://zusapi.com/lens/extension/aggregatedFrom"` to `"https://zusapi.com/lens/extension/aggregatedFrom"` in order to match what is used in upi-service