### PR TITLE
Export drawer from index

### DIFF
--- a/.changeset/honest-plants-camp.md
+++ b/.changeset/honest-plants-camp.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Exporting Drawer, models and some other core components

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "dependencies": {
         "@headlessui/react": "^1.7.3",
         "@heroicons/react": "^1.0.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,11 +9,20 @@ export * from "@/components/content/medication-history";
 export * from "@/components/content/medications-table-base";
 export * from "@/components/content/medication-drawer";
 // Core components
-export * from "@/components/core/table/table";
+export * from "@/components/core/alert";
+export * from "@/components/core/badge";
 export * as CTWBox from "@/components/core/ctw-box";
+export * from "@/components/core/drawer";
+export * from "@/components/core/modal";
+export * from "@/components/core/spinner";
+export * from "@/components/core/table/table";
+export * from "@/components/core/toggle";
+export * from "@/components/core/toggle-control";
 // Zus Providers and Hooks
 export * from "@/components/core/ctw-provider";
 export * from "@/components/core/patient-provider";
 export * from "@/hooks/use-medications";
+// Models
+export * from "@/models";
 // Utility
 export { version } from "../package.json";

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,8 @@
+export { ConditionModel } from "@/models/condition";
+export { MedicationModel } from "@/models/medication";
+export { MedicationDispenseModel } from "@/models/medication-dispense";
+export { MedicationStatementModel } from "@/models/medication-statement";
+export { OperationOutcomeModel } from "@/models/operation-outcome";
+export { OrganizationModel } from "@/models/organization";
+export { PatientModel } from "@/models/patients";
+export { PractitionerModel } from "@/models/practitioner";


### PR DESCRIPTION
Exporting parts of the library that would be used if someone were building custom components using the library. Currently it is difficult to build a custom medication table and drawer like `<PatientMedications />`  because we don't export some of the useful building blocks of the library.

It's possible that future refactors might make some of these exports obsolete, but if that's the case we should just version bump accordingly.