### PR TITLE
ActionList doesn't always need action handler

### DIFF
--- a/.changeset/six-guests-drop.md
+++ b/.changeset/six-guests-drop.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+ActionList onAction and actionText props are now optional. Added classname ctw-drawer-title to the Drawers h2 tag.

--- a/src/components/core/action-list/action-list.tsx
+++ b/src/components/core/action-list/action-list.tsx
@@ -12,9 +12,9 @@ export type MinActionItem = {
 export type ActionItemProps<T extends MinActionItem> = {
   className?: string;
   item: T;
-  onAction: (i: T) => void;
+  onAction?: (i: T) => void;
   onRowClick?: (i: T) => void;
-  actionText: string;
+  actionText?: string;
   activeClassName?: string;
   onUndoAction?: (i: T) => void;
   undoActionText?: string;
@@ -53,7 +53,7 @@ export const ActionList = <T extends MinActionItem>({
 export const ActionListItem = <T extends MinActionItem>({
   item,
   onRowClick,
-  onAction,
+  onAction = () => {},
   actionText = "Mark Complete",
   undoActionText = "Undo",
   onUndoAction,

--- a/src/components/core/drawer.tsx
+++ b/src/components/core/drawer.tsx
@@ -78,7 +78,7 @@ export function Drawer({
                 <Dialog.Panel className="ctw-pointer-events-auto ctw-w-screen ctw-max-w-xl">
                   <div className="ctw-flex ctw-h-full ctw-flex-col ctw-bg-white ctw-shadow-xl">
                     <div className="ctw-flex ctw-h-14 ctw-flex-shrink-0 ctw-items-center ctw-justify-between ctw-border-0 ctw-border-b ctw-border-solid ctw-border-content-lighter ctw-px-6">
-                      <Dialog.Title className="ctw-text-lg ctw-font-semibold ctw-uppercase ctw-text-content-black">
+                      <Dialog.Title className="ctw-drawer-title ctw-text-lg ctw-font-semibold ctw-uppercase ctw-text-content-black">
                         {title}
                       </Dialog.Title>
                       <div className="ctw-ml-3 ctw-flex ctw-h-7 ctw-items-center">


### PR DESCRIPTION
ActionList had `onAction` as required (at time of creation it made sense) but we found a use-case where the list was used without the action and had to be written as:
```tsx
              <ActionList
                className="ctw-medication-review-list"
                items={actionItems(builderMedications)}
                onAction={() => {}}
                onRowClick={({ medication }) => openMedicationDrawer(medication)}
                actionText=""
              />
```
so this makes `actionText` and `onAction` default to those empty values.

Additionally added `.ctw-drawer-title` to the drawers h2 tag so it can be easily targeted by CSS rules. We found a case where semanticui was messing up the h2 style in an app using ctw-component-library. We don't want to restyle from within, so this classname just makes it easier to target from without.