### PR TITLE
CTW-471 check message length rather than message status

### DIFF
--- a/.changeset/silent-cats-run.md
+++ b/.changeset/silent-cats-run.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Show other provider records if the data exists otherwise prompt to request records.
+Show other provider records if patient history messages exists, otherwise show show empty state with request records button.

--- a/.changeset/silent-cats-run.md
+++ b/.changeset/silent-cats-run.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Show other provider records if the data exists otherwise prompt to request records.

--- a/.changeset/silent-cats-run.md
+++ b/.changeset/silent-cats-run.md
@@ -1,4 +1,5 @@
 ---
 "@zus-health/ctw-component-library": patch
 ---
+
 Show other provider records if patient history messages exists, otherwise show empty state with request records button.

--- a/.changeset/silent-cats-run.md
+++ b/.changeset/silent-cats-run.md
@@ -1,5 +1,4 @@
 ---
 "@zus-health/ctw-component-library": patch
 ---
-
-Show other provider records if patient history messages exists, otherwise show show empty state with request records button.
+Show other provider records if patient history messages exists, otherwise show empty state with request records button.

--- a/src/services/patient-history/patient-history.ts
+++ b/src/services/patient-history/patient-history.ts
@@ -1,7 +1,6 @@
 import { getZusApiBaseUrl } from "@/api/urls";
 import { CTWRequestContext } from "@/components/core/ctw-context";
 import { errorResponse } from "@/utils/errors";
-import { parseISO } from "date-fns";
 import { PatientRefreshHistoryMessage } from "./patient-history-types";
 
 export async function getPatientRefreshHistoryMessages(
@@ -42,17 +41,6 @@ export async function hasFetchedPatientHistory(
   if (messages.length === 0) {
     return false;
   }
-
-  const latestMessage = messages.reduce((previous, current) =>
-    parseISO(current._updatedAt) > parseISO(previous._updatedAt) &&
-    current.status === "done"
-      ? current
-      : previous
-  );
-
-  if (latestMessage.status === "done") {
-    return true;
-  }
-
-  return false;
+  // This is the case for messages.length > 0 which is the current workaround.
+  return true;
 }


### PR DESCRIPTION
This PR checks message length as the current API has some issues and makes a decision: 

 If any status messages appear in the below API (regardless of content), the component will render as normal (if there are no conditions returned, shows the no condition available). If empty array is returned, we will show the Request Records view.

Data there (Sarah dev):
![Screen Shot 2022-11-30 at 12 15 39 PM](https://user-images.githubusercontent.com/98342697/204876526-652c2e80-a5b0-48bf-a5a3-f0fe60155a5b.png)

Data not there (Allen dev): 
![Screen Shot 2022-11-30 at 12 16 38 PM](https://user-images.githubusercontent.com/98342697/204876745-bce6758a-e7cc-4c33-9670-b14daccee9a5.png)

