### PR TITLE
fix regression in meds component where findReference throws error looking for an unresolvable resource

### DIFF
--- a/.changeset/early-dingos-grow.md
+++ b/.changeset/early-dingos-grow.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+MedicationStatement.lastPrescriber more resilant. This will try to resolve the prescriber name based on a reference from lastPrescriber lens and falling back to the display on the reference if the actual reference cannot be resolved.

--- a/src/fhir/models/medication-statement.ts
+++ b/src/fhir/models/medication-statement.ts
@@ -175,24 +175,20 @@ export class MedicationStatementModel extends FHIRModel<fhir4.MedicationStatemen
     if (!reference?.type || !reference.reference) {
       return undefined;
     }
-    try {
-      const resource = findReference(
-        reference.type as "Practitioner" | "Organization",
-        this.resource.contained,
-        this.includedResources,
-        reference.reference
-      );
-      if (resource?.name) {
-        if (typeof resource.name === "string") {
-          return resource.name;
-        }
-        const { family, given = [] } = resource.name[0];
-        return compact([family, given[0]]).join(", ");
+    const resource = findReference(
+      reference.type as "Practitioner" | "Organization",
+      this.resource.contained,
+      this.includedResources,
+      reference.reference
+    );
+    if (resource?.name) {
+      if (typeof resource.name === "string") {
+        return resource.name;
       }
-      return reference.display;
-    } catch {
-      return reference.display;
+      const { family, given = [] } = resource.name[0];
+      return compact([family, given[0]]).join(", ");
     }
+    return reference.display;
   }
 
   get lastPrescribedDate(): string | undefined {

--- a/src/fhir/models/medication-statement.ts
+++ b/src/fhir/models/medication-statement.ts
@@ -17,6 +17,7 @@ import {
   LENS_EXTENSION_MEDICATION_REFILLS,
 } from "@/fhir/system-urls";
 import { FHIRModel } from "./fhir-model";
+import { findReference } from "@/fhir/resource-helper";
 
 export class MedicationStatementModel extends FHIRModel<fhir4.MedicationStatement> {
   readonly builderPatientRxNormStatus?: Record<string, string>;
@@ -167,11 +168,31 @@ export class MedicationStatementModel extends FHIRModel<fhir4.MedicationStatemen
   }
 
   get lastPrescriber(): string | undefined {
-    const value = this.resource.extension?.find(
+    const reference = this.resource.extension?.find(
       (x) => x.url === LENS_EXTENSION_MEDICATION_LAST_PRESCRIBER
-    )?.valueString;
+    )?.valueReference;
 
-    return value && value !== "NO-VALUE" ? value : undefined;
+    if (!reference?.type || !reference.reference) {
+      return undefined;
+    }
+    try {
+      const resource = findReference(
+        reference.type as "Practitioner" | "Organization",
+        this.resource.contained,
+        this.includedResources,
+        reference.reference
+      );
+      if (resource?.name) {
+        if (typeof resource.name === "string") {
+          return resource.name;
+        }
+        const { family, given = [] } = resource.name[0];
+        return compact([family, given[0]]).join(", ");
+      }
+      return reference.display;
+    } catch {
+      return reference.display;
+    }
   }
 
   get lastPrescribedDate(): string | undefined {

--- a/src/fhir/resource-helper.ts
+++ b/src/fhir/resource-helper.ts
@@ -22,10 +22,7 @@ export function findReference<T extends ResourceTypeString>(
     }) as ResourceType<T> | undefined;
   }
 
-  if (
-    includedResources &&
-    includedResources[reference].resourceType === resourceType
-  ) {
+  if (includedResources?.[reference]?.resourceType === resourceType) {
     return includedResources[reference] as ResourceType<T>;
   }
 


### PR DESCRIPTION
There was a regression here because `fhir/model/medication.ts` is no longer getting "display" as a fallback from the reference. Additionally, the `lastPrescriber` lens will always be undefined so this also does the work of looking up that prescriber reference.