### PR TITLE
CTW-518/filter condition summary resources

### DIFF
--- a/.changeset/bright-kings-brush.md
+++ b/.changeset/bright-kings-brush.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Filter out other provider records by any matching patient records that are newer, regardless of active/inactive status.

--- a/src/components/content/conditions/helpers.test.ts
+++ b/src/components/content/conditions/helpers.test.ts
@@ -1,0 +1,71 @@
+import { ConditionModel } from "@/models";
+import { filterOtherConditions } from "./helpers";
+
+describe("Condition Helpers", () => {
+  describe("filterOtherConditions", () => {
+    it("should filter out when there's a match and other record has no date", () => {
+      const { others, patients } = setupConditions();
+      const filtered = filterOtherConditions(others, patients);
+      expect(filtered).toHaveLength(2);
+      expect(filtered[0].id).toEqual("other2");
+      expect(filtered[1].id).toEqual("other3");
+    });
+
+    it("should filter out when there's a match and patient record is newer", () => {
+      const { others, patients } = setupConditions("2022-11-09", "2022-11-10");
+      const filtered = filterOtherConditions(others, patients);
+      expect(filtered).toHaveLength(2);
+      expect(filtered[0].id).toEqual("other2");
+      expect(filtered[1].id).toEqual("other3");
+    });
+
+    it("should NOT filter out when there's a match and patient record is older", () => {
+      const { others, patients } = setupConditions("2022-11-10", "2022-11-09");
+      const filtered = filterOtherConditions(others, patients);
+      expect(filtered).toHaveLength(3);
+    });
+
+    function getCondition(id: string) {
+      return new ConditionModel({
+        id,
+        resourceType: "Condition",
+        subject: { display: "Sarah" },
+      });
+    }
+
+    function setupConditions(
+      otherRecordedDate?: string,
+      patientRecordedDate?: string
+    ) {
+      const burntEarSnomed = {
+        system: "http://snomed.info/sct",
+        code: "39065001",
+        display: "Burn of ear",
+      };
+
+      const otherCondition = getCondition("other");
+      otherCondition.resource.code = {
+        coding: [burntEarSnomed],
+      };
+      otherCondition.resource.recordedDate = otherRecordedDate;
+
+      const patientCondition = getCondition("patient");
+      patientCondition.resource.code = {
+        coding: [burntEarSnomed],
+      };
+      patientCondition.resource.recordedDate = patientRecordedDate;
+
+      const others = [
+        getCondition("other2"),
+        otherCondition,
+        getCondition("other3"),
+      ];
+      const patients = [
+        getCondition("patient2"),
+        patientCondition,
+        getCondition("patient3"),
+      ];
+      return { others, patients };
+    }
+  });
+});

--- a/src/components/content/conditions/helpers.ts
+++ b/src/components/content/conditions/helpers.ts
@@ -1,0 +1,22 @@
+import { ConditionModel } from "@/models";
+
+// Filter out other conditions where:
+//  1. There is an existing patient condition with a matching known code.
+//  2. The patient condition is more recent than the other condition.
+export const filterOtherConditions = (
+  otherConditions: ConditionModel[],
+  patientConditions: ConditionModel[]
+): ConditionModel[] =>
+  otherConditions.filter(
+    (otherCondition) =>
+      !patientConditions.some((patientCondition) => {
+        const otherRecordedDate = otherCondition.resource.recordedDate;
+        const patientRecordedDate = patientCondition.resource.recordedDate;
+
+        return (
+          otherCondition.knownCodingsMatch(patientCondition) &&
+          (!otherRecordedDate ||
+            (patientRecordedDate && otherRecordedDate <= patientRecordedDate))
+        );
+      })
+  );

