### PR TITLE
CTW-526/Create ActionList (match canvas UI)

### DIFF
--- a/.changeset/gentle-cameras-design.md
+++ b/.changeset/gentle-cameras-design.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": minor
 ---
 
-Added new component <ActionList/>
+Add new component <ActionList/>

--- a/.changeset/gentle-cameras-design.md
+++ b/.changeset/gentle-cameras-design.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Added new component <ActionList/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "0.23.2",
+  "version": "0.23.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "0.23.2",
+      "version": "0.23.5",
       "dependencies": {
         "@headlessui/react": "^1.7.3",
         "@heroicons/react": "^1.0.6",

--- a/src/components/core/action-list/action-list.scss
+++ b/src/components/core/action-list/action-list.scss
@@ -17,18 +17,16 @@
     // because we will use "after" to create colors on the left border, we need a transparent border here so content
     // will respect layout, as content would shift under the border of an absolutely positioned "after" element.
     border-left: 0.5rem solid transparent;
-    &:after {
+    &:before {
       border-left: 0.5rem solid theme("colors.icon.active");
       content: " ";
       position: absolute;
-      height: 100%;
-      width: 100%;
-      top: 0;
-      bottom: -10px;
+      top: -1px;
+      bottom: -1px;
       // Move left to sit over the transparent border on the list item
       left: -0.5rem;
     }
-    &:not(.active):after {
+    &:not(.active):before {
       border-left: 0.5rem solid theme("colors.divider.light");
     }
 

--- a/src/components/core/action-list/action-list.scss
+++ b/src/components/core/action-list/action-list.scss
@@ -5,6 +5,7 @@
   overflow: hidden; // so the left padding colored on items doesn't break border-radius
 
   .ctw-action-list-item {
+    position: relative;
     /* Inside auto layout */
     margin: -1px 0;
     width: 100%;
@@ -12,8 +13,22 @@
     // Colors
     background: theme("colors.white");
     border: 1px solid theme("colors.divider.light");
-    border-left: 0.5rem solid theme("colors.icon.active");
-    &:not(.active) {
+
+    // because we will use "after" to create colors on the left border, we need a transparent border here so content
+    // will respect layout, as content would shift under the border of an absolutely positioned "after" element.
+    border-left: 0.5rem solid transparent;
+    &:after {
+      border-left: 0.5rem solid theme("colors.icon.active");
+      content: " ";
+      position: absolute;
+      height: 100%;
+      width: 100%;
+      top: 0;
+      bottom: -10px;
+      // Move left to sit over the transparent border on the list item
+      left: -0.5rem;
+    }
+    &:not(.active):after {
       border-left: 0.5rem solid theme("colors.divider.light");
     }
 
@@ -26,8 +41,8 @@
     }
 
     .ctw-action-list-item-action {
-      // hide button by default
-      opacity: 0;
+      min-width: 8rem; // keep button container bigger than button
+      opacity: 0; // hide button by default
       button {
         float: right;
       }

--- a/src/components/core/action-list/action-list.scss
+++ b/src/components/core/action-list/action-list.scss
@@ -1,0 +1,36 @@
+.ctw-action-list {
+  @apply ctw-border-solid ctw-border-divider-light;
+  list-style: none;
+  padding-left: 0; // no space between left side of list and list items
+  overflow: hidden; // so the left padding colored on items doesn't break border-radius
+
+  .ctw-action-list-item {
+    /* Inside auto layout */
+    margin: -1px 0;
+    width: 100%;
+
+    // Colors
+    background: theme("colors.white");
+    border: 1px solid theme("colors.divider.light");
+    border-left: 0.5rem solid theme("colors.icon.active");
+    &:not(.active) {
+      border-left: 0.5rem solid theme("colors.divider.light");
+    }
+
+    // Show button on hover if an action is available
+    &:hover:is(.active),
+    &:hover:is(.undoable) {
+      .ctw-action-list-item-action {
+        opacity: 1;
+      }
+    }
+
+    .ctw-action-list-item-action {
+      // hide button by default
+      opacity: 0;
+      button {
+        float: right;
+      }
+    }
+  }
+}

--- a/src/components/core/action-list/action-list.stories.tsx
+++ b/src/components/core/action-list/action-list.stories.tsx
@@ -1,15 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   ActionList,
-  ActionListItem,
   ActionListProps,
-  ActionItemProps,
   MinActionItem,
 } from "@/components/core/action-list/action-list";
 
-type Item = MinActionItem;
-
-type Props = ActionListProps<Item>;
+type Props = ActionListProps<MinActionItem>;
 
 const item = (id = "", title = "", subtitle = "", complete = false) => ({
   id,

--- a/src/components/core/action-list/action-list.stories.tsx
+++ b/src/components/core/action-list/action-list.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  ActionList,
+  ActionListItem,
+  ActionListProps,
+  ActionItemProps,
+  MinActionItem,
+} from "@/components/core/action-list/action-list";
+
+type Item = MinActionItem;
+
+type Props = ActionListProps<Item>;
+
+const item = (id = "", title = "", subtitle = "", complete = false) => ({
+  id,
+  title,
+  subtitle,
+  complete,
+});
+const items: MinActionItem[] = [
+  item(
+    "007",
+    "Miralax Oral Product",
+    "Dissolve 17g in 4–8oz liquid and drink once daily for up to 7 days."
+  ),
+  item(
+    "123",
+    "3 ML insulin glargine 100 UNT/ML Pen Injector [Lantus]",
+    "Inject 3 ML with enclosed pen injector every morning."
+  ),
+  item(
+    "insulin",
+    "3 ML insulin aspart protamine, human 70 UNT/ML / insulin aspart, human 30 UNT/ML Pen Injector [NovoLog Mix] ",
+    "Inject 3 ML before meals. Quantity: 90 days"
+  ),
+  item(
+    "next",
+    "triamcinolone acetonide 0.147 MG/ML Topical Spray",
+    "Apply to affected area as needed for eczema exacerbation.",
+    true
+  ),
+];
+
+export const Basic: StoryObj<Props> = {
+  args: {
+    items,
+  },
+};
+
+export const WithUndo: StoryObj<Props> = {
+  args: {
+    items,
+    onUndoAction: () => {},
+  },
+};
+
+export const Empty: StoryObj<Props> = {
+  args: {
+    items: [],
+  },
+};
+
+export default {
+  component: ActionList,
+  argTypes: {
+    message: {
+      defaultValue: "Default",
+      options: ["Default"],
+      mapping: {
+        Default: (
+          <div className="ctw-space-y-4">
+            <ActionList
+              items={items}
+              onAction={() => {}}
+              actionText="Take Action"
+              undoActionText="Undo Action"
+            />
+          </div>
+        ),
+      },
+    },
+  },
+} as Meta<Props>;

--- a/src/components/core/action-list/action-list.stories.tsx
+++ b/src/components/core/action-list/action-list.stories.tsx
@@ -58,6 +58,15 @@ export const Empty: StoryObj<Props> = {
 
 export default {
   component: ActionList,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+        \nDisplays a list of action items which reflect whether they are completed or not. List items marked "active" will show a (primary) colored border to the left and when hovered will present a button to take action. Use the "onAction" handler to mark items as "complete".
+        \nOptionally the opposite can be done for inactive items if an "onUndoAction" handler is passed in, but that is not a requirement.`,
+      },
+    },
+  },
   argTypes: {
     message: {
       defaultValue: "Default",

--- a/src/components/core/action-list/action-list.tsx
+++ b/src/components/core/action-list/action-list.tsx
@@ -1,0 +1,103 @@
+import cx from "classnames";
+import { isFunction } from "lodash/fp";
+import "./action-list.scss";
+
+export type MinActionItem = {
+  id: string;
+  subtitle?: string;
+  title: string;
+  complete: boolean;
+};
+
+export type ActionItemProps<T extends MinActionItem> = {
+  className?: string;
+  item: T;
+  onAction: (i: T) => void;
+  onRowClick?: (i: T) => void;
+  actionText: string;
+  activeClassName?: string;
+  onUndoAction?: (i: T) => void;
+  undoActionText?: string;
+};
+
+export type ActionListProps<T extends MinActionItem> = {
+  items: T[];
+} & Omit<ActionItemProps<T>, "item">;
+
+export const ActionList = <T extends MinActionItem>({
+  items,
+  className,
+  ...itemProps
+}: ActionListProps<T>) => (
+  <ul
+    className={cx("ctw-action-list ctw-rounded-lg", className, {
+      "ctw-border-0": items.length === 0,
+      "ctw-bg-bg-lighter": items.length > 0,
+    })}
+  >
+    {items.map((item) => (
+      <ActionListItem key={item.id} item={item} {...itemProps} />
+    ))}
+  </ul>
+);
+
+export const ActionListItem = <T extends MinActionItem>({
+  item,
+  onRowClick,
+  onAction,
+  actionText = "Mark Complete",
+  undoActionText = "Undo",
+  onUndoAction,
+  activeClassName = "active",
+}: ActionItemProps<T>) => (
+  <li
+    role="row"
+    className={cx(
+      "ctw-action-list-item",
+      "ctw-border-lighter ctw-flex ctw-cursor-pointer ctw-p-4",
+      {
+        [activeClassName]: !item.complete,
+        undoable: isFunction(onUndoAction),
+      }
+    )}
+    onKeyDown={(evt) => {
+      // Visible, non-intercomplete elements with click handlers must have at least 1 keyboard listener
+      if (evt.key === "Enter") {
+        evt.currentTarget.click();
+      }
+    }}
+    onClick={() => onRowClick?.(item)}
+  >
+    <div className="ctw-action-list-item-content ctw-flex-grow">
+      <div className="ctw-font-semibold">{item.title}</div>
+      {item.subtitle && <div className="ctw-font-light">{item.subtitle}</div>}
+    </div>
+    <div className="ctw-action-list-item-action">
+      {!item.complete && (
+        <button
+          type="button"
+          className="ctw-btn-primary"
+          onClick={(evt) => {
+            evt.stopPropagation();
+            onAction(item);
+          }}
+        >
+          {actionText}
+        </button>
+      )}
+
+      {item.complete && !!onUndoAction && (
+        <button
+          type="button"
+          className="ctw-btn-default"
+          onClick={(evt) => {
+            evt.stopPropagation();
+            onUndoAction(item);
+          }}
+        >
+          {undoActionText}
+        </button>
+      )}
+    </div>
+  </li>
+);

--- a/src/components/core/action-list/action-list.tsx
+++ b/src/components/core/action-list/action-list.tsx
@@ -60,7 +60,7 @@ export const ActionListItem = <T extends MinActionItem>({
         undoable: isFunction(onUndoAction),
       }
     )}
-    onKeyDown={(evt) => {
+    onKeyDown={(event) => {
       // Visible, non-intercomplete elements with click handlers must have at least 1 keyboard listener
       if (evt.key === "Enter") {
         evt.currentTarget.click();

--- a/src/components/core/action-list/action-list.tsx
+++ b/src/components/core/action-list/action-list.tsx
@@ -62,8 +62,8 @@ export const ActionListItem = <T extends MinActionItem>({
     )}
     onKeyDown={(event) => {
       // Visible, non-intercomplete elements with click handlers must have at least 1 keyboard listener
-      if (evt.key === "Enter") {
-        evt.currentTarget.click();
+      if (event.key === "Enter") {
+        event.currentTarget.click();
       }
     }}
     onClick={() => onRowClick?.(item)}
@@ -77,8 +77,8 @@ export const ActionListItem = <T extends MinActionItem>({
         <button
           type="button"
           className="ctw-btn-primary"
-          onClick={(evt) => {
-            evt.stopPropagation();
+          onClick={(event) => {
+            event.stopPropagation();
             onAction(item);
           }}
         >
@@ -90,8 +90,8 @@ export const ActionListItem = <T extends MinActionItem>({
         <button
           type="button"
           className="ctw-btn-default"
-          onClick={(evt) => {
-            evt.stopPropagation();
+          onClick={(event) => {
+            event.stopPropagation();
             onUndoAction(item);
           }}
         >

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from "@/components/content/medication-history";
 export * from "@/components/content/medications-table-base";
 export * from "@/components/content/medication-drawer";
 // Core components
+export * from "@/components/core/action-list/action-list";
 export * from "@/components/core/alert";
 export * from "@/components/core/badge";
 export * as CTWBox from "@/components/core/ctw-box";


### PR DESCRIPTION
Creates an `<ActionList/>` component which will look something like this:
<img width="1205" alt="Screen Shot 2022-11-09 at 12 18 44 PM" src="https://user-images.githubusercontent.com/6380075/200897404-c95a8a99-308d-461d-9c96-19ff4dd6bf24.png">

And in the wild:
<img width="544" alt="Screen Shot 2022-11-09 at 12 27 48 PM" src="https://user-images.githubusercontent.com/6380075/200899296-f7394e81-7781-4c1b-b591-28db4c58c1ad.png">

Notable attributes:
List items marked "active" will show a (primary) colored border to the left by default and when hovered present a button to take action on that item. Optionally the opposite can be done for inactive items if an `onUndoAction` handler is passed in, but that is not a requirement.

It is the duty of the data owner to set the "active" property on their item through their custom "onAction" handler. The list is simply rendering state and wiring up the event listeners.

There is an optional "onRowClick" handler that will take action if the row is clicked or enter button is pushed while row is focused. It is the responsibility of the code-base utilizing this component to create a style for the focus state using CSS. We are not implementing focused css styles or class-names at the time. The keyboard handler here is less about accessibility than it is about ensuring we're not actively preventing consumers of the library from building accessible applications using Zus components.