### PR TITLE
Ctw 506/show notes previous text when editing

### DIFF
--- a/.changeset/slimy-moose-hide.md
+++ b/.changeset/slimy-moose-hide.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-If notes is populated it will now show when editing a condition. Notes can only be resized vertically now.
+If notes is pre-populated it will now show when editing a condition. Notes can only be resized vertically now.

--- a/.changeset/slimy-moose-hide.md
+++ b/.changeset/slimy-moose-hide.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+If notes is populated it will now show when editing a condition. Notes can only be resized vertically now.

--- a/src/components/content/forms/condition-schema.tsx
+++ b/src/components/content/forms/condition-schema.tsx
@@ -70,7 +70,7 @@ const sharedFields = (condition: ConditionModel) => [
   },
   {
     label: "Note",
-    value: condition.notes,
+    value: condition.notes as unknown as string,
     lines: 3,
     field: "note",
   },

--- a/src/components/content/forms/condition-schema.tsx
+++ b/src/components/content/forms/condition-schema.tsx
@@ -70,6 +70,7 @@ const sharedFields = (condition: ConditionModel) => [
   },
   {
     label: "Note",
+    value: condition.notes,
     lines: 3,
     field: "note",
   },

--- a/src/components/content/forms/condition-schema.tsx
+++ b/src/components/content/forms/condition-schema.tsx
@@ -70,7 +70,7 @@ const sharedFields = (condition: ConditionModel) => [
   },
   {
     label: "Note",
-    value: condition.notes as unknown as string,
+    value: condition.notes,
     lines: 3,
     field: "note",
   },

--- a/src/components/content/forms/drawer-form-with-fields.tsx
+++ b/src/components/content/forms/drawer-form-with-fields.tsx
@@ -7,7 +7,7 @@ import { FormField } from "./form-field";
 export type FormEntry = {
   label: string;
   field: string;
-  value?: string;
+  value?: string | string[];
   lines?: number;
   readonly?: boolean;
   hidden?: boolean;

--- a/src/components/content/forms/form-field.tsx
+++ b/src/components/content/forms/form-field.tsx
@@ -8,7 +8,7 @@ export type FormFieldProps = {
   errors?: string[];
   options?: string[];
   lines?: number;
-  defaultValue?: string;
+  defaultValue?: string | string[];
   readonly?: boolean;
   render?: (
     readonly: boolean | undefined,
@@ -31,7 +31,7 @@ export const FormField = ({
 
   const value =
     inputProps.type === "date"
-      ? formatDateLocalToISO(defaultValue)
+      ? formatDateLocalToISO(defaultValue as string)
       : defaultValue;
 
   const getFieldComponent = () => {

--- a/src/components/core/main.scss
+++ b/src/components/core/main.scss
@@ -33,6 +33,7 @@
     @apply ctw-rounded-md ctw-border ctw-border-icon-light ctw-px-3 ctw-py-2 ctw-text-sm ctw-shadow-sm;
     border-style: solid;
     background-color: initial;
+    resize: vertical;
   }
 
   .ctw-listbox {


### PR DESCRIPTION
CTW-506
- If notes is populated it will now show when editing a condition (This should also happen when adding from other patient records - have to confirm if we want this). Notes can only be resized vertically now.

