### PR TITLE
Ctw 543/fix edit add condition bug

### DIFF
--- a/.changeset/rude-items-hear.md
+++ b/.changeset/rude-items-hear.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Clicking add condition from other provider records after clicking edit condition does not result in an error anymore.

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -101,6 +101,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
     setAddConditionDefaults(newCondition);
 
     if (patientResponse.data) {
+      setSchema(conditionAddSchema);
       setDrawerIsOpen(true);
       setFormAction("Add");
       setCurrentlySelectedData(


### PR DESCRIPTION
CTW-543

Clicking add condition from other provider records after clicking edit condition does not result in an error anymore.
