### PR TITLE
Add version to Provenance target reference

### DIFF
--- a/.changeset/forty-lies-walk.md
+++ b/.changeset/forty-lies-walk.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Provenance now saves which historical version of a resource resulted from an operation, for more thorough tracking of changes.

--- a/src/fhir/action-helper.ts
+++ b/src/fhir/action-helper.ts
@@ -29,7 +29,6 @@ export async function createOrEditFhirResource(
     });
     if (!isFhirError(response)) {
       resourceModified.id = response.id;
-      console.log(createProvenance("CREATE", resourceModified, requestContext));
     }
     return response;
   } catch (err) {

--- a/src/fhir/action-helper.ts
+++ b/src/fhir/action-helper.ts
@@ -19,7 +19,7 @@ export async function createOrEditFhirResource(
         body: omitEmptyArrays(resource),
       });
       if (!isFhirError(response)) {
-        createProvenance("UPDATE", resource, requestContext);
+        createProvenance("UPDATE", response, requestContext);
       }
       return response;
     }
@@ -29,7 +29,7 @@ export async function createOrEditFhirResource(
     });
     if (!isFhirError(response)) {
       resourceModified.id = response.id;
-      createProvenance("CREATE", resourceModified, requestContext);
+      console.log(createProvenance("CREATE", resourceModified, requestContext));
     }
     return response;
   } catch (err) {

--- a/src/fhir/provenance.ts
+++ b/src/fhir/provenance.ts
@@ -4,7 +4,7 @@ import {
   claimsBuilderName,
   claimsPractitionerId,
 } from "@/utils/auth";
-import { Provenance, Resource } from "fhir/r4";
+import { Provenance, Reference, Resource } from "fhir/r4";
 import { getPractitioner } from "./practitioner";
 import {
   SYSTEM_PROVENANCE_ACTIVITY_TYPE,
@@ -43,27 +43,28 @@ export const createProvenance = async (
   requestContext: CTWRequestContext
 ) => {
   const { fhirClient } = requestContext;
-  const practitionerId = claimsPractitionerId(requestContext.authToken);
   const builderName = claimsBuilderName(requestContext.authToken);
+  const versionId = parseInt(resource.meta?.versionId || "0", 10) + 1;
 
-  let practitionerDisplay: string;
-  let practitionerReference: string | undefined;
-  try {
+  const practitionerId = claimsPractitionerId(requestContext.authToken);
+  let practitionerReference: Reference = {};
+  if (practitionerId !== "") {
     const practitioner = await getPractitioner(practitionerId, requestContext);
-    practitionerDisplay = practitioner.fullName;
-    practitionerReference = `Practitioner/${practitionerId}`;
-  } catch {
-    practitionerDisplay = claimsAuthEmail(requestContext.authToken);
+    practitionerReference = {
+      reference: `Practitioner/${practitionerId}`,
+      display: practitioner.fullName,
+    };
+  } else {
+    practitionerReference = {
+      display: claimsAuthEmail(requestContext.authToken),
+    };
   }
 
   const provenance: Provenance = {
     resourceType: "Provenance",
     agent: [
       {
-        who: {
-          reference: practitionerReference,
-          display: practitionerDisplay,
-        },
+        who: practitionerReference,
         onBehalfOf: { display: builderName },
       },
       {
@@ -76,7 +77,7 @@ export const createProvenance = async (
     recorded: new Date().toISOString(),
     target: [
       {
-        reference: `${resource.resourceType}/${resource.id}`,
+        reference: `${resource.resourceType}/${resource.id}/_history/${versionId}`,
         type: resource.resourceType,
       },
     ],


### PR DESCRIPTION
CTW-558

Provenance now saves which historical version of a resource resulted from an operation, for more thorough tracking of changes. It saves this information as part of the target resource reference.

[Example of a Provenance record this produces](https://fhirplace.dev.zusapi.com/#/Condition/e823c9e5-806d-4fb6-864e-c3ab5e70aa86/show/provenance)