### PR TITLE
CTW- 533 De-dupe med history

### DIFF
--- a/.changeset/eleven-eels-try.md
+++ b/.changeset/eleven-eels-try.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Adding de-duping logic for medication history

--- a/src/fhir/medications.ts
+++ b/src/fhir/medications.ts
@@ -7,7 +7,7 @@ import { errorResponse } from "@/utils/errors";
 import { QUERY_KEY_MEDICATION_HISTORY } from "@/utils/query-keys";
 import { sort } from "@/utils/sort";
 import type { FhirResource, MedicationStatement } from "fhir/r4";
-import { uniqBy } from "lodash";
+import { uniqWith } from "lodash";
 import {
   compact,
   get,
@@ -229,7 +229,12 @@ export function useMedicationHistory(medication: fhir4.MedicationStatement) {
         ]).map((m) => new MedicationModel(m, includedResources));
 
         const medications = sort(
-          uniqBy(medicationResources, "date"),
+          uniqWith(
+            medicationResources,
+            (a, b) =>
+              a.date === b.date &&
+              a.resource.resourceType === b.resource.resourceType
+          ),
           "date",
           "desc",
           true


### PR DESCRIPTION
Adding de-duping logic to medication history so that we only show 1 record per date. This logic takes the first record per date, so it's possible we'll be choosing a record that has less useful information than another, but we can address that as it comes up during troubleshooting. This seems like a reasonable first step, especially as we saw so many dupes in early production tests that the history was hard to make sense of.

Screenshot with dupes
<img width="400" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/97455910/200338714-3bf3002a-41c1-431b-a1c9-372348ecbcb1.png">

Screenshot after change
<img width="400" alt="albuterol sulfate 0 042  (1 25 MG3" src="https://user-images.githubusercontent.com/97455910/200338758-dc1c3159-4c68-4773-bc99-bdb3fda713d1.png">
