### PR TITLE
Ctw 547 subtitles for medication filled

### DIFF
--- a/src/components/content/medication-history/index.tsx
+++ b/src/components/content/medication-history/index.tsx
@@ -149,9 +149,9 @@ function createMedicationDispenseCard(medication: MedicationModel) {
     hideEmpty: false,
     id: medication.id,
     title: "Medication Filled",
-    subTitle: compact([
+    subtitle: compact([
       quantityDisplay || null,
-      supplied ? `Supplied for ${supplied}` : null,
+      supplied ? `${supplied} supplied` : null,
     ]).join(", "),
     data: [
       { label: "Quantity", value: quantityDisplay },

--- a/src/components/content/medication-history/index.tsx
+++ b/src/components/content/medication-history/index.tsx
@@ -1,3 +1,4 @@
+import { capitalize, compact } from "lodash";
 import { CollapsibleDataListProps } from "@/components/core/collapsible-data-list";
 import { CollapsibleDataListStack } from "@/components/core/collapsible-data-list-stack";
 import { Loading } from "@/components/core/loading";
@@ -5,7 +6,6 @@ import { useMedicationHistory } from "@/fhir/medications";
 import { MedicationModel } from "@/fhir/models/medication";
 import { MedicationDispenseModel } from "@/fhir/models/medication-dispense";
 import { MedicationStatementModel } from "@/fhir/models/medication-statement";
-import { capitalize } from "lodash";
 import { useEffect, useState } from "react";
 
 const MEDICATION_HISTORY_LIMIT = 10;
@@ -142,11 +142,16 @@ function createMedicationDispenseCard(medication: MedicationModel) {
 
   const { quantityDisplay, supplied, performerDetails } = medDispense;
   const { name, address, telecom } = performerDetails;
+
   return {
     date: medication.dateLocal,
     hideEmpty: false,
     id: medication.id,
     title: "Medication Filled",
+    subTitle: compact([
+      quantityDisplay || null,
+      supplied ? `Supplied for ${supplied}`: null
+    ]).join(", "),
     data: [
       { label: "Quantity", value: quantityDisplay },
       {

--- a/src/fhir/models/medication-dispense.ts
+++ b/src/fhir/models/medication-dispense.ts
@@ -40,6 +40,9 @@ export class MedicationDispenseModel extends FHIRModel<fhir4.MedicationDispense>
 
   get quantityDisplay() {
     const { value, unit } = this.resource.quantity || {};
+    if (value && !unit) {
+      return `${value} units`;
+    }
     return compact([value, unit]).join(" ");
   }
 


### PR DESCRIPTION
sometimes it will only have "x days supplied"
<img width="557" alt="Screen Shot 2022-11-22 at 2 59 11 PM" src="https://user-images.githubusercontent.com/6380075/203409628-114053d5-425e-4a1f-8767-e7431802c779.png">

but wherever possible, it will have units and days supplied
<img width="557" alt="Screen Shot 2022-11-22 at 3 00 15 PM" src="https://user-images.githubusercontent.com/6380075/203409812-b7d01a32-5ea1-4ae5-8a32-eb2a342b3cc8.png">

Where the quantity is
```
{ value: 10, unit: undefined }
```
we would show "10 units" because we can't say "tablets", "pills", ect.