### PR TITLE
CTW-545/MedicationAdministration card for Med History

### DIFF
--- a/.changeset/nasty-eels-cry.md
+++ b/.changeset/nasty-eels-cry.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Medication history now supports MedicationAdminstration details.

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -65,7 +65,7 @@ function setupData(condition: ConditionModel): CollapsibleDataListProps {
     id: condition.id,
     date: condition.recordedDate,
     title: startCase(condition.categories[0]),
-    subTitle: condition.patient?.organization?.name,
+    subtitle: condition.patient?.organization?.name,
     data: detailData,
   };
 }

--- a/src/components/content/medication-history/index.tsx
+++ b/src/components/content/medication-history/index.tsx
@@ -5,8 +5,9 @@ import { useMedicationHistory } from "@/fhir/medications";
 import { MedicationModel } from "@/fhir/models/medication";
 import { MedicationDispenseModel } from "@/fhir/models/medication-dispense";
 import { MedicationStatementModel } from "@/fhir/models/medication-statement";
-import { capitalize } from "lodash";
+import { capitalize, compact } from "lodash";
 import { useEffect, useState } from "react";
+import { MedicationAdministrationModel } from "@/fhir/models/medication-administration";
 
 const MEDICATION_HISTORY_LIMIT = 10;
 
@@ -62,7 +63,7 @@ function createMedicationStatementCard(medication: MedicationModel) {
     id: medication.id,
     title: "Medication Reviewed",
     hideEmpty: false,
-    subTitle: medStatement.informationSource?.display || "",
+    subtitle: medStatement.informationSource?.display || "",
     data: [
       {
         label: "Status",
@@ -112,7 +113,7 @@ function createMedicationRequestCard(medication: MedicationModel) {
     date: medication.dateLocal,
     id: medication.id,
     title: "Prescription Ordered",
-    subTitle: prescriber,
+    subtitle: prescriber,
     hideEmpty: false,
     data: [
       { label: "Quantity", value: [value, unit].join(" ") },
@@ -168,11 +169,34 @@ function createMedicationDispenseCard(medication: MedicationModel) {
 }
 
 function createMedicationAdminCard(medication: MedicationModel) {
+  const resource = medication.resource as fhir4.MedicationAdministration;
+  const medAdmin = new MedicationAdministrationModel(
+    resource,
+    medication.includedResources
+  );
+
   return {
     id: medication.id,
     date: medication.dateLocal,
     hideEmpty: false,
     title: "Medication Administered",
-    data: [],
+    subtitle: compact([medAdmin.dosageDisplay, medAdmin.dosageRoute]).join(
+      ", "
+    ),
+    data: [
+      { label: "Dosage", value: medAdmin.dosageDisplay },
+      {
+        label: "Route",
+        value: medAdmin.dosageRoute,
+      },
+      {
+        label: "Start Date",
+        value: medAdmin.effectivePeriod.start,
+      },
+      {
+        label: "End Date",
+        value: medAdmin.effectivePeriod.end,
+      },
+    ],
   };
 }

--- a/src/components/core/collapsible-data-list-stack.tsx
+++ b/src/components/core/collapsible-data-list-stack.tsx
@@ -25,7 +25,7 @@ export const CollapsibleDataListStack = ({
             id={entry.id}
             date={entry.date}
             title={entry.title}
-            subTitle={entry.subTitle}
+            subtitle={entry.subtitle}
             data={entry.data}
             hideEmpty={entry.hideEmpty}
           />

--- a/src/components/core/collapsible-data-list.tsx
+++ b/src/components/core/collapsible-data-list.tsx
@@ -12,7 +12,7 @@ export type CollapsibleDataListProps = {
   id: string;
   date?: string;
   title?: string;
-  subTitle?: string;
+  subtitle?: string;
   data: CollapsibleDataListEntry[];
   hideEmpty?: boolean;
 };
@@ -26,7 +26,7 @@ export const CollapsibleDataList = ({
   id,
   date,
   title,
-  subTitle,
+  subtitle,
   data,
   hideEmpty,
 }: CollapsibleDataListProps) => {
@@ -37,7 +37,7 @@ export const CollapsibleDataList = ({
       <DetailSummary
         date={date}
         title={title}
-        subTitle={subTitle}
+        subtitle={subtitle}
         isDetailShown={isDetailShown}
         setIsDetailShown={setIsDetailShown}
       />
@@ -49,13 +49,13 @@ export const CollapsibleDataList = ({
 const DetailSummary = ({
   date,
   title,
-  subTitle,
+  subtitle,
   isDetailShown,
   setIsDetailShown,
 }: {
   date?: string;
   title?: string;
-  subTitle?: string;
+  subtitle?: string;
   isDetailShown: boolean;
   setIsDetailShown: React.Dispatch<React.SetStateAction<boolean>>;
 }) => (
@@ -71,7 +71,7 @@ const DetailSummary = ({
           <div className="ctw-font-semibold ctw-text-content-black">
             {title}
           </div>
-          <div className="ctw-text-content-light">{subTitle}</div>
+          <div className="ctw-text-content-light">{subtitle}</div>
         </div>
       </div>
       <div className="ctw-justify-right ctw-flex">

--- a/src/fhir/medications.ts
+++ b/src/fhir/medications.ts
@@ -220,7 +220,7 @@ export function useMedicationHistory(medication?: fhir4.MedicationStatement) {
             "MedicationDispense",
             requestContext,
             resources.MedicationDispense,
-            ["MedicationDispense:performer"]
+            ["MedicationDispense:performer", "MedicationDispense:prescription"]
           ),
         ]);
 

--- a/src/fhir/models/medication-administration.ts
+++ b/src/fhir/models/medication-administration.ts
@@ -1,0 +1,28 @@
+import { compact } from "lodash/fp";
+import { FHIRModel } from "./fhir-model";
+import { formatDateISOToLocal } from "@/fhir/formatters";
+
+export class MedicationAdministrationModel extends FHIRModel<fhir4.MedicationAdministration> {
+  get dosageDisplay(): string {
+    const { text, route, dose } = this.resource.dosage || {};
+    if (text) {
+      return text;
+    }
+
+    return compact([dose?.value, dose?.unit]).join(" ");
+  }
+
+  get dosageRoute(): string | undefined {
+    const { route } = this.resource.dosage || {};
+    return route?.text;
+  }
+
+  get effectivePeriod() {
+    const { start, end } = this.resource.effectivePeriod || {};
+
+    return {
+      start: start ? formatDateISOToLocal(start) : "",
+      end: end ? formatDateISOToLocal(end) : "",
+    };
+  }
+}

--- a/src/fhir/models/medication.ts
+++ b/src/fhir/models/medication.ts
@@ -8,6 +8,7 @@ import { PatientModel } from "./patient";
 import { MedicationRequestModel } from "@/fhir/models/medication-request";
 import { MedicationDispenseModel } from "@/fhir/models/medication-dispense";
 import { MedicationStatementModel } from "@/fhir/models/medication-statement";
+import { MedicationAdministrationModel } from "@/fhir/models/medication-administration";
 
 export class MedicationModel extends FHIRModel<Medication> {
   get performer(): string | undefined {
@@ -24,7 +25,10 @@ export class MedicationModel extends FHIRModel<Medication> {
       case "MedicationStatement":
         return this.resource.dosage?.[0]?.text;
       case "MedicationAdministration":
-        return this.resource.dosage?.text;
+        return new MedicationAdministrationModel(
+          this.resource,
+          this.includedResources
+        ).dosageDisplay;
       case "MedicationDispense":
       case "MedicationRequest":
         return codeableConceptLabel(this.resource.dosageInstruction?.[0]);


### PR DESCRIPTION
- Added this new card for MedicationAdministration resources.
<img width="557" alt="Screen Shot 2022-11-21 at 4 21 43 PM" src="https://user-images.githubusercontent.com/6380075/203160560-4237c4cb-3c8f-4a5f-9367-c0dee4ad2ccd.png">
- Created a `fhir/models/medication-administration.ts` to help support this
- Renamed prop `subTitle` to `subtitle`. Verified that in ctw and we aren't explicitly using this `subTitle` prop anywhere. CTW Component Library uses this prop internally to make subtitles on med and condition cards so this change is safe to make