### PR TITLE
CTW-522/css issues

### DIFF
--- a/.changeset/fast-spiders-rush.md
+++ b/.changeset/fast-spiders-rush.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix a handful of CSS issues impacting importing of this component library. Additionally get conditions autocomplete options to float (absolute positioning) instead of pushing other content down when options are showed.

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -227,7 +227,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
             hideMenu={readOnly}
             message={
               <>
-                {patientRecordsMessage}
+                <div>{patientRecordsMessage}</div>
                 {!patientRecordsResponse.isError && (
                   <div className="ctw-my-5">{addConditionBtn}</div>
                 )}

--- a/src/components/core/form/combobox-field.tsx
+++ b/src/components/core/form/combobox-field.tsx
@@ -1,4 +1,4 @@
-import { isMouseEvent } from "@/utils/typescript";
+import { isMouseEvent } from "@/utils/types";
 import { Combobox } from "@headlessui/react";
 import { debounce, isEmpty, isObject } from "lodash";
 import { ChangeEvent, useMemo, useState } from "react";

--- a/src/components/core/form/combobox-field.tsx
+++ b/src/components/core/form/combobox-field.tsx
@@ -1,3 +1,4 @@
+import { isMouseEvent } from "@/utils/typescript";
 import { Combobox } from "@headlessui/react";
 import { debounce, isEmpty, isObject } from "lodash";
 import { ChangeEvent, useMemo, useState } from "react";
@@ -53,25 +54,45 @@ export const ComboboxField = <T,>({
 
   return (
     <Combobox onChange={onSelectChange} value={searchTerm} disabled={readonly}>
-      <Combobox.Input
-        className="ctw-listbox-input ctw-w-full"
-        onChange={(e) => {
-          // Due to debounce, we have to persist the event.
-          // https://reactjs.org/docs/legacy-event-pooling.html
-          e.persist();
-          debouncedSearchInputChange(e);
-        }}
-        placeholder="Type to search"
-      />
+      {({ open }) => (
+        <div>
+          <Combobox.Button
+            as="div"
+            onClick={(e: unknown) => {
+              if (open || searchTerm.length === 0) {
+                if (isMouseEvent(e)) {
+                  e.preventDefault();
+                }
+              }
+            }}
+          >
+            <Combobox.Input
+              className="ctw-listbox-input ctw-w-full"
+              onChange={(e) => {
+                // Due to debounce, we have to persist the event.
+                // https://reactjs.org/docs/legacy-event-pooling.html
+                e.persist();
+                debouncedSearchInputChange(e);
+              }}
+              placeholder="Type to search"
+            />
+          </Combobox.Button>
 
-      <input hidden name={name} value={inputValueParsed as string} readOnly />
-      <Combobox.Options className="ctw-listbox ctw-max-h-60 ctw-overflow-auto ctw-rounded-md ctw-bg-white ctw-py-1 ctw-text-base ctw-shadow-lg ctw-ring-1 ctw-ring-opacity-5 focus:ctw-outline-none sm:ctw-text-sm">
-        <ComboboxOptions
-          options={options}
-          query={searchTerm}
-          isLoading={isLoading}
-        />
-      </Combobox.Options>
+          <input
+            hidden
+            name={name}
+            value={inputValueParsed as string}
+            readOnly
+          />
+          <Combobox.Options className="ctw-listbox ctw-absolute ctw-z-10 ctw-m-0 ctw-mt-1 ctw-max-h-60 ctw-w-full ctw-list-none ctw-overflow-auto ctw-rounded-md ctw-bg-white ctw-p-0 ctw-py-1 ctw-text-base ctw-shadow-lg ctw-ring-1 ctw-ring-opacity-5 focus:ctw-outline-none sm:ctw-text-sm">
+            <ComboboxOptions
+              options={options}
+              query={searchTerm}
+              isLoading={isLoading}
+            />
+          </Combobox.Options>
+        </div>
+      )}
     </Combobox>
   );
 };

--- a/src/components/core/main.scss
+++ b/src/components/core/main.scss
@@ -35,12 +35,6 @@
     background-color: initial;
   }
 
-  .ctw-listbox {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
   .ctw-listbox-button:disabled,
   .ctw-listbox-textarea:disabled,
   .ctw-listbox-textarea:read-only,

--- a/src/components/core/table/table-full-length-row.tsx
+++ b/src/components/core/table/table-full-length-row.tsx
@@ -9,7 +9,7 @@ export const TableFullLengthRow = ({
 }) => (
   <tr>
     <td
-      className="ctw-p-6 ctw-text-center ctw-text-content-light"
+      className="ctw-flex ctw-flex-col ctw-items-center ctw-p-6 ctw-text-content-light"
       colSpan={colSpan}
     >
       {children}

--- a/src/components/core/table/table-rows.tsx
+++ b/src/components/core/table/table-rows.tsx
@@ -1,5 +1,5 @@
-import { ReactElement } from "react";
 import cx from "classnames";
+import { ReactElement } from "react";
 import { Spinner } from "../spinner";
 import type { MinRecordItem, TableColumn } from "./table";
 import { TableDataCell } from "./table-data-cell";
@@ -23,7 +23,7 @@ export const TableRows = <T extends MinRecordItem>({
   if (isLoading) {
     return (
       <TableFullLengthRow colSpan={columns.length}>
-        <div className="ctw-flex ctw-items-center ctw-justify-center ctw-space-x-2">
+        <div className="ctw-flex ctw-justify-center ctw-space-x-2">
           <span>Loading...</span>
           <Spinner />
         </div>

--- a/src/styles/tailwind.theme.ts
+++ b/src/styles/tailwind.theme.ts
@@ -1,4 +1,10 @@
-import { Subset } from "../utils/typescript";
+// DO NOT IMPORT OUTSIDE THINGS WITHIN THIs FILE!
+// We compile this file and any imports will get compiled
+// to .js files which would then need to be cleaned up.
+
+type Subset<K> = {
+  [attr in keyof K]?: K[attr] extends object ? Subset<K[attr]> : K[attr];
+};
 
 export const CLASS_PREFIX = "ctw-";
 

--- a/src/styles/tailwind.theme.ts
+++ b/src/styles/tailwind.theme.ts
@@ -67,6 +67,40 @@ export const TailwindTheme = {
   },
 };
 
+// Some post processing workflows (older versions of PostCSS) will
+// incorrectly remove tailwind's empty CSS variables.
+// To fix this, we manually apply them in CTWProvider.
+// See https://github.com/tailwindlabs/tailwindcss/issues/2889#issuecomment-734238826
+export const EmptyTailwindCSSVars: Record<string, string> = {
+  "--tw-pan-x": " ",
+  "--tw-pan-y": " ",
+  "--tw-pinch-zoom": " ",
+  "--tw-ordinal": " ",
+  "--tw-slashed-zero": " ",
+  "--tw-numeric-figure": " ",
+  "--tw-numeric-spacing": " ",
+  "--tw-numeric-fraction": " ",
+  "--tw-ring-inset": " ",
+  "--tw-blur": " ",
+  "--tw-brightness": " ",
+  "--tw-contrast": " ",
+  "--tw-grayscale": " ",
+  "--tw-hue-rotate": " ",
+  "--tw-invert": " ",
+  "--tw-saturate": " ",
+  "--tw-sepia": " ",
+  "--tw-drop-shadow": " ",
+  "--tw-backdrop-blur": " ",
+  "--tw-backdrop-brightness": " ",
+  "--tw-backdrop-contrast": " ",
+  "--tw-backdrop-grayscale": " ",
+  "--tw-backdrop-hue-rotate": " ",
+  "--tw-backdrop-invert": " ",
+  "--tw-backdrop-opacity": " ",
+  "--tw-backdrop-saturate": " ",
+  "--tw-backdrop-sepia": " ",
+};
+
 // Theme type is a nested partial
 export type ColorTheme = Subset<typeof TailwindTheme["colors"]>;
 export type Theme = {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,3 @@
+export function isMouseEvent(e: unknown): e is MouseEvent {
+  return !!(e && typeof e === "object" && "preventDefault" in e);
+}

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -2,3 +2,7 @@
 export type Subset<K> = {
   [attr in keyof K]?: K[attr] extends object ? Subset<K[attr]> : K[attr];
 };
+
+export function isMouseEvent(e: unknown): e is MouseEvent {
+  return !!(e && typeof e === "object" && "preventDefault" in e);
+}

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -1,8 +1,0 @@
-// Like Partial except recursively sets all keys on an object to optional.
-export type Subset<K> = {
-  [attr in keyof K]?: K[attr] extends object ? Subset<K[attr]> : K[attr];
-};
-
-export function isMouseEvent(e: unknown): e is MouseEvent {
-  return !!(e && typeof e === "object" && "preventDefault" in e);
-}


### PR DESCRIPTION
* Change how empty table message gets centered
* Put empty CSS vars in CTWProvider's div style
* Autocomplete changes
  * Make autocomplete use absolute positioned options.
  * Make autocomplete reopen when clicking in the input box.
 
Autocomplete with floating options
<img width="556" alt="Screen Shot 2022-11-08 at 10 33 59 AM" src="https://user-images.githubusercontent.com/1568246/200608163-2801b6c1-75f2-4078-b766-ca2294a1ae12.png">
