### PR TITLE
CTW Don't Show Chevron on Hover for Unsorted Column

### DIFF
--- a/.changeset/slow-games-drive.md
+++ b/.changeset/slow-games-drive.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Do not show the sorting chevron on hover if a column is unsortable.

--- a/src/components/core/table/table-head.tsx
+++ b/src/components/core/table/table-head.tsx
@@ -57,11 +57,13 @@ export const TableHead = <T extends MinRecordItem>({
         >
           <div className="ctw-flex ctw-items-center ctw-space-x-2">
             <div>{column.title}</div>
-            <SortChevron
-              sortOrder={
-                sort?.columnTitle === column.title ? sort?.dir : undefined
-              }
-            />
+            {(column.sortFnOverride || column.sortIndex) && (
+              <SortChevron
+                sortOrder={
+                  sort?.columnTitle === column.title ? sort?.dir : undefined
+                }
+              />
+            )}
           </div>
         </th>
       ))}


### PR DESCRIPTION
Patch for [CTW-336](https://zeushealth.atlassian.net/browse/CTW-336)
No longer shoes the sorting chevron on hover for unsortable columns.