### PR TITLE
Simplify action list stories

### DIFF
--- a/src/components/core/action-list/action-list.stories.tsx
+++ b/src/components/core/action-list/action-list.stories.tsx
@@ -1,11 +1,15 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import {
   ActionList,
   ActionListProps,
   MinActionItem,
 } from "@/components/core/action-list/action-list";
+import type { Meta, StoryObj } from "@storybook/react";
 
 type Props = ActionListProps<MinActionItem>;
+
+export default {
+  component: ActionList,
+} as Meta<Props>;
 
 const item = (id = "", title = "", subtitle = "", complete = false) => ({
   id,
@@ -43,10 +47,12 @@ export const Basic: StoryObj<Props> = {
   },
 };
 
-export const WithUndo: StoryObj<Props> = {
+export const WithoutUndo: StoryObj<Props> = {
   args: {
     items,
-    onUndoAction: () => {},
+    // Storybook will automatically add action callbacks so we have
+    // to explictily set it to undefined.
+    onUndoAction: undefined,
   },
 };
 
@@ -55,34 +61,3 @@ export const Empty: StoryObj<Props> = {
     items: [],
   },
 };
-
-export default {
-  component: ActionList,
-  parameters: {
-    docs: {
-      description: {
-        component: `
-        \nDisplays a list of action items which reflect whether they are completed or not. List items marked "active" will show a (primary) colored border to the left and when hovered will present a button to take action. Use the "onAction" handler to mark items as "complete".
-        \nOptionally the opposite can be done for inactive items if an "onUndoAction" handler is passed in, but that is not a requirement.`,
-      },
-    },
-  },
-  argTypes: {
-    message: {
-      defaultValue: "Default",
-      options: ["Default"],
-      mapping: {
-        Default: (
-          <div className="ctw-space-y-4">
-            <ActionList
-              items={items}
-              onAction={() => {}}
-              actionText="Take Action"
-              undoActionText="Undo Action"
-            />
-          </div>
-        ),
-      },
-    },
-  },
-} as Meta<Props>;

--- a/src/components/core/action-list/action-list.tsx
+++ b/src/components/core/action-list/action-list.tsx
@@ -24,6 +24,15 @@ export type ActionListProps<T extends MinActionItem> = {
   items: T[];
 } & Omit<ActionItemProps<T>, "item">;
 
+/**
+ * Displays a list of action items which reflect whether they are
+ * completed or not. List items marked "active" will show a (primary)
+ * colored border to the left and when hovered will present a button
+ * to take action. Use the "onAction" handler to mark items as "complete".
+ *
+ * Optionally the opposite can be done for inactive items if an "onUndoAction"
+ * handler is passed in, but that is not a requirement.
+ */
 export const ActionList = <T extends MinActionItem>({
   items,
   className,


### PR DESCRIPTION
1. There is no `message` prop so remove it from `argTypes`.
2. Move `export default` to the top as that is the main thing that sets up the stories.
3. Storybook will automatically pass in callback functions which log to the `actions` tab when viewing a single story (see screenshot). So... we need to explicitly set a callback to `undefined` if we want to get rid of it.
4. Any description of the component or of the properties should be in the component code itself and not just the story code. Unfortunately there is a bug right now where this requires a storybook restart to get picked up. 

<img width="497" alt="Screen Shot 2022-11-14 at 12 07 13 PM" src="https://user-images.githubusercontent.com/1568246/201722057-c10d4b85-6de3-4aa6-bd7c-acd7c87f021a.png">
