### PR TITLE
Minor cleanup

### DIFF
--- a/.changeset/dirty-dragons-tap.md
+++ b/.changeset/dirty-dragons-tap.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Minor code cleanup.
+Change logic around showing empty "request records" box in other providers to only show if `clinicalHistoryExists` OR patient has no other provider records.

--- a/.changeset/dirty-dragons-tap.md
+++ b/.changeset/dirty-dragons-tap.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Minor code cleanup.

--- a/README.md
+++ b/README.md
@@ -56,10 +56,8 @@ The `PatientProvider` component provides patient details needed by other compone
 An example onPatientSave function could be as follows:
 
 ```
-const onPatientSave = async (data) => {
-  /* Logic to send data to data
-   data here is of type PatientFormData
-
+const onPatientSave = async (data: PatientFormData) => {
+/*
   type PatientFormData = {
     lastName: string;
     firstName: string;
@@ -74,7 +72,7 @@ const onPatientSave = async (data) => {
 };
 */
 
-// Do whatever you want with data
+// Do whatever you want with data (eg, send to server)
 
   return response
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ const {
   VITE_AUTH0_CLIENT_ID,
   VITE_AUTH0_AUDIENCE,
   VITE_AUTH0_CALLBACK_PATH,
-  VITE_ENV = "sandbox",
+  VITE_ENV = "dev",
 } = import.meta.env;
 
 const DemoApp = ({ accessToken = "" }) => (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ const {
   VITE_AUTH0_CLIENT_ID,
   VITE_AUTH0_AUDIENCE,
   VITE_AUTH0_CALLBACK_PATH,
-  VITE_ENV = "dev",
+  VITE_ENV = "sandbox",
 } = import.meta.env;
 
 const DemoApp = ({ accessToken = "" }) => (

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -75,7 +75,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
   const { getRequestContext } = useCTW();
   const [sort, setSort] = useState<TableSort>();
 
-  const [clinicalHistoryExists, setClinicalHistoryExists] = useState(false);
+  const [clinicalHistoryExists, setClinicalHistoryExists] = useState<boolean>();
 
   const patientRecordsMessage = patientRecordsResponse.isError
     ? ERROR_MSG
@@ -190,6 +190,11 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
       }
     }
     void load();
+    if (patientResponse.data?.id && clinicalHistoryExists === undefined) {
+      void handleClinicalHistory(patientResponse.data.id);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     includeInactive,
     patientResponse.data,
@@ -197,13 +202,6 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
     otherProviderRecordsResponse.data,
     patientRecordsResponse.error,
   ]);
-
-  useEffect(() => {
-    if (patientResponse.data?.id) {
-      void handleClinicalHistory(patientResponse.data.id);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [patientResponse.data?.id]);
 
   if (patientResponse.isError) {
     return <ConditionsNoPatient className={className} />;

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -200,6 +200,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
     patientResponse.data,
     patientRecordsResponse.data,
     otherProviderRecordsResponse.data,
+    clinicalHistoryExists,
     patientRecordsResponse.error,
   ]);
 

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -150,7 +150,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
     </button>
   );
 
-  const shouldShowClinicalHistory =
+  const shouldShowClinicalHistoryArea =
     clinicalHistoryExists || otherProviderRecordsResponse.data?.length;
 
   const checkClinicalHistory = async (patientID: string) => {
@@ -283,7 +283,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
         <div className="ctw-space-y-3">
           <div className="ctw-conditions-title-container">
             <div className="ctw-title">Other Provider Records</div>
-            {shouldShowClinicalHistory && (
+            {shouldShowClinicalHistoryArea && (
               <button
                 type="button"
                 className="ctw-btn-clear ctw-link"
@@ -293,7 +293,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
               </button>
             )}
           </div>
-          {shouldShowClinicalHistory ? (
+          {shouldShowClinicalHistoryArea ? (
             <ConditionsTableBase
               className="ctw-conditions-not-reviewed"
               stacked={breakpoints.sm}

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -150,6 +150,9 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
     </button>
   );
 
+  const shouldShowClinicalHistory =
+    clinicalHistoryExists || otherProviderRecordsResponse.data?.length;
+
   const checkClinicalHistory = async (patientID: string) => {
     const requestContext = await getRequestContext();
 
@@ -280,18 +283,17 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
         <div className="ctw-space-y-3">
           <div className="ctw-conditions-title-container">
             <div className="ctw-title">Other Provider Records</div>
-            {clinicalHistoryExists ||
-              (otherProviderRecordsResponse.data?.length && (
-                <button
-                  type="button"
-                  className="ctw-btn-clear ctw-link"
-                  onClick={() => setRequestDrawerIsOpen(true)}
-                >
-                  Request Records
-                </button>
-              ))}
+            {shouldShowClinicalHistory && (
+              <button
+                type="button"
+                className="ctw-btn-clear ctw-link"
+                onClick={() => setRequestDrawerIsOpen(true)}
+              >
+                Request Records
+              </button>
+            )}
           </div>
-          {clinicalHistoryExists ? (
+          {shouldShowClinicalHistory ? (
             <ConditionsTableBase
               className="ctw-conditions-not-reviewed"
               stacked={breakpoints.sm}

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -150,7 +150,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
     </button>
   );
 
-  const handleClinicalHistory = async (patientID: string) => {
+  const checkClinicalHistory = async (patientID: string) => {
     const requestContext = await getRequestContext();
 
     const patientHistoryFetched = await hasFetchedPatientHistory(
@@ -191,7 +191,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
     }
     void load();
     if (patientResponse.data?.id && clinicalHistoryExists === undefined) {
-      void handleClinicalHistory(patientResponse.data.id);
+      void checkClinicalHistory(patientResponse.data.id);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -280,15 +280,16 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
         <div className="ctw-space-y-3">
           <div className="ctw-conditions-title-container">
             <div className="ctw-title">Other Provider Records</div>
-            {clinicalHistoryExists && (
-              <button
-                type="button"
-                className="ctw-btn-clear ctw-link"
-                onClick={() => setRequestDrawerIsOpen(true)}
-              >
-                Request Records
-              </button>
-            )}
+            {clinicalHistoryExists ||
+              (otherProviderRecordsResponse.data?.length && (
+                <button
+                  type="button"
+                  className="ctw-btn-clear ctw-link"
+                  onClick={() => setRequestDrawerIsOpen(true)}
+                >
+                  Request Records
+                </button>
+              ))}
           </div>
           {clinicalHistoryExists ? (
             <ConditionsTableBase
@@ -363,6 +364,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
           patient={patientResponse.data}
           isOpen={requestRecordsDrawerIsOpen}
           onClose={() => setRequestDrawerIsOpen(false)}
+          setClinicalHistoryExists={setClinicalHistoryExists}
         />
       )}
 

--- a/src/components/content/patient-history-request-drawer.tsx
+++ b/src/components/content/patient-history-request-drawer.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { Dispatch, SetStateAction, useContext } from "react";
 import { CTWRequestContext } from "../core/ctw-context";
 import {
   DrawerFormWithFields,
@@ -20,7 +20,10 @@ import { getFormResponseErrors } from "@/utils/errors";
 type PatientHistoryRequestDrawer<T> = Pick<
   DrawerFormWithFieldsProps<T>,
   "isOpen" | "onClose" | "header"
-> & { patient: PatientModel };
+> & {
+  patient: PatientModel;
+  setClinicalHistoryExists: Dispatch<SetStateAction<boolean | undefined>>;
+};
 
 export type ScheduleHistoryFormData = {
   npi: string;
@@ -33,6 +36,7 @@ export const PatientHistoryRequestDrawer = <T,>({
   header,
   isOpen,
   onClose,
+  setClinicalHistoryExists,
 }: PatientHistoryRequestDrawer<T>) => {
   const onPatientSave = useHandlePatientSave(patient);
 
@@ -66,6 +70,9 @@ export const PatientHistoryRequestDrawer = <T,>({
       ];
       return new Error(requestErrors.join(","));
     }
+
+    // patientHistoryResponse has succeeded at this point and should remove empty request history state.
+    setClinicalHistoryExists(true);
 
     return patientHistoryResponse;
   };


### PR DESCRIPTION
- Revert useEffect based on feedback that it is more correct to have `handleClinicalHistory ` called once based on state being undefined. 
- Update readme
- Change logic around showing empty "request records" box in other providers to only show if `clinicalHistoryExists` OR patient has no other provider records.