### PR TITLE
Filter entered-in-error from condition history

### DIFF
--- a/.changeset/plenty-toes-taste.md
+++ b/.changeset/plenty-toes-taste.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Filter entered-in-error for verfication status in condition history.

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -98,12 +98,14 @@ export function ConditionHistory({ condition }: { condition: ConditionModel }) {
           "desc"
         );
 
-        const conditionsFilteredWithDate = sortedConditions.filter(
-          (c) => c.recordedDate
+        const filterEnteredinErrorConditions = sortedConditions.filter(
+          (c) => c.verificationStatus !== "entered-in-error"
         );
-        const conditionsFilteredWithoutDate = sortedConditions.filter(
-          (c) => !c.recordedDate
-        );
+
+        const conditionsFilteredWithDate =
+          filterEnteredinErrorConditions.filter((c) => c.recordedDate);
+        const conditionsFilteredWithoutDate =
+          filterEnteredinErrorConditions.filter((c) => !c.recordedDate);
 
         setConditionsWithDate(
           conditionsFilteredWithDate.map((model) => setupData(model))


### PR DESCRIPTION
[CTW-539](https://zeushealth.atlassian.net/jira/software/projects/CTW/boards/49?selectedIssue=CTW-539)

This PR filters entered-in-error for verification status from condition history panel. 

Before: 
<img width="582" alt="Screen Shot 2022-11-08 at 10 46 34 AM" src="https://user-images.githubusercontent.com/98342697/200625631-fbcfa431-18f5-4c9b-aa22-99bfb96419e9.png">

After: 
<img width="585" alt="Screen Shot 2022-11-08 at 10 46 58 AM" src="https://user-images.githubusercontent.com/98342697/200625671-e568d09e-ff4a-4584-80c6-32ab3b66f70d.png">
