### PR TITLE
CTW-565/Medication Review (MedicationStatement) date fallback

### DIFF
--- a/src/fhir/models/medication.ts
+++ b/src/fhir/models/medication.ts
@@ -40,7 +40,9 @@ export class MedicationModel extends FHIRModel<Medication> {
   get date(): string | undefined {
     switch (this.resource.resourceType) {
       case "MedicationStatement":
-        return this.resource.dateAsserted;
+        return (
+          this.resource.dateAsserted ?? this.resource.effectivePeriod?.start
+        );
       case "MedicationAdministration":
         return this.resource.effectivePeriod?.start;
       case "MedicationDispense":


### PR DESCRIPTION
In the medication history panel, we should be displaying `MedicationStatement.dateAsserted` if available. When it isn’t available - which is not often - we should fall back to `MedicationStatement.effectivePeriod.start`.

---
Example of a broken card
<img width="575" alt="Screen Shot 2022-11-23 at 3 33 14 PM" src="https://user-images.githubusercontent.com/6380075/203641167-30bc2371-793a-4396-91cb-9ba364308e77.png">

Looking at the underlying resource, it has a date under `MedicationStatement.effectivePeriod.start`
