### PR TITLE
Medication Request more resilient pharmacy data

### DIFF
--- a/src/components/content/medication-history/index.tsx
+++ b/src/components/content/medication-history/index.tsx
@@ -8,6 +8,7 @@ import { MedicationStatementModel } from "@/fhir/models/medication-statement";
 import { capitalize, compact } from "lodash";
 import { useEffect, useState } from "react";
 import { MedicationAdministrationModel } from "@/fhir/models/medication-administration";
+import { MedicationRequestModel } from "@/fhir/models/medication-request";
 
 const MEDICATION_HISTORY_LIMIT = 10;
 
@@ -103,8 +104,10 @@ function createMedicationDetailsCard(
 function createMedicationRequestCard(medication: MedicationModel) {
   const resource = medication.resource as fhir4.MedicationRequest;
   const { prescriber } = medication;
-  const pharmacy = resource.dispenseRequest?.performer?.display || "";
-
+  const { name, address, telecom } = new MedicationRequestModel(
+    resource,
+    medication.includedResources
+  ).pharmacy;
   const { numberOfRepeatsAllowed = "", initialFill } =
     resource.dispenseRequest || {};
   const { value = "", unit = "" } = initialFill?.quantity || {};
@@ -128,7 +131,13 @@ function createMedicationRequestCard(medication: MedicationModel) {
       { label: "Prescriber", value: prescriber },
       {
         label: "Pharmacy",
-        value: pharmacy,
+        value: (
+          <>
+            {name && <div>{name}</div>}
+            {address && <div>{address}</div>}
+            {telecom && <div>T: {telecom}</div>}
+          </>
+        ),
       },
     ],
   };

--- a/src/fhir/models/medication-request.ts
+++ b/src/fhir/models/medication-request.ts
@@ -1,9 +1,10 @@
 import { FHIRModel } from "./fhir-model";
 import { findReference } from "@/fhir/resource-helper";
 import { PractitionerModel } from "@/fhir/models/practitioner";
+import { compact } from "lodash/fp";
 
 export class MedicationRequestModel extends FHIRModel<fhir4.MedicationRequest> {
-  get includedRequester(): string | undefined {
+  get includedRequester() {
     const reference = this.resource.requester?.reference;
 
     const practitioner = findReference(
@@ -17,5 +18,36 @@ export class MedicationRequestModel extends FHIRModel<fhir4.MedicationRequest> {
       return new PractitionerModel(practitioner).fullName;
     }
     return this.resource.requester?.display;
+  }
+
+  get pharmacy() {
+    const { reference, display } =
+      this.resource.dispenseRequest?.performer || {};
+    const organization = findReference(
+      "Organization",
+      this.resource.contained,
+      this.includedResources,
+      reference
+    );
+    if (organization) {
+      const telecom = organization.telecom?.[0].value;
+      const {
+        city,
+        state,
+        postalCode,
+        text,
+        line = [],
+      } = organization.address?.[0] || {};
+      const cityStatePostal = compact([city, `${state} ${postalCode}`]).join(
+        ", "
+      );
+
+      return {
+        telecom,
+        name: organization.name,
+        address: text ?? compact([line, cityStatePostal]).join("\n"),
+      };
+    }
+    return { name: display };
   }
 }


### PR DESCRIPTION
Prescriber and Pharmacy are both missing in several Prescription Ordered cards.

The prescriber was handled in https://zeushealth.atlassian.net/browse/CTW-546

This PR looks up the pharmacy and tries to resolve it in a contained or included resource in the MedicationRequests, then falling back to display text (as it originally was doing).

<img width="575" alt="Screen Shot 2022-11-23 at 3 08 52 PM" src="https://user-images.githubusercontent.com/6380075/203637410-5b3aa310-61bd-40ac-bc3d-3f693142f685.png">
