### PR TITLE
More condition stories

### DIFF
--- a/.changeset/yellow-pears-applaud.md
+++ b/.changeset/yellow-pears-applaud.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix a few minor style bugs with stacked conditions.

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,16 @@
 // Always include our main styles to get tailwind and
 // anything else our components may depend on.
+import { queryClient } from "@/utils/request";
 import { initialize, mswDecorator } from "msw-storybook-addon";
 import "./preview.scss";
+
+// Disable caching in react query. This way mock data responses
+// won't persist across stories and multiple requests.
+queryClient.setDefaultOptions({
+  queries: {
+    staleTime: 0,
+  },
+});
 
 // By default MSW assumes the service worker will be at
 // root/mockServiceWorker.js

--- a/src/components/content/conditions.scss
+++ b/src/components/content/conditions.scss
@@ -1,8 +1,28 @@
 .ctw-conditions {
   @apply ctw-border ctw-border-solid ctw-border-divider-light ctw-bg-white;
+
+  .ctw-conditions-body-container {
+    @apply ctw-m-3 ctw-space-y-5 ctw-bg-bg-white;
+  }
+
+  .ctw-conditions-heading-container {
+    @apply ctw-flex ctw-h-11 ctw-items-center ctw-justify-between ctw-bg-bg-light ctw-p-3;
+  }
+
+  .ctw-conditions-title-container {
+    @apply ctw-flex ctw-items-center ctw-justify-between;
+  }
 }
 
