### PR TITLE
CTW-552 canvas fit and finish meds drawer heading style

### DIFF
--- a/.changeset/neat-wolves-hear.md
+++ b/.changeset/neat-wolves-hear.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+The title header atop Drawers (medications, conditions or otherwise) now has a full width bottom border. This is a border between fixed content and scrolling content so it makes more sense that the divider spans the full width of the drawer.

--- a/src/components/core/drawer.tsx
+++ b/src/components/core/drawer.tsx
@@ -77,7 +77,7 @@ export function Drawer({
               >
                 <Dialog.Panel className="ctw-pointer-events-auto ctw-w-screen ctw-max-w-xl">
                   <div className="ctw-flex ctw-h-full ctw-flex-col ctw-bg-white ctw-shadow-xl">
-                    <div className="ctw-px-6 ctw-flex ctw-h-14 ctw-flex-shrink-0 ctw-items-center ctw-justify-between ctw-border-0 ctw-border-b ctw-border-solid ctw-border-content-lighter">
+                    <div className="ctw-flex ctw-h-14 ctw-flex-shrink-0 ctw-items-center ctw-justify-between ctw-border-0 ctw-border-b ctw-border-solid ctw-border-content-lighter ctw-px-6">
                       <Dialog.Title className="ctw-text-lg ctw-font-semibold ctw-uppercase ctw-text-content-black">
                         {title}
                       </Dialog.Title>

--- a/src/components/core/drawer.tsx
+++ b/src/components/core/drawer.tsx
@@ -77,7 +77,7 @@ export function Drawer({
               >
                 <Dialog.Panel className="ctw-pointer-events-auto ctw-w-screen ctw-max-w-xl">
                   <div className="ctw-flex ctw-h-full ctw-flex-col ctw-bg-white ctw-shadow-xl">
-                    <div className="ctw-mx-6 ctw-flex ctw-h-14 ctw-flex-shrink-0 ctw-items-center ctw-justify-between ctw-border-0 ctw-border-b ctw-border-solid ctw-border-content-lighter">
+                    <div className="ctw-px-6 ctw-flex ctw-h-14 ctw-flex-shrink-0 ctw-items-center ctw-justify-between ctw-border-0 ctw-border-b ctw-border-solid ctw-border-content-lighter">
                       <Dialog.Title className="ctw-text-lg ctw-font-semibold ctw-uppercase ctw-text-content-black">
                         {title}
                       </Dialog.Title>


### PR DESCRIPTION
This PR makes the bottom border of the top title header inside a `<Drawer/>` span the full width of the drawer. This line delimitates a fixed heading and the remaining scrolling content of the drawer.

Notice the separation between heading/content/footer in the following two images to see the difference 

**Previous:**
<img width="590" alt="Screen Shot 2022-11-30 at 1 28 02 PM" src="https://user-images.githubusercontent.com/6380075/204879017-3a5d96f4-68c7-4a7f-abcb-682222c43066.png">


**Updated:**
<img width="590" alt="Screen Shot 2022-11-30 at 1 27 22 PM" src="https://user-images.githubusercontent.com/6380075/204878887-ae70a88a-77d9-40b2-8034-6d0aab6d39e6.png">


---
Also notice how this looks now where content is under the fixed heading (it more closely resembles how content looks going under the fixed footer)

<img width="897" alt="Screen Shot 2022-11-30 at 1 33 09 PM" src="https://user-images.githubusercontent.com/6380075/204880005-2de12add-b2bf-4c28-99b8-c40480e47ad5.png">
