### PR TITLE
CTW-349 Capitalizing fields in details/history drawer

### DIFF
--- a/.changeset/pink-hairs-call.md
+++ b/.changeset/pink-hairs-call.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Capitalizing fields in details/history drawers
+Capitalize label and fields in detail and history drawers.

--- a/.changeset/pink-hairs-call.md
+++ b/.changeset/pink-hairs-call.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Capitalizing fields in details/history drawers

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -2,7 +2,7 @@ import { Loading } from "@/components/core/loading";
 import { getIncludedResources } from "@/fhir/bundle";
 import { useConditionHistory } from "@/fhir/conditions";
 import { ConditionModel } from "@/models/condition";
-import { orderBy } from "lodash";
+import { capitalize, orderBy, startCase } from "lodash";
 import { useEffect, useState } from "react";
 import { CodingList } from "../core/coding-list";
 import { CollapsibleDataListProps } from "../core/collapsible-data-list";
@@ -23,11 +23,11 @@ function setupData(condition: ConditionModel): CollapsibleDataListProps {
     },
     {
       label: "Clinical Status",
-      value: condition.clinicalStatus,
+      value: capitalize(condition.clinicalStatus),
     },
     {
       label: "Verification Status",
-      value: condition.verificationStatus,
+      value: capitalize(condition.verificationStatus),
     },
     {
       label: "Recorded Date",
@@ -35,7 +35,7 @@ function setupData(condition: ConditionModel): CollapsibleDataListProps {
     },
     {
       label: "Category",
-      value: condition.categories[0],
+      value: startCase(condition.categories[0]),
     },
     {
       label: "Note",

--- a/src/components/content/medication-drawer.tsx
+++ b/src/components/content/medication-drawer.tsx
@@ -1,4 +1,5 @@
 import type { MedicationStatementModel } from "@/models/medication-statement";
+import { capitalize } from "lodash";
 import type { DataListEntry } from "../core/data-list";
 import { DataList, entryFromArray } from "../core/data-list";
 import type { DrawerProps } from "../core/drawer";
@@ -14,7 +15,7 @@ function getDataEntriesFromMedicationStatement(
 ): DataListEntry[] {
   return medication
     ? [
-        { label: "Status", value: medication.status },
+        { label: "Status", value: capitalize(medication.status) },
         { label: "Last Fill Date", value: medication.lastFillDate },
         { label: "Quantity", value: medication.quantity },
         { label: "Days Supply", value: medication.daysSupply },

--- a/src/components/content/medication-history.tsx
+++ b/src/components/content/medication-history.tsx
@@ -5,6 +5,7 @@ import { useMedicationHistory } from "@/fhir/medications";
 import { MedicationModel } from "@/models/medication";
 import { MedicationDispenseModel } from "@/models/medication-dispense";
 import { MedicationStatementModel } from "@/models/medication-statement";
+import { capitalize } from "lodash";
 import { useEffect, useState } from "react";
 
 const MEDICATION_HISTORY_LIMIT = 10;
@@ -63,7 +64,7 @@ function createMedicationStatementCard(medication: MedicationModel) {
     data: [
       {
         label: "Status",
-        value: medStatement.status,
+        value: capitalize(medStatement.status),
       },
       {
         label: "Instructions",


### PR DESCRIPTION
Capitalizing various fields in the details/history drawers. I figured there was 3 options here: 

1. Do it generically in the underlying core components with something like a `capitalize` boolean prop
2. Do it in the getters
3. Do it when setting up data to pass to the component for presentation

I chose option 3 because it felt like this kind of decision belongs close to the presentation layer. The underlying data may not be capitalized, and this is likely a case-by-case decision (eg. we're not going to capitalize the "h" at the beginning of a URL), so I thought this was the appropriate place to put this logic.

https://user-images.githubusercontent.com/97455910/200661327-a865a375-0b9a-498b-a996-4b35cd27ae10.mov