--- a/src/fhir/conditions.ts
+++ b/src/fhir/conditions.ts
@@ -10,7 +10,6 @@ import { SearchParams } from "fhir-kit-client";
 import { orderBy } from "lodash";
 import { CodePreference } from "./codeable-concept";
 import {
-  flattenArrayFilters,
   searchBuilderRecords,
   searchCommonRecords,
   searchLensRecords,
@@ -33,30 +32,6 @@ export const CONDITION_CODE_PREFERENCE_ORDER: CodePreference[] = [
   { system: SYSTEM_ICD9_CM },
 ];
 
-export type ClinicalStatus =
-  | "active"
-  | "recurrence"
-  | "relapse"
-  | "inactive"
-  | "remission"
-  | "resolved";
-
-export type ConditionFilters = {
-  "clinical-status"?: ClinicalStatus | ClinicalStatus[];
-};
-
-export type QueryKeyConditionHistory = [
-  string,
-  string,
-  ConditionModel | undefined
-];
-export type QueryKeyPatientConditions = [
-  string,
-  string | undefined,
-  ConditionFilters
-];
-export type QueryKeyOtherProviderConditions = [string, string | undefined];
-
 export function getNewCondition(patientId: string) {
   const newCondition: fhir4.Condition = {
     resourceType: "Condition",
@@ -70,10 +45,10 @@ export function getNewCondition(patientId: string) {
   return newCondition;
 }
 
-export function usePatientConditions(conditionFilters: ConditionFilters) {
+export function usePatientConditions() {
   return useQueryWithPatient(
     QUERY_KEY_PATIENT_CONDITIONS,
-    [conditionFilters],
+    [],
     async (requestContext, patient) => {
       try {
         const { resources: conditions } = await searchBuilderRecords(
@@ -81,7 +56,6 @@ export function usePatientConditions(conditionFilters: ConditionFilters) {
           requestContext,
           {
             patientUPID: patient.UPID as string,
-            ...flattenArrayFilters(conditionFilters),
           }
         );
         return filterAndSort(conditions);
@@ -172,19 +146,3 @@ function filterAndSort(conditions: fhir4.Condition[]) {
     ["desc"]
   );
 }
-
-export const filterConditionsWithConfirmedCodes = (
-  target: fhir4.Condition[],
-  confirmedCodes: fhir4.Coding[]
-) =>
-  target.filter((c) => {
-    const conditionModel = new ConditionModel(c);
-
-    return !confirmedCodes.some((code) =>
-      conditionModel.knownCodings.some(
-        (availableCode) =>
-          availableCode.code === code.code &&
-          availableCode.system === code.system
-      )
-    );
-  });

--- a/src/models/condition.test.ts
+++ b/src/models/condition.test.ts
@@ -1,0 +1,87 @@
+import { clone } from "lodash";
+import { ConditionModel } from "./condition";
+
+describe("FHIR Model: Condition", () => {
+  describe("active", () => {
+    test("should return true or false correctly for different clinical statuses", () => {
+      const condition = getCondition();
+
+      ["active", "recurrence", "relapse"].forEach((status) => {
+        condition.resource.clinicalStatus = { coding: [{ code: status }] };
+        expect(condition.active).toBeTruthy();
+      });
+
+      ["inactive", "remission", "resolved"].forEach((status) => {
+        condition.resource.clinicalStatus = { coding: [{ code: status }] };
+        expect(condition.active).toBeFalsy();
+      });
+    });
+  });
+
+  describe("knownCodingsMatch", () => {
+    test("should return true with matching ICD10", () => {
+      const condition2 = getCondition();
+      condition2.resource.code = { coding: [decoy, burntEarICD10] };
+      expect(condition.knownCodingsMatch(condition2)).toBeTruthy();
+      expect(condition2.knownCodingsMatch(condition)).toBeTruthy();
+    });
+
+    test("should return true with matching snomed with different display", () => {
+      const condition2 = getCondition();
+      const snomed = clone(burntEarSnomed);
+      snomed.display = "Different display";
+      condition2.resource.code = {
+        coding: [burntEarSnomed, decoy, otherSnomed],
+      };
+      expect(condition.knownCodingsMatch(condition2)).toBeTruthy();
+      expect(condition2.knownCodingsMatch(condition)).toBeTruthy();
+    });
+
+    test("should return false when only matching custom system (nont known coding)", () => {
+      const condition2 = getCondition();
+      condition2.resource.code = {
+        coding: [decoy, burntEarCustom, otherSnomed],
+      };
+      expect(condition.knownCodingsMatch(condition2)).toBeFalsy();
+      expect(condition2.knownCodingsMatch(condition)).toBeFalsy();
+    });
+
+    const burntEarICD10 = {
+      system: "http://hl7.org/fhir/sid/icd-10",
+      code: "T20.31",
+      display: "Burn of third degree of ear",
+    };
+    const burntEarSnomed = {
+      system: "http://snomed.info/sct",
+      code: "39065001",
+      display: "Burn of ear",
+    };
+    const burntEarCustom = {
+      system: "http://example.com/custom",
+      code: "12345",
+      display: "Burn of ear",
+    };
+    const otherSnomed = {
+      system: "http://snomed.info/sct",
+      code: "12345",
+      display: "Fake snomed",
+    };
+    const decoy = {
+      system: "http://example.com/decoy",
+      code: "39065001", // happens to have same burnt ear code.
+      display: "This shouldn't cause matches!",
+    };
+
+    const condition = getCondition();
+    condition.resource.code = {
+      coding: [burntEarICD10, burntEarSnomed, burntEarCustom],
+    };
+  });
+
+  function getCondition() {
+    return new ConditionModel({
+      resourceType: "Condition",
+      subject: { display: "Bob" },
+    });
+  }
+});


### PR DESCRIPTION
CTW-518

We now filter out other provider conditions if there are ANY (active or inactive) patient conditions that match and are newer. In order to do this we fetch all conditions.

NOTE: There is currently a bug here if there are more than 250 conditions as that is the max we get from ODS without paging.