### PR TITLE
eslint imports with default sorting of groups

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -34,7 +34,25 @@ module.exports = {
     "import/order": [
       "error",
       {
-        groups: ["builtin", "external", "parent", "sibling", "index"],
+        alphabetize: {
+          caseInsensitive: true,
+          order: "asc",
+        },
+        groups: [
+          ["builtin", "external", "object", "type"],
+          ["internal", "parent", "sibling", "index"],
+        ],
+        "newlines-between": "never",
+      },
+    ],
+    "sort-imports": [
+      "error",
+      {
+        allowSeparatedGroups: true,
+        ignoreCase: true,
+        ignoreDeclarationSort: true,
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: ["none", "all", "multiple", "single"],
       },
     ],
     "import/no-unresolved": "off",

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -31,7 +31,12 @@ module.exports = {
     "no-void": ["error", { allowAsStatement: true }],
     curly: "error",
     "import/extensions": "off",
-    "import/order": "off",
+    "import/order": [
+      "error",
+      {
+        groups: ["builtin", "external", "parent", "sibling", "index"],
+      },
+    ],
     "import/no-unresolved": "off",
     "import/prefer-default-export": "off",
     "import/no-extraneous-dependencies": [

--- a/src/api/patient-history.ts
+++ b/src/api/patient-history.ts
@@ -1,5 +1,5 @@
-import { CTWRequestContext } from "@/components/core/ctw-context";
 import { getZusApiBaseUrl } from "./urls";
+import { CTWRequestContext } from "@/components/core/ctw-context";
 
 export type PatientHistoryResponseError = {
   // TODO: Can code be a list of status codes? Do we have that type defined anywhere.

--- a/src/components/content/conditions-helper.ts
+++ b/src/components/content/conditions-helper.ts
@@ -1,10 +1,10 @@
+import { FhirResource } from "fhir-kit-client";
+import { cloneDeep } from "lodash";
+import { CTWRequestContext } from "../core/ctw-context";
 import { createOrEditFhirResource } from "@/fhir/action-helper";
 import { SYSTEM_CONDITION_VERIFICATION_STATUS } from "@/fhir/system-urls";
 import { QUERY_KEY_PATIENT_CONDITIONS } from "@/utils/query-keys";
 import { queryClient } from "@/utils/request";
-import { FhirResource } from "fhir-kit-client";
-import { cloneDeep } from "lodash";
-import { CTWRequestContext } from "../core/ctw-context";
 
 export const onConditionDelete = async (
   resource: fhir4.Condition,

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -1,7 +1,3 @@
-import { Loading } from "@/components/core/loading";
-import { getIncludedResources } from "@/fhir/bundle";
-import { useConditionHistory } from "@/fhir/conditions";
-import { ConditionModel } from "@/fhir/models/condition";
 import { capitalize, isEqual, orderBy, startCase, uniqWith } from "lodash";
 import { useEffect, useState } from "react";
 import { CodingList } from "../core/coding-list";
@@ -13,6 +9,10 @@ import {
 } from "../core/collapsible-data-list-stack";
 import { NotesList } from "../core/notes-list";
 import { ConditionHeader } from "./condition-header";
+import { ConditionModel } from "@/fhir/models/condition";
+import { useConditionHistory } from "@/fhir/conditions";
+import { getIncludedResources } from "@/fhir/bundle";
+import { Loading } from "@/components/core/loading";
 
 const CONDITION_HISTORY_LIMIT = 10;
 

--- a/src/components/content/conditions-history.tsx
+++ b/src/components/content/conditions-history.tsx
@@ -9,10 +9,10 @@ import {
 } from "../core/collapsible-data-list-stack";
 import { NotesList } from "../core/notes-list";
 import { ConditionHeader } from "./condition-header";
-import { ConditionModel } from "@/fhir/models/condition";
-import { useConditionHistory } from "@/fhir/conditions";
-import { getIncludedResources } from "@/fhir/bundle";
 import { Loading } from "@/components/core/loading";
+import { getIncludedResources } from "@/fhir/bundle";
+import { useConditionHistory } from "@/fhir/conditions";
+import { ConditionModel } from "@/fhir/models/condition";
 
 const CONDITION_HISTORY_LIMIT = 10;
 

--- a/src/components/content/conditions-table-base.tsx
+++ b/src/components/content/conditions-table-base.tsx
@@ -1,9 +1,9 @@
-import { ConditionModel } from "@/fhir/models/condition";
-import { alphaSortBlankLast } from "@/utils/sort";
 import { DotsHorizontalIcon } from "@heroicons/react/outline";
 import { DropdownMenu, MenuItems } from "../core/dropdown-menu";
 import { Table, TableBaseProps } from "../core/table/table";
 import { TableColumn } from "../core/table/table-helpers";
+import { alphaSortBlankLast } from "@/utils/sort";
+import { ConditionModel } from "@/fhir/models/condition";
 
 export type ConditionsTableBaseProps = {
   className?: string;

--- a/src/components/content/conditions-table-base.tsx
+++ b/src/components/content/conditions-table-base.tsx
@@ -2,8 +2,8 @@ import { DotsHorizontalIcon } from "@heroicons/react/outline";
 import { DropdownMenu, MenuItems } from "../core/dropdown-menu";
 import { Table, TableBaseProps } from "../core/table/table";
 import { TableColumn } from "../core/table/table-helpers";
-import { alphaSortBlankLast } from "@/utils/sort";
 import { ConditionModel } from "@/fhir/models/condition";
+import { alphaSortBlankLast } from "@/utils/sort";
 
 export type ConditionsTableBaseProps = {
   className?: string;

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -26,10 +26,6 @@ import {
 import { editPatientAndScheduleHistory } from "./forms/patients";
 import { PatientHistoryRequestDrawer } from "./patient-history-request-drawer";
 import { PatientHistoryMessage } from "./patient-history/patient-history-message";
-import { AnyZodSchema } from "@/utils/form-helper";
-import { hasFetchedPatientHistory } from "@/services/patient-history/patient-history";
-import { useBreakpoints } from "@/hooks/use-breakpoints";
-import { ConditionModel } from "@/fhir/models/condition";
 import {
   conditionAddSchema,
   conditionEditSchema,
@@ -40,6 +36,10 @@ import {
   useOtherProviderConditions,
   usePatientConditions,
 } from "@/fhir/conditions";
+import { ConditionModel } from "@/fhir/models/condition";
+import { useBreakpoints } from "@/hooks/use-breakpoints";
+import { hasFetchedPatientHistory } from "@/services/patient-history/patient-history";
+import { AnyZodSchema } from "@/utils/form-helper";
 
 export type ConditionsProps = {
   className?: string;

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -1,16 +1,3 @@
-import {
-  conditionAddSchema,
-  conditionEditSchema,
-  getEditingPatientConditionData,
-} from "@/components/content/forms/condition-schema";
-import {
-  getNewCondition,
-  useOtherProviderConditions,
-  usePatientConditions,
-} from "@/fhir/conditions";
-import { ConditionModel } from "@/fhir/models/condition";
-import { useBreakpoints } from "@/hooks/use-breakpoints";
-import { AnyZodSchema } from "@/utils/form-helper";
 import cx from "classnames";
 import { curry } from "lodash";
 import { useEffect, useRef, useState } from "react";
@@ -38,6 +25,19 @@ import {
 } from "./forms/conditions";
 import { editPatientAndScheduleHistory } from "./forms/patients";
 import { PatientHistoryRequestDrawer } from "./patient-history-request-drawer";
+import {
+  conditionAddSchema,
+  conditionEditSchema,
+  getEditingPatientConditionData,
+} from "@/components/content/forms/condition-schema";
+import {
+  getNewCondition,
+  useOtherProviderConditions,
+  usePatientConditions,
+} from "@/fhir/conditions";
+import { ConditionModel } from "@/fhir/models/condition";
+import { AnyZodSchema } from "@/utils/form-helper";
+import { useBreakpoints } from "@/hooks/use-breakpoints";
 
 export type ConditionsProps = {
   className?: string;

--- a/src/components/content/conditions/conditions.stories.tsx
+++ b/src/components/content/conditions/conditions.stories.tsx
@@ -8,9 +8,9 @@ import { emptyConditions } from "./story-helpers/mocks/empty-conditions";
 import { otherConditions } from "./story-helpers/mocks/other-conditions";
 import { patientConditions } from "./story-helpers/mocks/patient-conditions";
 import { setupConditionMocks } from "./story-helpers/mocks/requests";
-import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
-import { PatientProvider } from "@/components/core/patient-provider";
 import { CTWProvider } from "@/components/core/ctw-provider";
+import { PatientProvider } from "@/components/core/patient-provider";
+import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
 
 type Props = ConditionsProps;
 

--- a/src/components/content/conditions/conditions.stories.tsx
+++ b/src/components/content/conditions/conditions.stories.tsx
@@ -1,6 +1,3 @@
-import { CTWProvider } from "@/components/core/ctw-provider";
-import { PatientProvider } from "@/components/core/patient-provider";
-import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
 import { expect } from "@storybook/jest";
 import type { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
@@ -11,6 +8,9 @@ import { emptyConditions } from "./story-helpers/mocks/empty-conditions";
 import { otherConditions } from "./story-helpers/mocks/other-conditions";
 import { patientConditions } from "./story-helpers/mocks/patient-conditions";
 import { setupConditionMocks } from "./story-helpers/mocks/requests";
+import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
+import { PatientProvider } from "@/components/core/patient-provider";
+import { CTWProvider } from "@/components/core/ctw-provider";
 
 type Props = ConditionsProps;
 

--- a/src/components/content/conditions/helpers.test.ts
+++ b/src/components/content/conditions/helpers.test.ts
@@ -1,9 +1,9 @@
+import { filterOtherConditions } from "./helpers";
 import { ConditionModel } from "@/fhir/models";
 import {
   SYSTEM_CONDITION_VERIFICATION_STATUS,
   SYSTEM_SNOMED,
 } from "@/fhir/system-urls";
-import { filterOtherConditions } from "./helpers";
 
 describe("Condition Helpers", () => {
   describe("filterOtherConditions", () => {

--- a/src/components/content/conditions/story-helpers/mocks/requests.ts
+++ b/src/components/content/conditions/story-helpers/mocks/requests.ts
@@ -1,4 +1,3 @@
-import { SYSTEM_SUMMARY } from "@/fhir/system-urls";
 import { cloneDeep } from "lodash";
 import { rest } from "msw";
 import { ComponentType, createElement } from "react";
@@ -10,6 +9,7 @@ import { historyGeneralizedAnxiety } from "./history-generalized-anxiety";
 import { historyIronDeficiency } from "./history-iron-deficiency";
 import { historyOralContraception } from "./history-oral-contraception";
 import { patient } from "./patient";
+import { SYSTEM_SUMMARY } from "@/fhir/system-urls";
 
 let patientConditionsCache: fhir4.Bundle;
 let otherConditionsCache: fhir4.Bundle;

--- a/src/components/content/forms/condition-schema.tsx
+++ b/src/components/content/forms/condition-schema.tsx
@@ -1,7 +1,7 @@
-import { ConditionModel } from "@/fhir/models/condition";
 import Zod, { RefinementCtx, z } from "zod";
 import type { FormEntry } from "../../core/form/drawer-form-with-fields";
 import { ConditionsAutoComplete } from "./conditions-autocomplete";
+import { ConditionModel } from "@/fhir/models/condition";
 
 export const getAddConditionData = ({
   condition,

--- a/src/components/content/forms/condition-schema.tsx
+++ b/src/components/content/forms/condition-schema.tsx
@@ -1,5 +1,5 @@
-import Zod, { RefinementCtx, z } from "zod";
 import type { FormEntry } from "../../core/form/drawer-form-with-fields";
+import Zod, { RefinementCtx, z } from "zod";
 import { ConditionsAutoComplete } from "./conditions-autocomplete";
 import { ConditionModel } from "@/fhir/models/condition";
 

--- a/src/components/content/forms/conditions-autocomplete.tsx
+++ b/src/components/content/forms/conditions-autocomplete.tsx
@@ -1,10 +1,10 @@
-import { getAutoCompleteConditions } from "@/api/autocomplete-conditions";
-import { useCTW } from "@/components/core/ctw-provider";
 import { InputHTMLAttributes, useState } from "react";
 import {
   ComboboxField,
   ComboxboxFieldOption,
 } from "../../core/form/combobox-field";
+import { getAutoCompleteConditions } from "@/api/autocomplete-conditions";
+import { useCTW } from "@/components/core/ctw-provider";
 
 export type AutoCompleteComboboxProps = {
   defaultCoding?: fhir4.Coding;

--- a/src/components/content/forms/conditions.ts
+++ b/src/components/content/forms/conditions.ts
@@ -1,3 +1,6 @@
+import { Condition } from "fhir/r4";
+import { cloneDeep } from "lodash";
+import { ActionReturn } from "./types";
 import { CTWRequestContext } from "@/components/core/ctw-context";
 import { FormErrors } from "@/components/core/form/drawer-form";
 import { createOrEditFhirResource } from "@/fhir/action-helper";
@@ -18,9 +21,6 @@ import {
   QUERY_KEY_PATIENT_CONDITIONS,
 } from "@/utils/query-keys";
 import { queryClient } from "@/utils/request";
-import { Condition } from "fhir/r4";
-import { cloneDeep } from "lodash";
-import { ActionReturn } from "./types";
 
 // Sets any autofill values that apply when a user adds a condition, whether creating or confirming.
 export function getAddConditionWithDefaults(condition: Condition): Condition {

--- a/src/components/content/forms/form-field.tsx
+++ b/src/components/content/forms/form-field.tsx
@@ -1,8 +1,8 @@
-import { formatDateLocalToISO } from "@/fhir/formatters";
 import { ExclamationCircleIcon, LockClosedIcon } from "@heroicons/react/solid";
 import cx from "classnames";
 import { startCase } from "lodash";
 import type { InputHTMLAttributes } from "react";
+import { formatDateLocalToISO } from "@/fhir/formatters";
 
 export type FormFieldProps = {
   errors?: string[];

--- a/src/components/content/forms/medications.ts
+++ b/src/components/content/forms/medications.ts
@@ -1,3 +1,6 @@
+import { z } from "zod";
+import type { FormEntry } from "../../core/form/drawer-form-with-fields";
+import { ActionReturn, MedicationFormData } from "./types";
 import { CTWRequestContext } from "@/components/core/ctw-context";
 import { createOrEditFhirResource } from "@/fhir/action-helper";
 import { isFhirError } from "@/fhir/errors";
@@ -13,9 +16,6 @@ import {
   QUERY_KEY_PATIENT_MEDICATIONS,
 } from "@/utils/query-keys";
 import { queryClient } from "@/utils/request";
-import { z } from "zod";
-import type { FormEntry } from "../../core/form/drawer-form-with-fields";
-import { ActionReturn, MedicationFormData } from "./types";
 
 export const medicationStatementSchema = z.object({
   subjectID: z.string({ required_error: "Patient must be specified." }),

--- a/src/components/content/forms/medications.ts
+++ b/src/components/content/forms/medications.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
 import type { FormEntry } from "../../core/form/drawer-form-with-fields";
+import { z } from "zod";
 import { ActionReturn, MedicationFormData } from "./types";
 import { CTWRequestContext } from "@/components/core/ctw-context";
 import { createOrEditFhirResource } from "@/fhir/action-helper";

--- a/src/components/content/forms/request-history-schema.tsx
+++ b/src/components/content/forms/request-history-schema.tsx
@@ -1,6 +1,6 @@
+import { z } from "zod";
 import { FormEntry } from "@/components/core/form/drawer-form-with-fields";
 import { PatientModel } from "@/fhir/models";
-import { z } from "zod";
 
 export const getRequestData = (patient: PatientModel): FormEntry[] => [
   {

--- a/src/components/content/medication-drawer.tsx
+++ b/src/components/content/medication-drawer.tsx
@@ -1,12 +1,12 @@
-import { capitalize } from "lodash";
 import type { DataListEntry } from "../core/data-list";
-import { DataList, entryFromArray } from "../core/data-list";
 import type { DrawerProps } from "../core/drawer";
+import type { MedicationStatementModel } from "@/fhir/models/medication-statement";
+import { capitalize } from "lodash";
+import { DataList, entryFromArray } from "../core/data-list";
 import { Drawer } from "../core/drawer";
 import { MedicationHistory } from "./medications/medication-history";
-import type { MedicationStatementModel } from "@/fhir/models/medication-statement";
-import { useLastPrescriber } from "@/fhir/medications";
 import { Loading } from "@/components/core/loading";
+import { useLastPrescriber } from "@/fhir/medications";
 
 export type MedicationDrawerProps = {
   medication?: MedicationStatementModel;

--- a/src/components/content/medication-drawer.tsx
+++ b/src/components/content/medication-drawer.tsx
@@ -1,12 +1,12 @@
-import { Loading } from "@/components/core/loading";
-import { useLastPrescriber } from "@/fhir/medications";
-import type { MedicationStatementModel } from "@/fhir/models/medication-statement";
 import { capitalize } from "lodash";
 import type { DataListEntry } from "../core/data-list";
 import { DataList, entryFromArray } from "../core/data-list";
 import type { DrawerProps } from "../core/drawer";
 import { Drawer } from "../core/drawer";
 import { MedicationHistory } from "./medications/medication-history";
+import type { MedicationStatementModel } from "@/fhir/models/medication-statement";
+import { useLastPrescriber } from "@/fhir/medications";
+import { Loading } from "@/components/core/loading";
 
 export type MedicationDrawerProps = {
   medication?: MedicationStatementModel;

--- a/src/components/content/medications-table-base.tsx
+++ b/src/components/content/medications-table-base.tsx
@@ -1,10 +1,10 @@
+import type { MedicationStatementModel } from "@/fhir/models/medication-statement";
 import { DotsHorizontalIcon } from "@heroicons/react/outline";
 import { compact, isFunction } from "lodash/fp";
 import { ReactNode, useRef } from "react";
 import { MinRecordItem, TableColumn } from "../core/table/table-helpers";
 import { DropdownMenu, MenuItems } from "@/components/core/dropdown-menu";
 import { Table, TableBaseProps } from "@/components/core/table/table";
-import type { MedicationStatementModel } from "@/fhir/models/medication-statement";
 import { useBreakpoints } from "@/hooks/use-breakpoints";
 
 export type MedicationsTableBaseProps<T extends MinRecordItem> = {

--- a/src/components/content/medications-table-base.tsx
+++ b/src/components/content/medications-table-base.tsx
@@ -1,11 +1,11 @@
-import { DropdownMenu, MenuItems } from "@/components/core/dropdown-menu";
-import { Table, TableBaseProps } from "@/components/core/table/table";
-import type { MedicationStatementModel } from "@/fhir/models/medication-statement";
-import { useBreakpoints } from "@/hooks/use-breakpoints";
 import { DotsHorizontalIcon } from "@heroicons/react/outline";
 import { compact, isFunction } from "lodash/fp";
 import { ReactNode, useRef } from "react";
 import { MinRecordItem, TableColumn } from "../core/table/table-helpers";
+import { DropdownMenu, MenuItems } from "@/components/core/dropdown-menu";
+import { Table, TableBaseProps } from "@/components/core/table/table";
+import type { MedicationStatementModel } from "@/fhir/models/medication-statement";
+import { useBreakpoints } from "@/hooks/use-breakpoints";
 
 export type MedicationsTableBaseProps<T extends MinRecordItem> = {
   medicationStatements: MedicationStatementModel[];

--- a/src/components/content/medications/add-new-med-drawer.tsx
+++ b/src/components/content/medications/add-new-med-drawer.tsx
@@ -1,3 +1,5 @@
+import { format } from "date-fns";
+import { ReactElement } from "react";
 import {
   createMedicationStatement,
   getMedicationFormData,
@@ -6,8 +8,6 @@ import {
 import { DrawerFormWithFields } from "@/components/core/form/drawer-form-with-fields";
 import { usePatient } from "@/components/core/patient-provider";
 import { MedicationStatementModel } from "@/fhir/models/medication-statement";
-import { format } from "date-fns";
-import { ReactElement } from "react";
 
 type Props = {
   isOpen: boolean;

--- a/src/components/content/medications/medication-history.stories.tsx
+++ b/src/components/content/medications/medication-history.stories.tsx
@@ -1,14 +1,14 @@
-import { aggregatedFromMedStatement } from "@/components/content/medications/story-helpers/mocks/aggregated-from-med-statement";
-import { CTWProvider } from "@/components/core/ctw-provider";
-import { PatientProvider } from "@/components/core/patient-provider";
-import { MedicationStatementModel } from "@/fhir/models";
-import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
 import type { Meta, StoryObj } from "@storybook/react";
 import {
   MedicationHistory,
   MedicationHistoryProps,
 } from "./medication-history";
 import { setupMedicationMocks } from "./story-helpers/mocks/requests";
+import { aggregatedFromMedStatement } from "@/components/content/medications/story-helpers/mocks/aggregated-from-med-statement";
+import { CTWProvider } from "@/components/core/ctw-provider";
+import { PatientProvider } from "@/components/core/patient-provider";
+import { MedicationStatementModel } from "@/fhir/models";
+import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
 
 type Props = MedicationHistoryProps;
 

--- a/src/components/content/medications/medication-history.tsx
+++ b/src/components/content/medications/medication-history.tsx
@@ -1,4 +1,5 @@
 import { capitalize, compact } from "lodash";
+import { useEffect, useState } from "react";
 import { CollapsibleDataListProps } from "@/components/core/collapsible-data-list";
 import { CollapsibleDataListStack } from "@/components/core/collapsible-data-list-stack";
 import { Loading } from "@/components/core/loading";
@@ -6,7 +7,6 @@ import { useMedicationHistory } from "@/fhir/medications";
 import { MedicationModel } from "@/fhir/models/medication";
 import { MedicationDispenseModel } from "@/fhir/models/medication-dispense";
 import { MedicationStatementModel } from "@/fhir/models/medication-statement";
-import { useEffect, useState } from "react";
 import { MedicationAdministrationModel } from "@/fhir/models/medication-administration";
 import { MedicationRequestModel } from "@/fhir/models/medication-request";
 

--- a/src/components/content/medications/medication-history.tsx
+++ b/src/components/content/medications/medication-history.tsx
@@ -5,10 +5,10 @@ import { CollapsibleDataListStack } from "@/components/core/collapsible-data-lis
 import { Loading } from "@/components/core/loading";
 import { useMedicationHistory } from "@/fhir/medications";
 import { MedicationModel } from "@/fhir/models/medication";
-import { MedicationDispenseModel } from "@/fhir/models/medication-dispense";
-import { MedicationStatementModel } from "@/fhir/models/medication-statement";
 import { MedicationAdministrationModel } from "@/fhir/models/medication-administration";
+import { MedicationDispenseModel } from "@/fhir/models/medication-dispense";
 import { MedicationRequestModel } from "@/fhir/models/medication-request";
+import { MedicationStatementModel } from "@/fhir/models/medication-statement";
 
 const MEDICATION_HISTORY_LIMIT = 10;
 

--- a/src/components/content/medications/other-provider-meds-table.stories.tsx
+++ b/src/components/content/medications/other-provider-meds-table.stories.tsx
@@ -1,3 +1,5 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { setupMedicationMocks } from "./story-helpers/mocks/requests";
 import {
   OtherProviderMedsTable,
   OtherProviderMedsTableProps,
@@ -5,8 +7,6 @@ import {
 import { CTWProvider } from "@/components/core/ctw-provider";
 import { PatientProvider } from "@/components/core/patient-provider";
 import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
-import type { Meta, StoryObj } from "@storybook/react";
-import { setupMedicationMocks } from "./story-helpers/mocks/requests";
 
 type Props = OtherProviderMedsTableProps;
 

--- a/src/components/content/medications/other-provider-meds-table.tsx
+++ b/src/components/content/medications/other-provider-meds-table.tsx
@@ -1,10 +1,10 @@
+import { get, pipe, toLower } from "lodash/fp";
+import { useEffect, useState } from "react";
 import { MedicationDrawer } from "@/components/content/medication-drawer";
 import { MedicationsTableBase } from "@/components/content/medications-table-base";
 import { MedicationStatementModel } from "@/fhir/models/medication-statement";
 import { useQueryAllPatientMedications } from "@/hooks/use-medications";
 import { sort, SortDir } from "@/utils/sort";
-import { get, pipe, toLower } from "lodash/fp";
-import { useEffect, useState } from "react";
 
 export type OtherProviderMedsTableProps = {
   className?: string;

--- a/src/components/content/medications/patient-medications.stories.tsx
+++ b/src/components/content/medications/patient-medications.stories.tsx
@@ -1,3 +1,5 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { setupMedicationMocks } from "./story-helpers/mocks/requests";
 import {
   PatientMedications,
   PatientMedicationsProps,
@@ -5,8 +7,6 @@ import {
 import { CTWProvider } from "@/components/core/ctw-provider";
 import { PatientProvider } from "@/components/core/patient-provider";
 import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
-import type { Meta, StoryObj } from "@storybook/react";
-import { setupMedicationMocks } from "./story-helpers/mocks/requests";
 
 type Props = PatientMedicationsProps;
 

--- a/src/components/content/medications/patient-medications.tsx
+++ b/src/components/content/medications/patient-medications.tsx
@@ -1,11 +1,11 @@
+import cx from "classnames";
+import { useState } from "react";
 import { AddNewMedDrawer } from "@/components/content/medications/add-new-med-drawer";
 import { OtherProviderMedsTable } from "@/components/content/medications/other-provider-meds-table";
 import { ProviderMedsTable } from "@/components/content/medications/provider-meds-table";
 import * as CTWBox from "@/components/core/ctw-box";
 import { ToggleControl } from "@/components/core/toggle-control";
 import type { ClinicalStatus } from "@/fhir/medication";
-import cx from "classnames";
-import { useState } from "react";
 import "./patient-medications.scss";
 
 export type PatientMedicationsProps = {

--- a/src/components/content/medications/patient-medications.tsx
+++ b/src/components/content/medications/patient-medications.tsx
@@ -1,3 +1,4 @@
+import type { ClinicalStatus } from "@/fhir/medication";
 import cx from "classnames";
 import { useState } from "react";
 import { AddNewMedDrawer } from "@/components/content/medications/add-new-med-drawer";
@@ -5,7 +6,6 @@ import { OtherProviderMedsTable } from "@/components/content/medications/other-p
 import { ProviderMedsTable } from "@/components/content/medications/provider-meds-table";
 import * as CTWBox from "@/components/core/ctw-box";
 import { ToggleControl } from "@/components/core/toggle-control";
-import type { ClinicalStatus } from "@/fhir/medication";
 import "./patient-medications.scss";
 
 export type PatientMedicationsProps = {

--- a/src/components/content/medications/provider-meds-table.stories.tsx
+++ b/src/components/content/medications/provider-meds-table.stories.tsx
@@ -1,3 +1,5 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { setupMedicationMocks } from "./story-helpers/mocks/requests";
 import {
   ProviderMedsTable,
   ProviderMedsTableProps,
@@ -5,8 +7,6 @@ import {
 import { CTWProvider } from "@/components/core/ctw-provider";
 import { PatientProvider } from "@/components/core/patient-provider";
 import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
-import type { Meta, StoryObj } from "@storybook/react";
-import { setupMedicationMocks } from "./story-helpers/mocks/requests";
 
 type Props = ProviderMedsTableProps;
 

--- a/src/components/content/medications/provider-meds-table.tsx
+++ b/src/components/content/medications/provider-meds-table.tsx
@@ -1,10 +1,10 @@
+import { get, pipe, toLower } from "lodash/fp";
+import { useEffect, useState } from "react";
 import { MedicationDrawer } from "@/components/content/medication-drawer";
 import { MedicationsTableBase } from "@/components/content/medications-table-base";
 import { MedicationStatementModel } from "@/fhir/models/medication-statement";
 import { useQueryAllPatientMedications } from "@/hooks/use-medications";
 import { sort, SortDir } from "@/utils/sort";
-import { get, pipe, toLower } from "lodash/fp";
-import { useEffect, useState } from "react";
 
 export type ProviderMedsTableProps = {
   className?: string;

--- a/src/components/content/patient-history-request-drawer.tsx
+++ b/src/components/content/patient-history-request-drawer.tsx
@@ -1,4 +1,3 @@
-import { PatientModel } from "@/fhir/models";
 import {
   DrawerFormWithFields,
   DrawerFormWithFieldsProps,
@@ -7,6 +6,7 @@ import {
   getRequestData,
   requestHistorySchema,
 } from "./forms/request-history-schema";
+import { PatientModel } from "@/fhir/models";
 
 type PatientHistoryRequestDrawer<T> = Pick<
   DrawerFormWithFieldsProps<T>,

--- a/src/components/core/action-list/action-list.stories.tsx
+++ b/src/components/core/action-list/action-list.stories.tsx
@@ -1,9 +1,9 @@
+import type { Meta, StoryObj } from "@storybook/react";
 import {
   ActionList,
   ActionListProps,
   MinActionItem,
 } from "@/components/core/action-list/action-list";
-import type { Meta, StoryObj } from "@storybook/react";
 
 type Props = ActionListProps<MinActionItem>;
 

--- a/src/components/core/collapsible-data-list-details.tsx
+++ b/src/components/core/collapsible-data-list-details.tsx
@@ -1,5 +1,5 @@
-import { PencilIcon } from "@heroicons/react/solid";
 import type { CollapsibleDataListEntry } from "./collapsible-data-list";
+import { PencilIcon } from "@heroicons/react/solid";
 
 type DetailsProps = {
   hideEmpty?: boolean;

--- a/src/components/core/collapsible-data-list.tsx
+++ b/src/components/core/collapsible-data-list.tsx
@@ -1,5 +1,4 @@
 import { ChevronRightIcon } from "@heroicons/react/outline";
-
 import cx from "classnames";
 import { ReactNode, useState } from "react";
 import { Details } from "./collapsible-data-list-details";

--- a/src/components/core/ctw-context.tsx
+++ b/src/components/core/ctw-context.tsx
@@ -1,6 +1,6 @@
+import type { Env } from "./ctw-provider";
 import Client from "fhir-kit-client";
 import { createContext, RefObject } from "react";
-import type { Env } from "./ctw-provider";
 import { Theme } from "@/styles/tailwind.theme";
 
 export type CTWToken = {

--- a/src/components/core/ctw-context.tsx
+++ b/src/components/core/ctw-context.tsx
@@ -1,7 +1,7 @@
-import { Theme } from "@/styles/tailwind.theme";
 import Client from "fhir-kit-client";
 import { createContext, RefObject } from "react";
 import type { Env } from "./ctw-provider";
+import { Theme } from "@/styles/tailwind.theme";
 
 export type CTWToken = {
   accessToken: string;

--- a/src/components/core/ctw-provider.tsx
+++ b/src/components/core/ctw-provider.tsx
@@ -1,12 +1,3 @@
-import { getFhirClient } from "@/fhir/client";
-import {
-  DefaultTheme,
-  EmptyTailwindCSSVars,
-  mapToCSSVar,
-  Theme,
-} from "@/styles/tailwind.theme";
-import { claimsBuilderId } from "@/utils/auth";
-import { queryClient } from "@/utils/request";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { merge } from "lodash";
 import {
@@ -25,6 +16,15 @@ import {
   CTWStateContext,
   CTWToken,
 } from "./ctw-context";
+import { queryClient } from "@/utils/request";
+import { claimsBuilderId } from "@/utils/auth";
+import {
+  DefaultTheme,
+  EmptyTailwindCSSVars,
+  mapToCSSVar,
+  Theme,
+} from "@/styles/tailwind.theme";
+import { getFhirClient } from "@/fhir/client";
 import "./main.scss";
 
 export type Env = "dev" | "sandbox" | "production";

--- a/src/components/core/ctw-provider.tsx
+++ b/src/components/core/ctw-provider.tsx
@@ -16,15 +16,15 @@ import {
   CTWStateContext,
   CTWToken,
 } from "./ctw-context";
-import { queryClient } from "@/utils/request";
-import { claimsBuilderId } from "@/utils/auth";
+import { getFhirClient } from "@/fhir/client";
 import {
   DefaultTheme,
   EmptyTailwindCSSVars,
   mapToCSSVar,
   Theme,
 } from "@/styles/tailwind.theme";
-import { getFhirClient } from "@/fhir/client";
+import { claimsBuilderId } from "@/utils/auth";
+import { queryClient } from "@/utils/request";
 import "./main.scss";
 
 export type Env = "dev" | "sandbox" | "production";

--- a/src/components/core/data-list-table.tsx
+++ b/src/components/core/data-list-table.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
 import type { DataListEntry } from "./data-list";
+import { useState } from "react";
 
 export type DataListStackEntry = { id: string; data: DataListEntry[] };
 export type DataListStackEntries = DataListStackEntry[];

--- a/src/components/core/data-list.stories.tsx
+++ b/src/components/core/data-list.stories.tsx
@@ -1,5 +1,5 @@
-import { DataList, DataListProps } from "@/components/core/data-list";
 import type { Meta, StoryObj } from "@storybook/react";
+import { DataList, DataListProps } from "@/components/core/data-list";
 
 export default {
   component: DataList,

--- a/src/components/core/drawer.stories.tsx
+++ b/src/components/core/drawer.stories.tsx
@@ -1,8 +1,8 @@
-import { Drawer, DrawerProps } from "@/components/core/drawer";
 import { expect } from "@storybook/jest";
 import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import { useState } from "react";
+import { Drawer, DrawerProps } from "@/components/core/drawer";
 
 export default {
   component: Drawer,

--- a/src/components/core/form/combobox-field.tsx
+++ b/src/components/core/form/combobox-field.tsx
@@ -1,7 +1,7 @@
-import { isMouseEvent } from "@/utils/types";
 import { Combobox } from "@headlessui/react";
 import { debounce, isEmpty, isObject } from "lodash";
 import { ChangeEvent, useMemo, useState } from "react";
+import { isMouseEvent } from "@/utils/types";
 
 export type ComboxboxFieldOption = { value: unknown; label: string };
 

--- a/src/components/core/form/drawer-form-with-fields.tsx
+++ b/src/components/core/form/drawer-form-with-fields.tsx
@@ -1,7 +1,7 @@
-import { FormField } from "@/components/content/forms/form-field";
-import { AnyZodSchema, useFormInputProps } from "@/utils/form-helper";
 import { InputHTMLAttributes, ReactNode } from "react";
 import { DrawerForm, DrawerFormProps } from "./drawer-form";
+import { FormField } from "@/components/content/forms/form-field";
+import { AnyZodSchema, useFormInputProps } from "@/utils/form-helper";
 
 export type FormFieldType = {
   label: string;

--- a/src/components/core/form/drawer-form.tsx
+++ b/src/components/core/form/drawer-form.tsx
@@ -1,12 +1,12 @@
+import { isEmpty } from "lodash";
+import { ReactNode, useState } from "react";
+import { Drawer, DrawerProps } from "../drawer";
 import { SaveButton } from "@/components/content/forms/save-button";
 import { ActionReturn } from "@/components/content/forms/types";
 import { ErrorAlert } from "@/components/core/alert";
 import { CTWRequestContext } from "@/components/core/ctw-context";
 import { useCTW } from "@/components/core/ctw-provider";
 import { AnyZodSchema } from "@/utils/form-helper";
-import { isEmpty } from "lodash";
-import { ReactNode, useState } from "react";
-import { Drawer, DrawerProps } from "../drawer";
 
 export type FormErrors = Record<string, string[]>;
 type InputError = Record<string, string[]>;

--- a/src/components/core/patient-provider.tsx
+++ b/src/components/core/patient-provider.tsx
@@ -1,12 +1,12 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { createContext, ReactNode, useContext, useMemo } from "react";
+import { CTWRequestContext } from "./ctw-context";
+import { useCTW } from "./ctw-provider";
 import { PatientModel } from "@/fhir/models/patient";
 import { getBuilderFhirPatient } from "@/fhir/patient-helper";
 import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
 import { Tag } from "@/fhir/types";
 import { QUERY_KEY_PATIENT } from "@/utils/query-keys";
-import { useQuery, UseQueryResult } from "@tanstack/react-query";
-import { createContext, ReactNode, useContext, useMemo } from "react";
-import { CTWRequestContext } from "./ctw-context";
-import { useCTW } from "./ctw-provider";
 
 // Cache patient for 5 minutes.
 const PATIENT_STALE_TIME = 1000 * 60 * 5;

--- a/src/components/core/spinner.stories.tsx
+++ b/src/components/core/spinner.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react";
-
 import { Spinner, SpinnerProps } from "@/components/core/spinner";
 
 export default {

--- a/src/components/core/table/table-head.tsx
+++ b/src/components/core/table/table-head.tsx
@@ -1,7 +1,7 @@
-import { SortDir } from "@/utils/sort";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/outline";
 import cx from "classnames";
 import { MinRecordItem, TableColumn, TableSort } from "./table-helpers";
+import { SortDir } from "@/utils/sort";
 
 type SortChevronProps = {
   sortOrder?: SortDir;

--- a/src/components/core/table/table-helpers.tsx
+++ b/src/components/core/table/table-helpers.tsx
@@ -1,5 +1,5 @@
-import { alphaSortBlankLast, SortDir } from "@/utils/sort";
 import { ReactNode } from "react";
+import { alphaSortBlankLast, SortDir } from "@/utils/sort";
 
 export interface MinRecordItem {
   id: string | number;

--- a/src/components/core/toggle-control.tsx
+++ b/src/components/core/toggle-control.tsx
@@ -1,5 +1,4 @@
 import { FormEvent } from "react";
-
 import { Toggle, ToggleProps } from "./toggle";
 
 export type ToggleControlProps = {

--- a/src/fhir/action-helper.ts
+++ b/src/fhir/action-helper.ts
@@ -1,8 +1,8 @@
-import { CTWRequestContext } from "@/components/core/ctw-context";
 import { Resource } from "fhir/r4";
 import { omitEmptyArrays } from "./client";
 import { isFhirError } from "./errors";
 import { createProvenance } from "./provenance";
+import { CTWRequestContext } from "@/components/core/ctw-context";
 
 export async function createOrEditFhirResource(
   resource: Resource,

--- a/src/fhir/bundle.ts
+++ b/src/fhir/bundle.ts
@@ -1,7 +1,6 @@
 import type { ResourceMap, ResourceType, ResourceTypeString } from "./types";
 import type { FhirResource } from "fhir-kit-client";
 
-
 export const isBundle = (resource: fhir4.Resource): resource is fhir4.Bundle =>
   resource.resourceType === "Bundle";
 

--- a/src/fhir/bundle.ts
+++ b/src/fhir/bundle.ts
@@ -1,6 +1,6 @@
+import type { ResourceMap, ResourceType, ResourceTypeString } from "./types";
 import type { FhirResource } from "fhir-kit-client";
 
-import type { ResourceMap, ResourceType, ResourceTypeString } from "./types";
 
 export const isBundle = (resource: fhir4.Resource): resource is fhir4.Bundle =>
   resource.resourceType === "Bundle";

--- a/src/fhir/client.ts
+++ b/src/fhir/client.ts
@@ -1,5 +1,4 @@
 import Client from "fhir-kit-client";
-
 import { Env } from "@/components/core/ctw-provider";
 
 export function getFhirClient(

--- a/src/fhir/conditions.ts
+++ b/src/fhir/conditions.ts
@@ -14,15 +14,15 @@ import {
   SYSTEM_ICD9_CM,
   SYSTEM_SNOMED,
 } from "./system-urls";
+import { getAddConditionWithDefaults } from "@/components/content/forms/conditions";
+import { CTWRequestContext } from "@/components/core/ctw-context";
+import { useQueryWithPatient } from "@/components/core/patient-provider";
+import { ConditionModel } from "@/fhir/models/condition";
 import {
   QUERY_KEY_CONDITION_HISTORY,
   QUERY_KEY_OTHER_PROVIDER_CONDITIONS,
   QUERY_KEY_PATIENT_CONDITIONS,
 } from "@/utils/query-keys";
-import { ConditionModel } from "@/fhir/models/condition";
-import { useQueryWithPatient } from "@/components/core/patient-provider";
-import { CTWRequestContext } from "@/components/core/ctw-context";
-import { getAddConditionWithDefaults } from "@/components/content/forms/conditions";
 
 export const CONDITION_CODE_PREFERENCE_ORDER: CodePreference[] = [
   { system: SYSTEM_SNOMED, checkForEnrichment: true },

--- a/src/fhir/conditions.ts
+++ b/src/fhir/conditions.ts
@@ -1,12 +1,3 @@
-import { getAddConditionWithDefaults } from "@/components/content/forms/conditions";
-import { CTWRequestContext } from "@/components/core/ctw-context";
-import { useQueryWithPatient } from "@/components/core/patient-provider";
-import { ConditionModel } from "@/fhir/models/condition";
-import {
-  QUERY_KEY_CONDITION_HISTORY,
-  QUERY_KEY_OTHER_PROVIDER_CONDITIONS,
-  QUERY_KEY_PATIENT_CONDITIONS,
-} from "@/utils/query-keys";
 import { SearchParams } from "fhir-kit-client";
 import { orderBy } from "lodash";
 import { CodePreference } from "./codeable-concept";
@@ -23,6 +14,15 @@ import {
   SYSTEM_ICD9_CM,
   SYSTEM_SNOMED,
 } from "./system-urls";
+import {
+  QUERY_KEY_CONDITION_HISTORY,
+  QUERY_KEY_OTHER_PROVIDER_CONDITIONS,
+  QUERY_KEY_PATIENT_CONDITIONS,
+} from "@/utils/query-keys";
+import { ConditionModel } from "@/fhir/models/condition";
+import { useQueryWithPatient } from "@/components/core/patient-provider";
+import { CTWRequestContext } from "@/components/core/ctw-context";
+import { getAddConditionWithDefaults } from "@/components/content/forms/conditions";
 
 export const CONDITION_CODE_PREFERENCE_ORDER: CodePreference[] = [
   { system: SYSTEM_SNOMED, checkForEnrichment: true },

--- a/src/fhir/errors.ts
+++ b/src/fhir/errors.ts
@@ -1,5 +1,5 @@
-import { OperationOutcomeModel } from "@/fhir/models/operation-outcome";
 import { isOperationOutcome } from "./operation-outcome";
+import { OperationOutcomeModel } from "@/fhir/models/operation-outcome";
 
 export type FhirError = {
   response: {

--- a/src/fhir/medication.ts
+++ b/src/fhir/medication.ts
@@ -1,7 +1,7 @@
+import type { ResourceMap } from "./types";
 import { get, sortBy } from "lodash";
 import { findReference } from "./resource-helper";
 import { SYSTEM_ENRICHMENT, SYSTEM_RXNORM } from "./system-urls";
-import type { ResourceMap } from "./types";
 
 export type Medication =
   | fhir4.MedicationStatement

--- a/src/fhir/medications.ts
+++ b/src/fhir/medications.ts
@@ -1,11 +1,3 @@
-import { CTWRequestContext } from "@/components/core/ctw-context";
-import { useQueryWithPatient } from "@/components/core/patient-provider";
-import { MedicationModel } from "@/fhir/models/medication";
-import { MedicationStatementModel } from "@/fhir/models/medication-statement";
-import { PatientModel } from "@/fhir/models/patient";
-import { errorResponse } from "@/utils/errors";
-import { QUERY_KEY_MEDICATION_HISTORY } from "@/utils/query-keys";
-import { sort } from "@/utils/sort";
 import type { FhirResource, MedicationStatement } from "fhir/r4";
 import { uniqWith } from "lodash";
 import {
@@ -32,6 +24,14 @@ import {
   SearchReturn,
 } from "./search-helpers";
 import { ResourceMap, ResourceTypeString } from "./types";
+import { CTWRequestContext } from "@/components/core/ctw-context";
+import { useQueryWithPatient } from "@/components/core/patient-provider";
+import { MedicationModel } from "@/fhir/models/medication";
+import { MedicationStatementModel } from "@/fhir/models/medication-statement";
+import { PatientModel } from "@/fhir/models/patient";
+import { errorResponse } from "@/utils/errors";
+import { QUERY_KEY_MEDICATION_HISTORY } from "@/utils/query-keys";
+import { sort } from "@/utils/sort";
 
 export type InformationSource =
   | "Patient"

--- a/src/fhir/models/condition.ts
+++ b/src/fhir/models/condition.ts
@@ -1,16 +1,16 @@
+import { compact, intersectionWith, uniqWith } from "lodash";
+import { formatDateISOToLocal, formatStringToDate } from "../formatters";
+import { SYSTEM_CCS, SYSTEM_ICD10, SYSTEM_SNOMED } from "../system-urls";
+import { FHIRModel } from "./fhir-model";
+import { PatientModel } from "./patient";
+import { findReference } from "@/fhir/resource-helper";
+import { CONDITION_CODE_PREFERENCE_ORDER } from "@/fhir/conditions";
 import {
   codeableConceptLabel,
   findCoding,
   findCodingByOrderOfPreference,
   findCodingWithEnrichment,
 } from "@/fhir/codeable-concept";
-import { CONDITION_CODE_PREFERENCE_ORDER } from "@/fhir/conditions";
-import { findReference } from "@/fhir/resource-helper";
-import { compact, intersectionWith, uniqWith } from "lodash";
-import { formatDateISOToLocal, formatStringToDate } from "../formatters";
-import { SYSTEM_CCS, SYSTEM_ICD10, SYSTEM_SNOMED } from "../system-urls";
-import { FHIRModel } from "./fhir-model";
-import { PatientModel } from "./patient";
 
 export class ConditionModel extends FHIRModel<fhir4.Condition> {
   get abatement(): string | undefined {

--- a/src/fhir/models/condition.ts
+++ b/src/fhir/models/condition.ts
@@ -3,14 +3,14 @@ import { formatDateISOToLocal, formatStringToDate } from "../formatters";
 import { SYSTEM_CCS, SYSTEM_ICD10, SYSTEM_SNOMED } from "../system-urls";
 import { FHIRModel } from "./fhir-model";
 import { PatientModel } from "./patient";
-import { findReference } from "@/fhir/resource-helper";
-import { CONDITION_CODE_PREFERENCE_ORDER } from "@/fhir/conditions";
 import {
   codeableConceptLabel,
   findCoding,
   findCodingByOrderOfPreference,
   findCodingWithEnrichment,
 } from "@/fhir/codeable-concept";
+import { CONDITION_CODE_PREFERENCE_ORDER } from "@/fhir/conditions";
+import { findReference } from "@/fhir/resource-helper";
 
 export class ConditionModel extends FHIRModel<fhir4.Condition> {
   get abatement(): string | undefined {

--- a/src/fhir/models/medication-dispense.ts
+++ b/src/fhir/models/medication-dispense.ts
@@ -1,7 +1,7 @@
+import { FHIRModel } from "./fhir-model";
 import { getPerformingOrganization } from "@/fhir/medication";
 import { PractitionerModel } from "@/fhir/models/practitioner";
 import { findReference } from "@/fhir/resource-helper";
-import { FHIRModel } from "./fhir-model";
 
 export class MedicationDispenseModel extends FHIRModel<fhir4.MedicationDispense> {
   get includedPerformer(): string | undefined {

--- a/src/fhir/models/medication-request.ts
+++ b/src/fhir/models/medication-request.ts
@@ -1,7 +1,7 @@
+import { compact } from "lodash/fp";
 import { FHIRModel } from "./fhir-model";
 import { findReference } from "@/fhir/resource-helper";
 import { PractitionerModel } from "@/fhir/models/practitioner";
-import { compact } from "lodash/fp";
 
 export class MedicationRequestModel extends FHIRModel<fhir4.MedicationRequest> {
   get includedRequester() {

--- a/src/fhir/models/medication-request.ts
+++ b/src/fhir/models/medication-request.ts
@@ -1,7 +1,7 @@
 import { compact } from "lodash/fp";
 import { FHIRModel } from "./fhir-model";
-import { findReference } from "@/fhir/resource-helper";
 import { PractitionerModel } from "@/fhir/models/practitioner";
+import { findReference } from "@/fhir/resource-helper";
 
 export class MedicationRequestModel extends FHIRModel<fhir4.MedicationRequest> {
   get includedRequester() {

--- a/src/fhir/models/medication-statement.ts
+++ b/src/fhir/models/medication-statement.ts
@@ -8,6 +8,7 @@ import {
   getMedicationCodeableConcept,
   patientStatus,
 } from "@/fhir/medication";
+import { findReference } from "@/fhir/resource-helper";
 import {
   LENS_EXTENSION_AGGREGATED_FROM,
   LENS_EXTENSION_MEDICATION_DAYS_SUPPLY,
@@ -17,7 +18,6 @@ import {
   LENS_EXTENSION_MEDICATION_QUANTITY,
   LENS_EXTENSION_MEDICATION_REFILLS,
 } from "@/fhir/system-urls";
-import { findReference } from "@/fhir/resource-helper";
 
 export class MedicationStatementModel extends FHIRModel<fhir4.MedicationStatement> {
   readonly builderPatientRxNormStatus?: Record<string, string>;

--- a/src/fhir/models/medication-statement.ts
+++ b/src/fhir/models/medication-statement.ts
@@ -1,5 +1,6 @@
 import type { Reference } from "fhir/r4";
 import { capitalize, compact, find, get } from "lodash/fp";
+import { FHIRModel } from "./fhir-model";
 import { codeableConceptLabel } from "@/fhir/codeable-concept";
 import { dateToISO, formatDateISOToLocal } from "@/fhir/formatters";
 import {
@@ -16,7 +17,6 @@ import {
   LENS_EXTENSION_MEDICATION_QUANTITY,
   LENS_EXTENSION_MEDICATION_REFILLS,
 } from "@/fhir/system-urls";
-import { FHIRModel } from "./fhir-model";
 import { findReference } from "@/fhir/resource-helper";
 
 export class MedicationStatementModel extends FHIRModel<fhir4.MedicationStatement> {

--- a/src/fhir/models/medication.ts
+++ b/src/fhir/models/medication.ts
@@ -1,8 +1,8 @@
+import type { Medication } from "@/fhir/medication";
 import { FHIRModel } from "./fhir-model";
 import { PatientModel } from "./patient";
 import { codeableConceptLabel } from "@/fhir/codeable-concept";
 import { formatDateISOToLocal } from "@/fhir/formatters";
-import type { Medication } from "@/fhir/medication";
 import { getPerformingOrganization } from "@/fhir/medication";
 import { MedicationAdministrationModel } from "@/fhir/models/medication-administration";
 import { MedicationDispenseModel } from "@/fhir/models/medication-dispense";

--- a/src/fhir/models/medication.ts
+++ b/src/fhir/models/medication.ts
@@ -1,3 +1,5 @@
+import { FHIRModel } from "./fhir-model";
+import { PatientModel } from "./patient";
 import { codeableConceptLabel } from "@/fhir/codeable-concept";
 import { formatDateISOToLocal } from "@/fhir/formatters";
 import type { Medication } from "@/fhir/medication";
@@ -7,8 +9,6 @@ import { MedicationDispenseModel } from "@/fhir/models/medication-dispense";
 import { MedicationRequestModel } from "@/fhir/models/medication-request";
 import { MedicationStatementModel } from "@/fhir/models/medication-statement";
 import { findReference } from "@/fhir/resource-helper";
-import { FHIRModel } from "./fhir-model";
-import { PatientModel } from "./patient";
 
 export class MedicationModel extends FHIRModel<Medication> {
   get performer(): string | undefined {

--- a/src/fhir/models/patient.ts
+++ b/src/fhir/models/patient.ts
@@ -1,9 +1,9 @@
-import { findReference } from "@/fhir/resource-helper";
-import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
 import { cloneDeep, find } from "lodash";
 import { formatDateISOToLocal, formatPhoneNumber } from "../formatters";
 import { FHIRModel } from "./fhir-model";
 import { OrganizationModel } from "./organization";
+import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
+import { findReference } from "@/fhir/resource-helper";
 
 export const MaritalStatuses = [
   { text: "Annulled", code: "A" },

--- a/src/fhir/models/patient.ts
+++ b/src/fhir/models/patient.ts
@@ -2,8 +2,8 @@ import { cloneDeep, find } from "lodash";
 import { formatDateISOToLocal, formatPhoneNumber } from "../formatters";
 import { FHIRModel } from "./fhir-model";
 import { OrganizationModel } from "./organization";
-import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
 import { findReference } from "@/fhir/resource-helper";
+import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
 
 export const MaritalStatuses = [
   { text: "Annulled", code: "A" },

--- a/src/fhir/patient-helper.ts
+++ b/src/fhir/patient-helper.ts
@@ -1,9 +1,9 @@
-import { CTWRequestContext } from "@/components/core/ctw-context";
-import { PatientModel } from "@/fhir/models/patient";
-import { errorResponse } from "@/utils/errors";
 import { SearchParams } from "fhir-kit-client";
 import { getIncludedResources } from "./bundle";
 import { searchBuilderRecords } from "./search-helpers";
+import { CTWRequestContext } from "@/components/core/ctw-context";
+import { PatientModel } from "@/fhir/models/patient";
+import { errorResponse } from "@/utils/errors";
 
 export async function getBuilderFhirPatient(
   requestContext: CTWRequestContext,

--- a/src/fhir/practitioner.ts
+++ b/src/fhir/practitioner.ts
@@ -1,6 +1,6 @@
+import { searchBuilderRecords } from "./search-helpers";
 import { CTWRequestContext } from "@/components/core/ctw-context";
 import { PractitionerModel } from "@/fhir/models/practitioner";
-import { searchBuilderRecords } from "./search-helpers";
 
 export const getPractitioner = async (
   practitionerId: string,

--- a/src/fhir/provenance.ts
+++ b/src/fhir/provenance.ts
@@ -1,15 +1,15 @@
-import { CTWRequestContext } from "@/components/core/ctw-context";
-import {
-  claimsAuthEmail,
-  claimsBuilderName,
-  claimsPractitionerId,
-} from "@/utils/auth";
 import { Provenance, Reference, Resource } from "fhir/r4";
 import { getPractitioner } from "./practitioner";
 import {
   SYSTEM_PROVENANCE_ACTIVITY_TYPE,
   SYSTEM_PROVENANCE_AGENT_TYPE,
 } from "./system-urls";
+import {
+  claimsAuthEmail,
+  claimsBuilderName,
+  claimsPractitionerId,
+} from "@/utils/auth";
+import { CTWRequestContext } from "@/components/core/ctw-context";
 
 const ASSEMBLER_CODING = {
   system: SYSTEM_PROVENANCE_AGENT_TYPE,

--- a/src/fhir/provenance.ts
+++ b/src/fhir/provenance.ts
@@ -4,12 +4,12 @@ import {
   SYSTEM_PROVENANCE_ACTIVITY_TYPE,
   SYSTEM_PROVENANCE_AGENT_TYPE,
 } from "./system-urls";
+import { CTWRequestContext } from "@/components/core/ctw-context";
 import {
   claimsAuthEmail,
   claimsBuilderName,
   claimsPractitionerId,
 } from "@/utils/auth";
-import { CTWRequestContext } from "@/components/core/ctw-context";
 
 const ASSEMBLER_CODING = {
   system: SYSTEM_PROVENANCE_AGENT_TYPE,

--- a/src/fhir/resource-helper.ts
+++ b/src/fhir/resource-helper.ts
@@ -1,5 +1,5 @@
-import { find } from "lodash";
 import type { ResourceMap, ResourceType, ResourceTypeString } from "./types";
+import { find } from "lodash";
 
 // Returns the referenced resource if there is one.
 // Checks both the contained resources AND any included resources map.

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -1,4 +1,3 @@
-import { CTWRequestContext } from "@/components/core/ctw-context";
 import { SearchParams } from "fhir-kit-client";
 import { mapValues, mergeWith } from "lodash";
 
@@ -12,6 +11,7 @@ import {
   SYSTEM_ZUS_UPI_RECORD_TYPE,
 } from "./system-urls";
 import { ResourceType, ResourceTypeString } from "./types";
+import { CTWRequestContext } from "@/components/core/ctw-context";
 
 const MAX_COUNT = 250;
 

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -1,6 +1,5 @@
 import { SearchParams } from "fhir-kit-client";
 import { mapValues, mergeWith } from "lodash";
-
 import { getResources } from "./bundle";
 import {
   SYSTEM_SUMMARY,

--- a/src/hooks/use-breakpoints.ts
+++ b/src/hooks/use-breakpoints.ts
@@ -2,8 +2,8 @@ import useResizeObserver from "@react-hook/resize-observer";
 import { mapValues } from "lodash";
 import { RefObject, useState } from "react";
 import { useIsomorphicLayoutEffect } from "./use-isomorphic-layout-effect";
-import { defaultBreakpoints } from "@/styles/tailwind.theme";
 import { useCTW } from "@/components/core/ctw-provider";
+import { defaultBreakpoints } from "@/styles/tailwind.theme";
 
 type BreakpointKeys = keyof typeof defaultBreakpoints;
 export type Breakpoints = Record<BreakpointKeys, boolean>;

--- a/src/hooks/use-breakpoints.ts
+++ b/src/hooks/use-breakpoints.ts
@@ -1,9 +1,9 @@
-import { useCTW } from "@/components/core/ctw-provider";
-import { defaultBreakpoints } from "@/styles/tailwind.theme";
 import useResizeObserver from "@react-hook/resize-observer";
 import { mapValues } from "lodash";
 import { RefObject, useState } from "react";
 import { useIsomorphicLayoutEffect } from "./use-isomorphic-layout-effect";
+import { defaultBreakpoints } from "@/styles/tailwind.theme";
+import { useCTW } from "@/components/core/ctw-provider";
 
 type BreakpointKeys = keyof typeof defaultBreakpoints;
 export type Breakpoints = Record<BreakpointKeys, boolean>;

--- a/src/hooks/use-medications.ts
+++ b/src/hooks/use-medications.ts
@@ -1,3 +1,5 @@
+import { UseQueryResult } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 import { useQueryWithPatient } from "@/components/core/patient-provider";
 import { getMergedIncludedResources } from "@/fhir/bundle";
 import {
@@ -11,8 +13,6 @@ import {
   QUERY_KEY_PATIENT_BUILDER_MEDICATIONS,
   QUERY_KEY_PATIENT_MEDICATIONS,
 } from "@/utils/query-keys";
-import { UseQueryResult } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
 
 // Gets patient medications for the builder, excluding meds where the information source is patient.
 export function useQueryGetPatientMedsForBuilder(): UseQueryResult<

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,8 +1,8 @@
+import { cloneDeep } from "lodash";
+import { OperationOutcomeModel } from "..";
 import { ActionReturn } from "@/components/content/forms/types";
 import { FhirError, fhirErrorResponse, isFhirError } from "@/fhir/errors";
 import { isOperationOutcome } from "@/fhir/operation-outcome";
-import { cloneDeep } from "lodash";
-import { OperationOutcomeModel } from "..";
 
 export function isError(error: unknown): error is Error {
   if (typeof error === "object" && error !== null) {


### PR DESCRIPTION
Explicitly setting the `import/order` configuration to the [default sort order](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md).

> The only allowed strings are: "builtin", "external", "internal", "unknown", "parent", "sibling", "index", "object", "type". The enforced order is the same as the order of each element in a group. Omitted types are implicitly grouped together as the last element.

This means since we are setting `"builtin", "external", "parent", "sibling", "index"`, groups like "object"/"type" don't have a specific ordering besides needing to come after the builtin, external, parent, sibling, index groups. We might think about making this more explicit if we run into issues where `eslint --fix` prints import-order errors but doesn't actually have enough context to fix the ordering for us.

It's also possible to enforce empty lines between groups and sort order within groups. Personally I'm not a fan of the empty lines between groups. I wouldn't mind setting sort order within groups though if we run into sort issues down the road.

This should be good to merge though. Maybe someone wants to test it out in VSCode first though @WesleyKapow 