-.ctw-conditions.ctw-stacked {
+.ctw-conditions.ctw-conditions-stacked {
+  .ctw-conditions-body-container {
+    @apply ctw-m-0;
+  }
+
+  .ctw-conditions-title-container {
+    @apply ctw-m-3 ctw-mb-0;
+  }
+
   // When there's zero records, we won't
   // show pagination and so we'll get a double border
   // unless we bump down by 1px.

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -212,7 +212,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
               <>
                 <div>{patientRecordsMessage}</div>
                 {!patientRecordsResponse.isError && !readOnly && (
-                  <div className="ctw-my-5">{addConditionBtn}</div>
+                  <div className="ctw-mt-5">{addConditionBtn}</div>
                 )}
               </>
             }

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -177,11 +177,11 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
     <div
       ref={containerRef}
       className={cx("ctw-conditions", className, {
-        "ctw-stacked": breakpoints.sm,
+        "ctw-conditions-stacked": breakpoints.sm,
       })}
     >
       {!readOnly && (
-        <div className="ctw-heading-container">
+        <div className="ctw-conditions-heading-container">
           <div className="ctw-title">Conditions</div>
           <button
             type="button"
@@ -192,9 +192,10 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
           </button>
         </div>
       )}
-      <div className="ctw-body-container">
+
+      <div className="ctw-conditions-body-container">
         <div className="ctw-space-y-3">
-          <div className="ctw-title-container">
+          <div className="ctw-conditions-title-container">
             <div className="ctw-title">Patient Record</div>
             <ToggleControl
               onFormChange={handleToggleChange}
@@ -241,7 +242,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
         </div>
 
         <div className="ctw-space-y-3">
-          <div className="ctw-title-container">
+          <div className="ctw-conditions-title-container">
             <div className="ctw-title">Other Provider Records</div>
           </div>
 

--- a/src/components/content/conditions/conditions.stories.tsx
+++ b/src/components/content/conditions/conditions.stories.tsx
@@ -4,6 +4,7 @@ import { SYSTEM_SUMMARY, SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
 import type { Meta, StoryObj } from "@storybook/react";
 import { rest } from "msw";
 import { Conditions, ConditionsProps } from "../conditions";
+import { emptyConditions } from "./mocks/empty-conditions";
 import { heartConditions } from "./mocks/forms-data-conditions-search";
 import { historyChronsDisease } from "./mocks/history-crohns-disease";
 import { historyDermatitis } from "./mocks/history-dermatitis";
@@ -19,6 +20,20 @@ type Props = ConditionsProps;
 export default {
   component: Conditions,
   tags: ["docsPage"],
+  argTypes: {
+    className: {
+      options: ["Blank", "Fixed Width"],
+      control: "select",
+      mapping: {
+        Blank: "",
+        "Fixed Width": "ctw-m-auto ctw-max-w-[600px]",
+      },
+    },
+  },
+  args: {
+    className: "Empty",
+    readOnly: false,
+  },
   decorators: [
     (Story, { args }) => (
       <CTWProvider env="dev" authToken="dummy-token" builderId="b123">
@@ -28,16 +43,23 @@ export default {
       </CTWProvider>
     ),
   ],
+} as Meta<Props>;
+
+const handlerPatient = rest.get(
+  "https://api.dev.zusapi.com/fhir/Patient",
+  (req, res, ctx) => res(ctx.delay(1000), ctx.status(200), ctx.json(patient))
+);
+
+const handlerConditionSearch = rest.get(
+  "https://api.dev.zusapi.com/forms-data/terminology/conditions",
+  (req, res, ctx) => res(ctx.status(200), ctx.json(heartConditions))
+);
+
+export const Basic: StoryObj<Props> = {
   parameters: {
     msw: [
-      rest.get("https://api.dev.zusapi.com/fhir/Patient", (req, res, ctx) =>
-        res(ctx.status(200), ctx.json(patient))
-      ),
-      // Mock condition autocomplete, using responses for "heart".
-      rest.get(
-        "https://api.dev.zusapi.com/forms-data/terminology/conditions",
-        (req, res, ctx) => res(ctx.status(200), ctx.json(heartConditions))
-      ),
+      handlerPatient,
+      handlerConditionSearch,
       rest.get("https://api.dev.zusapi.com/fhir/Condition", (req, res, ctx) => {
         const codeParam = req.url.searchParams.get("code");
 
@@ -69,6 +91,16 @@ export default {
       }),
     ],
   },
-} as Meta<Props>;
+};
 
-export const Basic: StoryObj<Props> = {};
+export const Empty: StoryObj<Props> = {
+  parameters: {
+    msw: [
+      handlerPatient,
+      handlerConditionSearch,
+      rest.get("https://api.dev.zusapi.com/fhir/Condition", (req, res, ctx) =>
+        res(ctx.status(200), ctx.json(emptyConditions))
+      ),
+    ],
+  },
+};

--- a/src/components/content/conditions/conditions.stories.tsx
+++ b/src/components/content/conditions/conditions.stories.tsx
@@ -31,7 +31,7 @@ export default {
     },
   },
   args: {
-    className: "Empty",
+    className: "Blank",
     readOnly: false,
   },
   decorators: [

--- a/src/components/content/conditions/mocks/empty-conditions.ts
+++ b/src/components/content/conditions/mocks/empty-conditions.ts
@@ -1,0 +1,9 @@
+export const emptyConditions = {
+  resourceType: "Bundle",
+  id: "eacb4f45-4e83-45db-9114-7d3e05eb1fb3",
+  meta: {
+    lastUpdated: "2022-11-16T15:13:00.795+00:00",
+  },
+  type: "searchset",
+  total: 0,
+};

--- a/src/components/core/main.scss
+++ b/src/components/core/main.scss
@@ -94,7 +94,7 @@
 
   .ctw-stacked {
     .ctw-body-container {
-      @apply ctw-m-0;
+      @apply ctw-mx-0;
     }
 
     .ctw-title-container {

--- a/src/components/core/main.scss
+++ b/src/components/core/main.scss
@@ -94,7 +94,7 @@
 
   .ctw-stacked {
     .ctw-body-container {
-      @apply ctw-mx-0;
+      @apply ctw-m-0;
     }
 
     .ctw-title-container {

--- a/src/components/core/main.scss
+++ b/src/components/core/main.scss
@@ -100,10 +100,6 @@
     .ctw-title-container {
       @apply ctw-m-3 ctw-mb-0;
     }
-
-    .ctw-table {
-      @apply ctw-rounded-none ctw-border-x-0;
-    }
   }
 
   .ctw-hyphens-auto {

--- a/src/components/core/pagination/pagination.tsx
+++ b/src/components/core/pagination/pagination.tsx
@@ -8,6 +8,7 @@ export type PaginationProps = {
 
 export const Pagination = ({ total, count, changeCount }: PaginationProps) => {
   const allShown = count >= total || total === 0;
+  const hasPages = total > DEFAULT_PAGE_SIZE;
 
   return (
     <div className="ctw-pagination ctw-flex ctw-items-center ctw-justify-between ctw-px-6">
@@ -16,35 +17,40 @@ export const Pagination = ({ total, count, changeCount }: PaginationProps) => {
         <span className="ctw-font-medium">{Math.min(count, total)}</span> of{" "}
         <span className="ctw-font-medium">{total}</span> results
       </div>
-      <div className="ctw-flex ctw-h-full ctw-justify-end ctw-space-x-3">
-        {!allShown && total > DEFAULT_PAGE_SIZE * 2 && (
-          <button
-            type="button"
-            className="ctw-btn-default"
-            onClick={() => changeCount(count + DEFAULT_PAGE_SIZE)}
-          >
-            Show More
-          </button>
-        )}
-        {!allShown && (
-          <button
-            type="button"
-            className="ctw-btn-primary ctw-w-28 ctw-whitespace-nowrap"
-            onClick={() => changeCount(total)}
-          >
-            Show All
-          </button>
-        )}
-        {allShown && total > DEFAULT_PAGE_SIZE && (
-          <button
-            type="button"
-            className="ctw-btn-primary ctw-w-28 ctw-whitespace-nowrap"
-            onClick={() => changeCount(DEFAULT_PAGE_SIZE)}
-          >
-            Reset
-          </button>
-        )}
-      </div>
+
+      {(!allShown || hasPages) && (
+        <div className="ctw-flex ctw-h-full ctw-justify-end ctw-space-x-3">
+          {!allShown && total > DEFAULT_PAGE_SIZE * 2 && (
+            <button
+              type="button"
+              className="ctw-btn-default"
+              onClick={() => changeCount(count + DEFAULT_PAGE_SIZE)}
+            >
+              Show More
+            </button>
+          )}
+
+          {!allShown && (
+            <button
+              type="button"
+              className="ctw-btn-primary ctw-w-28 ctw-whitespace-nowrap"
+              onClick={() => changeCount(total)}
+            >
+              Show All
+            </button>
+          )}
+
+          {allShown && hasPages && (
+            <button
+              type="button"
+              className="ctw-btn-primary ctw-w-28 ctw-whitespace-nowrap"
+              onClick={() => changeCount(DEFAULT_PAGE_SIZE)}
+            >
+              Reset
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/core/table/table-full-length-row.tsx
+++ b/src/components/core/table/table-full-length-row.tsx
@@ -8,10 +8,7 @@ export const TableFullLengthRow = ({
   colSpan: number;
 }) => (
   <tr>
-    <td
-      className="ctw-flex ctw-flex-col ctw-items-center ctw-p-6 ctw-text-content-light"
-      colSpan={colSpan}
-    >
+    <td className="ctw-table-full-length-row" colSpan={colSpan}>
       {children}
     </td>
   </tr>

--- a/src/components/core/table/table.scss
+++ b/src/components/core/table/table.scss
@@ -61,6 +61,10 @@
 
         td {
           @apply ctw-whitespace-pre-wrap ctw-px-3 ctw-py-4 ctw-text-sm ctw-text-content-light;
+
+          &.ctw-table-full-length-row {
+            @apply ctw-flex ctw-flex-col ctw-items-center ctw-p-6 ctw-text-content-light;
+          }
         }
       }
     }
@@ -99,7 +103,7 @@
       tr {
         @apply ctw-relative ctw-block ctw-p-3;
 
-        td {
+        td:not(.ctw-table-full-length-row) {
           @apply ctw-block ctw-w-full ctw-p-0 ctw-pr-7;
         }
       }

--- a/src/components/core/table/table.scss
+++ b/src/components/core/table/table.scss
@@ -26,13 +26,6 @@
 .ctw-table-container {
   @apply ctw-relative ctw-overflow-hidden ctw-rounded-lg ctw-border ctw-border-solid ctw-border-divider-light;
 
-  &.ctw-table {
-    // The container displaying a table and the table it renders shouldn't both have "display: table" because that
-    // can break both the display at the container level and also the scroll functionality of any <table> nested
-    // inside the .ctw-table-container
-    display: inherit;
-  }
-
   .ctw-scrollbar {
     @apply ctw-overflow-x-auto;
   }
@@ -76,6 +69,10 @@
 }
 
 .ctw-table-stacked {
+  .ctw-table-container {
+    @apply ctw-rounded-none ctw-border-x-0;
+  }
+
   .ctw-scrollbar {
     @apply ctw-overflow-x-hidden;
   }
@@ -86,6 +83,7 @@
   }
 
   .ctw-pagination {
+    margin: 8px 0 !important;
     flex-direction: column-reverse;
     gap: 10px;
   }
@@ -111,6 +109,7 @@
   }
 
   .ctw-table-action-column {
-    @apply ctw-absolute ctw-top-1 ctw-right-2 ctw-bg-transparent ctw-p-0;
+    @apply ctw-absolute ctw-top-1 ctw-right-2 ctw-bg-transparent;
+    padding-right: 0 !important;
   }
 }

--- a/src/components/core/table/table.tsx
+++ b/src/components/core/table/table.tsx
@@ -92,7 +92,7 @@ export const Table = <T extends MinRecordItem>({
       })}
     >
       <div
-        className={cx("ctw-table-container", "ctw-table", {
+        className={cx("ctw-table-container", {
           "ctw-table-scroll-left-shadow": showLeftShadow,
           "ctw-table-scroll-right-shadow": showRightShadow,
         })}


### PR DESCRIPTION
Story changes:
* Add empty conditions story.
* Fix bug where react query was caching mock responses across stories.
* Add a fixed-width prop option for className that will trigger stacked view.
* Setup default values for className and readOnly, this makes the toggles in the storybook actions UI immediately available.

Style fixes -- opted to copy over some styles into conditions.scsss that were previously refactored into main. The goal here is to have isolation within our components by using properly namespaced classes.
* Fixed centering bug for empty stacked tables.
* Fixed pagination whitespace when stacked.
* Fixed bug where bottom border was missing when stacked and showing pagination.

# Screenshots
**New empty story and property selections**
<img width="1126" alt="Screen Shot 2022-11-16 at 2 27 34 PM" src="https://user-images.githubusercontent.com/1568246/202275653-54d1f6cd-58e7-4ca6-afb7-fe7b40597b40.png">

**BEFORE** (centering bug)
<img width="623" alt="Screen Shot 2022-11-16 at 2 25 25 PM" src="https://user-images.githubusercontent.com/1568246/202275684-6f14178b-dc30-4660-9d21-d3e8ec89cd11.png">

**AFTER**
<img width="623" alt="Screen Shot 2022-11-16 at 2 36 12 PM" src="https://user-images.githubusercontent.com/1568246/202277310-bc4f8a09-f97e-4a5d-a1a5-1f39c3886023.png">

**BEFORE** (missing bottom border & bad pagination whitespace)
<img width="622" alt="Screen Shot 2022-11-16 at 2 24 39 PM" src="https://user-images.githubusercontent.com/1568246/202276154-cf39a46c-2a39-4684-bd8b-055cf577729c.png">

**AFTER**
<img width="636" alt="Screen Shot 2022-11-16 at 2 24 08 PM" src="https://user-images.githubusercontent.com/1568246/202275734-68e9e782-55ec-493f-8e82-b8c699a54d35.png">
