### PR TITLE
CTW-544 Changing condition history title to category

### DIFF
--- a/.changeset/angry-dryers-boil.md
+++ b/.changeset/angry-dryers-boil.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Changing title in conditions history to category

--- a/.changeset/angry-dryers-boil.md
+++ b/.changeset/angry-dryers-boil.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Changing title in conditions history to category
+Change title in conditions history to category

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -64,7 +64,7 @@ function setupData(condition: ConditionModel): CollapsibleDataListProps {
   return {
     id: condition.id,
     date: condition.recordedDate,
-    title: condition.snomedDisplay || condition.icd10Display,
+    title: startCase(condition.categories[0]),
     subTitle: condition.patient?.organization?.name,
     data: detailData,
   };


### PR DESCRIPTION
Previously we were displaying the code display value which was ending up pretty redundant. Per CTW-544 changing this to display the condition category which is either "Problem List Item" or "Encounter Diagnosis". Essentially distinguishing whether "this visit was to address this Dx" vs "we verified the patient has this condition". 

**Before**
![image](https://user-images.githubusercontent.com/97455910/201119857-3dfb2a23-f52c-4d3c-bb0a-15d6ff408706.png)

**After**
![image](https://user-images.githubusercontent.com/97455910/201119936-e37becf2-a7d7-45a9-b181-e45410782b9f.png)
