### PR TITLE
Fix bug with detecting active conditions

### DIFF
--- a/.changeset/short-rats-confess.md
+++ b/.changeset/short-rats-confess.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix bug where capital "Active" conditions were not showing up in the active conditions view. We now correctly filter based on the "code" and proper "system" of the clinicalStatus codings.

--- a/src/fhir/models/condition.test.ts
+++ b/src/fhir/models/condition.test.ts
@@ -1,4 +1,5 @@
 import { clone } from "lodash";
+import { SYSTEM_CONDITION_CLINICAL } from "../system-urls";
 import { ConditionModel } from "./condition";
 
 describe("FHIR Model: Condition", () => {
@@ -7,12 +8,31 @@ describe("FHIR Model: Condition", () => {
       const condition = getCondition();
 
       ["active", "recurrence", "relapse"].forEach((status) => {
-        condition.resource.clinicalStatus = { coding: [{ code: status }] };
+        condition.resource.clinicalStatus = {
+          coding: [{ code: status, system: SYSTEM_CONDITION_CLINICAL }],
+        };
         expect(condition.active).toBeTruthy();
       });
 
+      // Should find the right condition by system
+      condition.resource.clinicalStatus = {
+        text: "Active",
+        coding: [
+          { code: "foobar" },
+          {
+            code: "active",
+            display: "Active",
+            system: SYSTEM_CONDITION_CLINICAL,
+          },
+          { code: "inactive" },
+        ],
+      };
+      expect(condition.active).toBeTruthy();
+
       ["inactive", "remission", "resolved"].forEach((status) => {
-        condition.resource.clinicalStatus = { coding: [{ code: status }] };
+        condition.resource.clinicalStatus = {
+          coding: [{ code: status, system: SYSTEM_CONDITION_CLINICAL }],
+        };
         expect(condition.active).toBeFalsy();
       });
     });

--- a/src/fhir/models/condition.ts
+++ b/src/fhir/models/condition.ts
@@ -1,6 +1,11 @@
-import { compact, intersectionWith, uniqWith } from "lodash";
+import { compact, find, intersectionWith, uniqWith } from "lodash";
 import { formatDateISOToLocal, formatStringToDate } from "../formatters";
-import { SYSTEM_CCS, SYSTEM_ICD10, SYSTEM_SNOMED } from "../system-urls";
+import {
+  SYSTEM_CCS,
+  SYSTEM_CONDITION_CLINICAL,
+  SYSTEM_ICD10,
+  SYSTEM_SNOMED,
+} from "../system-urls";
 import { FHIRModel } from "./fhir-model";
 import { PatientModel } from "./patient";
 import {
@@ -36,7 +41,13 @@ export class ConditionModel extends FHIRModel<fhir4.Condition> {
   }
 
   get active(): boolean {
-    return ["active", "recurrence", "relapse"].includes(this.clinicalStatus);
+    const coding = find(this.resource.clinicalStatus?.coding, {
+      system: SYSTEM_CONDITION_CLINICAL,
+    });
+
+    return coding?.code
+      ? ["active", "recurrence", "relapse"].includes(coding.code)
+      : false;
   }
 
   get asserter(): string | undefined {


### PR DESCRIPTION
CTW-577

Previously we used `this.clinicalStatus` which uses `codeableConceptLabel` which grabs the `text` field if it exists. The production bug was that this value was `Active` (capitalized). We now go off the actual `code` for the correct `system`. NOTE: Code's here HAVE TO BE lowercase (ODS rejects them otherwise).