### PR TITLE
CTW-548 Fixing lens query tag filter that got reverted

### DIFF
--- a/.changeset/tame-spies-tell.md
+++ b/.changeset/tame-spies-tell.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fixing issue with duplicates showing up in other provider records when common patient record is enabled

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -92,8 +92,12 @@ export async function searchLensRecords<T extends ResourceTypeString>(
   requestContext: CTWRequestContext,
   searchParams?: SearchParams
 ): Promise<SearchReturn<T>> {
+  const tagFilter = [
+    ...SUMMARY_TAGS,
+    `${SYSTEM_ZUS_OWNER}|builder/${requestContext.builderId}`,
+  ];
   const params = mergeParams(searchParams, {
-    _tag: SUMMARY_TAGS,
+    _tag: tagFilter,
   });
   return searchAllRecords(resourceType, requestContext, params);
 }


### PR DESCRIPTION
We originally fixed an issue with dupes showing up from lens requests when CPR is turned on via this commit - https://github.com/zeus-health/ctw-component-library/commit/9b0b1ff752a9d9cf165b786c62a1615bda62b0a4.

Then this commit reverted the change - https://github.com/zeus-health/ctw-component-library/commit/bf1013e6c1705ddb908f81863da323023b007c30.

I think that was an oversight when merging. Having proper automated testing would prevent this kind of headache in the future. That said, trying to get this fix back in asap for demos.