### PR TITLE
CTW-569/archive other conditions

### DIFF
--- a/.changeset/modern-deers-chew.md
+++ b/.changeset/modern-deers-chew.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Add ability to archive other provider records.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,6 +7,7 @@ module.exports = {
     "prettier",
     "plugin:storybook/recommended",
   ],
+  plugins: ["unused-imports"],
   // Ignore js files as we now have typescript parsing rules.
   // See https://stackoverflow.com/a/65063702 for more.
   ignorePatterns: [
@@ -31,6 +32,7 @@ module.exports = {
     "no-void": ["error", { allowAsStatement: true }],
     curly: "error",
     "import/extensions": "off",
+    "unused-imports/no-unused-imports": "error",
     "import/order": [
       "error",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "dependencies": {
         "@headlessui/react": "^1.7.3",
         "@heroicons/react": "^1.0.6",
@@ -51,6 +51,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-storybook": "^0.6.6",
+        "eslint-plugin-unused-imports": "^2.0.0",
         "jsdom": "^20.0.1",
         "msw": "^0.48.2",
         "msw-storybook-addon": "^1.6.3",
@@ -17498,6 +17499,36 @@
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -50352,6 +50383,21 @@
           }
         }
       }
+    },
+    "eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-storybook": "^0.6.6",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "jsdom": "^20.0.1",
     "msw": "^0.48.2",
     "msw-storybook-addon": "^1.6.3",

--- a/src/components/content/conditions-helper.ts
+++ b/src/components/content/conditions-helper.ts
@@ -10,7 +10,6 @@ export const onConditionDelete = async (
   resource: fhir4.Condition,
   requestContext: CTWRequestContext
 ) => {
-  const client = requestContext.fhirClient;
   if (!resource.id) {
     throw new Error("Tried to edit a resource that hasn't been created yet.");
   }

--- a/src/components/content/conditions-table-base.tsx
+++ b/src/components/content/conditions-table-base.tsx
@@ -1,5 +1,5 @@
 import { DotsHorizontalIcon } from "@heroicons/react/outline";
-import { DropdownMenu, MenuItems } from "../core/dropdown-menu";
+import { DropdownMenu, MenuItem } from "../core/dropdown-menu";
 import { Table, TableBaseProps } from "../core/table/table";
 import { TableColumn } from "../core/table/table-helpers";
 import { ConditionModel } from "@/fhir/models/condition";
@@ -8,7 +8,7 @@ import { alphaSortBlankLast } from "@/utils/sort";
 export type ConditionsTableBaseProps = {
   className?: string;
   conditions: ConditionModel[];
-  rowActions: (condition: ConditionModel) => MenuItems[];
+  rowActions: (condition: ConditionModel) => MenuItem[];
   hideMenu: boolean;
 } & TableBaseProps<ConditionModel>;
 
@@ -47,7 +47,9 @@ export function ConditionsTableBase({
           <div className="ctw-text-content-black">
             {condition.clinicalStatus}
           </div>
-          <div>{condition.verificationStatus}</div>
+          <div>
+            {condition.isArchived ? "Archived" : condition.verificationStatus}
+          </div>
         </div>
       ),
       widthPercent: 17.5,

--- a/src/components/content/conditions/helpers.test.ts
+++ b/src/components/content/conditions/helpers.test.ts
@@ -9,7 +9,7 @@ describe("Condition Helpers", () => {
   describe("filterOtherConditions", () => {
     it("should filter out when there's a match and other record has no date", () => {
       const { others, patients } = setupConditions();
-      const filtered = filterOtherConditions(others, patients);
+      const filtered = filterOtherConditions(others, patients, false);
       expect(filtered).toHaveLength(2);
       expect(filtered[0].id).toEqual("other2");
       expect(filtered[1].id).toEqual("other3");
@@ -17,7 +17,7 @@ describe("Condition Helpers", () => {
 
     it("should filter out when there's a match and patient record is newer", () => {
       const { others, patients } = setupConditions("2022-11-09", "2022-11-10");
-      const filtered = filterOtherConditions(others, patients);
+      const filtered = filterOtherConditions(others, patients, false);
       expect(filtered).toHaveLength(2);
       expect(filtered[0].id).toEqual("other2");
       expect(filtered[1].id).toEqual("other3");
@@ -25,7 +25,7 @@ describe("Condition Helpers", () => {
 
     it("should NOT filter out when there's a match and patient record is older", () => {
       const { others, patients } = setupConditions("2022-11-10", "2022-11-09");
-      const filtered = filterOtherConditions(others, patients);
+      const filtered = filterOtherConditions(others, patients, false);
       expect(filtered).toHaveLength(3);
     });
 
@@ -36,7 +36,7 @@ describe("Condition Helpers", () => {
         "active",
         "active"
       );
-      const filtered = filterOtherConditions(others, patients);
+      const filtered = filterOtherConditions(others, patients, false);
       expect(filtered).toHaveLength(2);
     });
 
@@ -48,7 +48,7 @@ describe("Condition Helpers", () => {
         "active",
         "entered-in-error"
       );
-      const filtered = filterOtherConditions(others, patients);
+      const filtered = filterOtherConditions(others, patients, false);
       expect(filtered).toHaveLength(3);
     });
 

--- a/src/components/content/conditions/helpers.ts
+++ b/src/components/content/conditions/helpers.ts
@@ -4,25 +4,28 @@ import { ConditionModel } from "@/fhir/models";
 //  1. There is an existing patient condition with a matching known code.
 //  2. The other condition is older than the patient condition OR they
 //     have the same status.
+//  3. Condition is archived and includeArchived is false.
 export const filterOtherConditions = (
   otherConditions: ConditionModel[],
-  patientConditions: ConditionModel[]
+  patientConditions: ConditionModel[],
+  includeArchived: boolean
 ): ConditionModel[] =>
-  otherConditions.filter(
-    (otherCondition) =>
-      !patientConditions.some((patientCondition) => {
-        const otherRecordedDate = otherCondition.resource.recordedDate;
-        const patientRecordedDate = patientCondition.resource.recordedDate;
-        const isMatch = otherCondition.knownCodingsMatch(patientCondition);
-        const isEnteredInError =
-          patientCondition.verificationStatus === "entered-in-error";
+  otherConditions.filter((otherCondition) => {
+    if (otherCondition.isArchived && !includeArchived) return false;
 
-        const isOlder =
-          !otherRecordedDate ||
-          (patientRecordedDate && otherRecordedDate <= patientRecordedDate);
-        const hasSameStatus =
-          otherCondition.clinicalStatus === patientCondition.clinicalStatus;
+    return !patientConditions.some((patientCondition) => {
+      const otherRecordedDate = otherCondition.resource.recordedDate;
+      const patientRecordedDate = patientCondition.resource.recordedDate;
+      const isMatch = otherCondition.knownCodingsMatch(patientCondition);
+      const isEnteredInError =
+        patientCondition.verificationStatus === "entered-in-error";
 
-        return isMatch && !isEnteredInError && (isOlder || hasSameStatus);
-      })
-  );
+      const isOlder =
+        !otherRecordedDate ||
+        (patientRecordedDate && otherRecordedDate <= patientRecordedDate);
+      const hasSameStatus =
+        otherCondition.clinicalStatus === patientCondition.clinicalStatus;
+
+      return isMatch && !isEnteredInError && (isOlder || hasSameStatus);
+    });
+  });

--- a/src/components/content/forms/conditions.ts
+++ b/src/components/content/forms/conditions.ts
@@ -4,17 +4,16 @@ import { ActionReturn } from "./types";
 import { CTWRequestContext } from "@/components/core/ctw-context";
 import { FormErrors } from "@/components/core/form/drawer-form";
 import { createOrEditFhirResource } from "@/fhir/action-helper";
-import { setRecorderField } from "@/fhir/conditions";
 import { isFhirError } from "@/fhir/errors";
 import { dateToISO } from "@/fhir/formatters";
 import { ConditionModel } from "@/fhir/models/condition";
 import { OperationOutcomeModel } from "@/fhir/models/operation-outcome";
 import { isOperationOutcome } from "@/fhir/operation-outcome";
+import { getUsersPractitionerReference } from "@/fhir/practitioner";
 import {
   SYSTEM_CONDITION_CLINICAL,
   SYSTEM_CONDITION_VERIFICATION_STATUS,
 } from "@/fhir/system-urls";
-import { claimsPractitionerId } from "@/utils/auth";
 import { AnyZodSchema, getFormData } from "@/utils/form-helper";
 import {
   QUERY_KEY_OTHER_PROVIDER_CONDITIONS,
@@ -69,16 +68,13 @@ export const createOrEditCondition = async (
   }
 
   const requestContext = await getRequestContext();
-  const practitionerId = claimsPractitionerId(requestContext.authToken);
 
   // Defines the properties of the condition based on the form.
   // The autofill values that apply to both edits and creates are here; including Practitioner, Recorder, Patient, and Recorded date.
   const fhirCondition: fhir4.Condition = {
     resourceType: "Condition",
     id: result.data.id,
-    ...(practitionerId && {
-      recorder: await setRecorderField(practitionerId, requestContext),
-    }),
+    recorder: await getUsersPractitionerReference(requestContext),
     clinicalStatus: {
       coding: [
         {

--- a/src/components/content/forms/medications.ts
+++ b/src/components/content/forms/medications.ts
@@ -1,7 +1,5 @@
 import type { FormEntry } from "../../core/form/drawer-form-with-fields";
-import { cloneDeep } from "lodash";
 import { z } from "zod";
-import { ActionReturn } from "./types";
 import { CTWRequestContext } from "@/components/core/ctw-context";
 import { createOrEditFhirResource } from "@/fhir/action-helper";
 import { dateToISO } from "@/fhir/formatters";

--- a/src/components/content/forms/patients.ts
+++ b/src/components/content/forms/patients.ts
@@ -1,5 +1,3 @@
-import { cloneDeep } from "lodash";
-import { ActionReturn } from "./types";
 import { CTWRequestContext } from "@/components/core/ctw-context";
 import { createOrEditFhirResource } from "@/fhir/action-helper";
 import { dateToISO } from "@/fhir/formatters";

--- a/src/components/content/medications-table-base.tsx
+++ b/src/components/content/medications-table-base.tsx
@@ -3,13 +3,13 @@ import { DotsHorizontalIcon } from "@heroicons/react/outline";
 import { compact, isFunction } from "lodash/fp";
 import { ReactNode, useRef } from "react";
 import { MinRecordItem, TableColumn } from "../core/table/table-helpers";
-import { DropdownMenu, MenuItems } from "@/components/core/dropdown-menu";
+import { DropdownMenu, MenuItem } from "@/components/core/dropdown-menu";
 import { Table, TableBaseProps } from "@/components/core/table/table";
 import { useBreakpoints } from "@/hooks/use-breakpoints";
 
 export type MedicationsTableBaseProps<T extends MinRecordItem> = {
   medicationStatements: MedicationStatementModel[];
-  rowActions?: (condition: MedicationStatementModel) => MenuItems[];
+  rowActions?: (condition: MedicationStatementModel) => MenuItem[];
   hideMenu?: boolean;
   className?: string;
   children?: ReactNode;

--- a/src/components/content/medications/other-provider-meds-table.tsx
+++ b/src/components/content/medications/other-provider-meds-table.tsx
@@ -52,7 +52,7 @@ export function OtherProviderMedsTable({
         rowActions={(medication) => [
           {
             name: "View History",
-            action: () => {
+            action: async () => {
               openMedicationDrawer(medication);
             },
           },

--- a/src/components/content/medications/provider-meds-table.tsx
+++ b/src/components/content/medications/provider-meds-table.tsx
@@ -61,7 +61,7 @@ export function ProviderMedsTable({
         rowActions={(medication) => [
           {
             name: "View History",
-            action: () => {
+            action: async () => {
               openMedicationDrawer(medication);
             },
           },

--- a/src/components/content/patient-history-request-drawer.tsx
+++ b/src/components/content/patient-history-request-drawer.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useContext } from "react";
+import { Dispatch, SetStateAction } from "react";
 import { CTWRequestContext } from "../core/ctw-context";
 import {
   DrawerFormWithFields,

--- a/src/components/core/dropdown-menu.tsx
+++ b/src/components/core/dropdown-menu.tsx
@@ -1,23 +1,32 @@
 import { Menu } from "@headlessui/react";
 import * as RadixDropdownMenu from "@radix-ui/react-dropdown-menu";
 import cx from "classnames";
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { useCTW } from "./ctw-provider";
 import "./dropdown-menu.scss";
+import { Loading } from "./loading";
 
-export type MenuItems = {
+export type MenuItem = {
   name: string;
-  action: () => void;
+  action: () => Promise<void>;
   className?: string;
 };
 
 export type DropdownMenuProps = {
   children: ReactNode;
-  menuItems: MenuItems[];
+  menuItems: MenuItem[];
 };
 
 export function DropdownMenu({ children, menuItems }: DropdownMenuProps) {
   const { ctwProviderRef } = useCTW();
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Wrap our menuItem's action so that we set loading
+  async function handleClick(menuItem: MenuItem) {
+    setIsLoading(true);
+    await menuItem.action();
+    setIsLoading(false);
+  }
 
   return (
     <Menu>
@@ -26,7 +35,8 @@ export function DropdownMenu({ children, menuItems }: DropdownMenuProps) {
           className="ctw-btn-clear ctw-link"
           aria-label="dropdown"
         >
-          {children}
+          {isLoading && <Loading message="" />}
+          {!isLoading && children}
         </RadixDropdownMenu.Trigger>
 
         <RadixDropdownMenu.Portal container={ctwProviderRef.current}>
@@ -45,7 +55,7 @@ export function DropdownMenu({ children, menuItems }: DropdownMenuProps) {
 
             {menuItems.map((menuItem) => (
               <RadixDropdownMenu.Item
-                onClick={menuItem.action}
+                onClick={() => handleClick(menuItem)}
                 key={menuItem.name}
                 className={cx(menuItem.className, "ctw-dropdown-menu-item")}
               >

--- a/src/components/core/loading.tsx
+++ b/src/components/core/loading.tsx
@@ -2,7 +2,7 @@ import { Spinner } from "@/components/core/spinner";
 
 export const Loading = ({ message = "Loading..." }) => (
   <div className="ctw-space-x-2">
-    <span className="ctw-text-sm ctw-italic">{message}</span>
+    {message && <span className="ctw-text-sm ctw-italic">{message}</span>}
     <Spinner />
   </div>
 );

--- a/src/components/core/main.scss
+++ b/src/components/core/main.scss
@@ -51,7 +51,7 @@
   }
 
   .ctw-save-button:disabled {
-    @apply ctw-cursor-not-allowed ctw-opacity-70;
+    @apply ctw-pointer-events-none ctw-flex ctw-items-center ctw-justify-center ctw-opacity-70;
   }
 
   div.error .ctw-listbox-button {

--- a/src/components/core/modal-confirm-delete.tsx
+++ b/src/components/core/modal-confirm-delete.tsx
@@ -2,6 +2,7 @@ import { Resource } from "fhir/r4";
 import { useState } from "react";
 import { ErrorAlert } from "./alert";
 import { Modal, ModalProps } from "./modal";
+import { Spinner } from "./spinner";
 
 export type ModalConfirmDeleteProps = {
   resource: Resource;
@@ -18,16 +19,21 @@ export const ModalConfirmDelete = ({
   ...modalProps
 }: ModalConfirmDeleteProps) => {
   const [alert, setAlert] = useState<string>();
+  const [deleting, setDeleting] = useState(false);
 
   const onConfirm = async () => {
     try {
+      setDeleting(true);
       await onDelete();
+      setDeleting(false);
       onClose();
     } catch (err) {
+      setDeleting(false);
       setAlert(`Something went wrong. Please try again.`);
       throw err;
     }
   };
+
   return (
     <Modal onAfterClosed={() => setAlert(undefined)} {...modalProps}>
       {alert && <ErrorAlert header={alert} />}
@@ -51,10 +57,12 @@ export const ModalConfirmDelete = ({
         </button>
         <button
           type="button"
+          disabled={deleting}
           onClick={onConfirm}
-          className="ctw-btn-primary ctw-flex-1"
+          className="ctw-btn-primary ctw-save-button ctw-flex-1"
         >
-          Remove
+          {deleting ? "Removing..." : "Remove"}
+          {deleting && <Spinner className="ctw-ml-2 ctw-text-white" />}
         </button>
       </div>
     </Modal>

--- a/src/components/core/modal-confirm-delete.tsx
+++ b/src/components/core/modal-confirm-delete.tsx
@@ -19,16 +19,16 @@ export const ModalConfirmDelete = ({
   ...modalProps
 }: ModalConfirmDeleteProps) => {
   const [alert, setAlert] = useState<string>();
-  const [deleting, setDeleting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const onConfirm = async () => {
     try {
-      setDeleting(true);
+      setIsDeleting(true);
       await onDelete();
-      setDeleting(false);
+      setIsDeleting(false);
       onClose();
     } catch (err) {
-      setDeleting(false);
+      setIsDeleting(false);
       setAlert(`Something went wrong. Please try again.`);
       throw err;
     }
@@ -57,12 +57,12 @@ export const ModalConfirmDelete = ({
         </button>
         <button
           type="button"
-          disabled={deleting}
+          disabled={isDeleting}
           onClick={onConfirm}
           className="ctw-btn-primary ctw-save-button ctw-flex-1"
         >
-          {deleting ? "Removing..." : "Remove"}
-          {deleting && <Spinner className="ctw-ml-2 ctw-text-white" />}
+          {isDeleting ? "Removing..." : "Remove"}
+          {isDeleting && <Spinner className="ctw-ml-2 ctw-text-white" />}
         </button>
       </div>
     </Modal>

--- a/src/components/core/table/table-helpers.tsx
+++ b/src/components/core/table/table-helpers.tsx
@@ -1,4 +1,4 @@
-import { get, iteratee, ListIteratee, Many, orderBy } from "lodash";
+import { ListIteratee, orderBy } from "lodash";
 import { ReactNode } from "react";
 import { SortDir } from "@/utils/sort";
 import { isEmptyValue } from "@/utils/types";

--- a/src/fhir/action-helper.ts
+++ b/src/fhir/action-helper.ts
@@ -35,3 +35,49 @@ export async function createOrEditFhirResource(
     return err;
   }
 }
+
+export async function deleteMetaTags(
+  resource: Resource,
+  requestContext: CTWRequestContext,
+  tag: fhir4.Coding[]
+) {
+  const post = {
+    resourceType: "Parameters",
+    parameter: [
+      {
+        name: "meta",
+        valueMeta: {
+          tag,
+        },
+      },
+    ],
+  };
+
+  const { fhirClient } = requestContext;
+  await fhirClient.request(
+    `${resource.resourceType}/${resource.id}/$meta-delete`,
+    {
+      method: "POST",
+      body: JSON.stringify(post),
+      options: { headers: { "content-type": "application/json" } },
+    }
+  );
+}
+
+export async function deleteFhirResource(
+  resource: Resource,
+  requestContext: CTWRequestContext
+) {
+  const { fhirClient } = requestContext;
+
+  if (!resource.id) {
+    throw new Error(`Tried to delete a resource that hasn't been created yet.`);
+  }
+
+  await fhirClient.request(
+    `${resource.resourceType}/${resource.id}?_cascade=delete`,
+    {
+      method: "DELETE",
+    }
+  );
+}

--- a/src/fhir/basic.ts
+++ b/src/fhir/basic.ts
@@ -1,0 +1,77 @@
+import { FhirResource } from "fhir-kit-client";
+import { Basic } from "fhir/r4";
+import { filter } from "lodash";
+import { createOrEditFhirResource, deleteMetaTags } from "./action-helper";
+import { FHIRModel } from "./models/fhir-model";
+import { getUsersPractitionerReference } from "./practitioner";
+import {
+  SYSTEM_BASIC_RESOURCE_TYPE,
+  SYSTEM_ZUS_PROFILE_ACTION,
+} from "./system-urls";
+import { CTWRequestContext } from "@/components/core/ctw-context";
+
+export async function recordProfileAction<T extends fhir4.Resource>(
+  existingBasic: Basic | undefined,
+  model: FHIRModel<T>,
+  requestContext: CTWRequestContext,
+  profileAction: string
+) {
+  if (!model.id) {
+    throw new Error(
+      `Tried to ${profileAction} a resource that hasn't been created yet.`
+    );
+  }
+
+  if (!model.isSummaryResource) {
+    throw new Error(`Tried to ${profileAction} a patient record resource.`);
+  }
+
+  // First remove existing profile action meta tag first.
+  // We have to do this using special $meta-delete, otherwise
+  // meta tags get merged.
+  if (existingBasic) {
+    const tags = filter(existingBasic.meta?.tag, {
+      system: SYSTEM_ZUS_PROFILE_ACTION,
+    });
+    await deleteMetaTags(existingBasic, requestContext, tags);
+  }
+
+  const basic: fhir4.Basic = {
+    resourceType: "Basic",
+    id: existingBasic?.id,
+    meta: {
+      tag: [
+        {
+          system: SYSTEM_ZUS_PROFILE_ACTION,
+          code: profileAction,
+        },
+      ],
+    },
+    code: {
+      coding: [
+        {
+          system: SYSTEM_BASIC_RESOURCE_TYPE,
+          code: "adminact",
+          display: "Administrative Activity",
+        },
+      ],
+      text: "Administrative Activity",
+    },
+    subject: {
+      reference: `${model.resourceType}/${model.id}`,
+      type: model.resourceType,
+    },
+    author: await getUsersPractitionerReference(requestContext),
+  };
+
+  const response = (await createOrEditFhirResource(
+    basic,
+    requestContext
+  )) as FhirResource;
+
+  if (!response.id) {
+    throw new Error(
+      `Failed to ${profileAction} resource with id of ${model.id}`
+    );
+  }
+}

--- a/src/fhir/basic.ts
+++ b/src/fhir/basic.ts
@@ -33,7 +33,14 @@ export async function recordProfileAction<T extends fhir4.Resource>(
     const tags = filter(existingBasic.meta?.tag, {
       system: SYSTEM_ZUS_PROFILE_ACTION,
     });
-    await deleteMetaTags(existingBasic, requestContext, tags);
+
+    try {
+      await deleteMetaTags(existingBasic, requestContext, tags);
+    } catch (e) {
+      throw new Error(
+        `There was an error setting ${profileAction} for a resource.`
+      );
+    }
   }
 
   const basic: fhir4.Basic = {

--- a/src/fhir/conditions.ts
+++ b/src/fhir/conditions.ts
@@ -1,7 +1,6 @@
 import { SearchParams } from "fhir-kit-client";
 import { orderBy } from "lodash";
 import { CodePreference } from "./codeable-concept";
-import { getPractitioner } from "./practitioner";
 import {
   searchBuilderRecords,
   searchCommonRecords,
@@ -15,7 +14,6 @@ import {
   SYSTEM_SNOMED,
 } from "./system-urls";
 import { getAddConditionWithDefaults } from "@/components/content/forms/conditions";
-import { CTWRequestContext } from "@/components/core/ctw-context";
 import { useQueryWithPatient } from "@/components/core/patient-provider";
 import { ConditionModel } from "@/fhir/models/condition";
 import {
@@ -146,17 +144,3 @@ function filterAndSort(conditions: fhir4.Condition[]) {
     ["desc"]
   );
 }
-
-export const setRecorderField = async (
-  practitionerId: string,
-  requestContext: CTWRequestContext
-) => {
-  const practitioner = await getPractitioner(practitionerId, requestContext);
-  const display = practitioner.fullName;
-
-  return {
-    reference: `Practitioner/${practitionerId}`,
-    type: "Practitioner",
-    display,
-  };
-};

--- a/src/fhir/models/condition.ts
+++ b/src/fhir/models/condition.ts
@@ -50,6 +50,10 @@ export class ConditionModel extends FHIRModel<fhir4.Condition> {
       : false;
   }
 
+  get isArchived(): boolean {
+    return this.getBasicResourceByAction("archive") !== undefined;
+  }
+
   get asserter(): string | undefined {
     return this.resource.asserter?.display;
   }

--- a/src/fhir/models/fhir-model.ts
+++ b/src/fhir/models/fhir-model.ts
@@ -1,3 +1,6 @@
+import { Basic, Resource } from "fhir/r4";
+import { find } from "lodash";
+import { SYSTEM_SUMMARY, SYSTEM_ZUS_PROFILE_ACTION } from "../system-urls";
 import { ResourceMap } from "../types";
 
 export abstract class FHIRModel<T extends fhir4.Resource> {
@@ -5,17 +8,40 @@ export abstract class FHIRModel<T extends fhir4.Resource> {
 
   readonly includedResources?: ResourceMap;
 
-  constructor(resource: T, includedResources?: ResourceMap) {
+  readonly revIncludes?: Resource[];
+
+  constructor(
+    resource: T,
+    includedResources?: ResourceMap,
+    revIncludes?: Resource[]
+  ) {
     this.resource = resource;
     this.includedResources = includedResources;
+    this.revIncludes = revIncludes;
   }
 
   get id(): string {
     return this.resource.id || "";
   }
 
+  // Returns true if this resource is a summary/lens resource.
+  get isSummaryResource(): boolean {
+    return (
+      find(this.resource.meta?.tag, { system: SYSTEM_SUMMARY }) !== undefined
+    );
+  }
+
   get resourceType(): string {
     return this.resource.resourceType;
+  }
+
+  getBasicResourceByAction(profileAction: string): Basic | undefined {
+    return find(this.revIncludes, {
+      resourceType: "Basic",
+      meta: {
+        tag: [{ system: SYSTEM_ZUS_PROFILE_ACTION, code: profileAction }],
+      },
+    }) as Basic | undefined;
   }
 
   // Returns a string that would setup this model.

--- a/src/fhir/provenance.ts
+++ b/src/fhir/provenance.ts
@@ -1,15 +1,11 @@
-import { Provenance, Reference, Resource } from "fhir/r4";
-import { getPractitioner } from "./practitioner";
+import { Provenance, Resource } from "fhir/r4";
+import { getUsersPractitionerReference } from "./practitioner";
 import {
   SYSTEM_PROVENANCE_ACTIVITY_TYPE,
   SYSTEM_PROVENANCE_AGENT_TYPE,
 } from "./system-urls";
 import { CTWRequestContext } from "@/components/core/ctw-context";
-import {
-  claimsAuthEmail,
-  claimsBuilderName,
-  claimsPractitionerId,
-} from "@/utils/auth";
+import { claimsBuilderName } from "@/utils/auth";
 
 const ASSEMBLER_CODING = {
   system: SYSTEM_PROVENANCE_AGENT_TYPE,
@@ -46,25 +42,11 @@ export const createProvenance = async (
   const builderName = claimsBuilderName(requestContext.authToken);
   const versionId = parseInt(resource.meta?.versionId || "0", 10);
 
-  const practitionerId = claimsPractitionerId(requestContext.authToken);
-  let practitionerReference: Reference = {};
-  if (practitionerId) {
-    const practitioner = await getPractitioner(practitionerId, requestContext);
-    practitionerReference = {
-      reference: `Practitioner/${practitionerId}`,
-      display: practitioner.fullName,
-    };
-  } else {
-    practitionerReference = {
-      display: claimsAuthEmail(requestContext.authToken),
-    };
-  }
-
   const provenance: Provenance = {
     resourceType: "Provenance",
     agent: [
       {
-        who: practitionerReference,
+        who: await getUsersPractitionerReference(requestContext),
         onBehalfOf: { display: builderName },
       },
       {

--- a/src/fhir/system-urls.ts
+++ b/src/fhir/system-urls.ts
@@ -1,13 +1,25 @@
-export const SYSTEM_CCS =
-  "https://www.hcup-us.ahrq.gov/toolssoftware/ccsr/dxccsr.jsp";
+// HL7 / FHIR
 
+export const SYSTEM_BASIC_RESOURCE_TYPE = `http://terminology.hl7.org/CodeSystem/basic-resource-type`;
 export const SYSTEM_CONDITION_CLINICAL =
   "http://terminology.hl7.org/CodeSystem/condition-clinical";
-
 export const SYSTEM_CONDITION_VERIFICATION_STATUS =
   "http://terminology.hl7.org/CodeSystem/condition-ver-status";
+export const SYSTEM_MARITAL_STATUS =
+  "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus";
+export const SYSTEM_PROVENANCE_ACTIVITY_TYPE =
+  "http://terminology.hl7.org/3.1.0/CodeSystem-v3-DataOperation.html";
+export const SYSTEM_PROVENANCE_AGENT_TYPE =
+  "http://terminology.hl7.org/CodeSystem/provenance-participant-type";
+export const SYSTEM_RELATIONSHIP =
+  "http://terminology.hl7.org/CodeSystem/v2-0131";
+export const SYSTEM_TASK_STATUS =
+  "https://www.hl7.org/fhir/codesystem-task-status.html";
 
-export const SYSTEM_ENRICHMENT = "https://zusapi.com/terminology/enrichment";
+// CODE SYSTEMS
+
+export const SYSTEM_CCS =
+  "https://www.hcup-us.ahrq.gov/toolssoftware/ccsr/dxccsr.jsp";
 
 export const SYSTEM_ICD9 = "http://hl7.org/fhir/sid/icd-9";
 
@@ -17,38 +29,32 @@ export const SYSTEM_ICD10 = "http://hl7.org/fhir/sid/icd-10";
 
 export const SYSTEM_ICD10_CM = "http://hl7.org/fhir/sid/icd-10-cm";
 
-export const SYSTEM_MARITAL_STATUS =
-  "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus";
-
-export const SYSTEM_PRACTITIONER_ID = "https://zusapi.com/practitioner_id";
-
-export const SYSTEM_PROVENANCE_ACTIVITY_TYPE =
-  "http://terminology.hl7.org/3.1.0/CodeSystem-v3-DataOperation.html";
-
-export const SYSTEM_PROVENANCE_AGENT_TYPE =
-  "http://terminology.hl7.org/CodeSystem/provenance-participant-type";
-
-export const SYSTEM_RELATIONSHIP =
-  "http://terminology.hl7.org/CodeSystem/v2-0131";
-
 export const SYSTEM_RXNORM = "http://www.nlm.nih.gov/research/umls/rxnorm";
 
 export const SYSTEM_SNOMED = "http://snomed.info/sct";
 
-export const SYSTEM_SUMMARY = "https://zusapi.com/summary";
+// ZUS
 
-export const SYSTEM_TASK_STATUS =
-  "https://www.hl7.org/fhir/codesystem-task-status.html";
+export const SYSTEM_SUMMARY = "https://zusapi.com/summary";
 
 export const SYSTEM_ZUS_BUILDER_ID = "https://zusapi.com/builder_id";
 export const SYSTEM_ZUS_LENS = "https://zusapi.com/lens";
 export const SYSTEM_ZUS_OWNER = "https://zusapi.com/accesscontrol/owner";
+export const SYSTEM_ZUS_PRACTITIONER_ID = "https://zusapi.com/practitioner_id";
+export const SYSTEM_ZUS_PROFILE_ACTION = "https://zusapi.com/profile/action";
 export const SYSTEM_ZUS_THIRD_PARTY = "https://zusapi.com/thirdparty/source";
 export const SYSTEM_ZUS_UNIVERSAL_ID =
   "https://zusapi.com/fhir/identifier/universal-id";
 export const SYSTEM_ZUS_UPI_RECORD_TYPE =
   "https://zusapi.com/fhir/tag/upi-record-type";
 export const SYSTEM_ZUS_USER_TYPE = "https://zusapi.com/user_type";
+
+// ENRICHMENT
+
+export const SYSTEM_ENRICHMENT = "https://zusapi.com/terminology/enrichment";
+
+// LENS
+
 export const LENS_EXTENSION_MEDICATION_LAST_FILL_DATE =
   "https://zusapi.com/lens/extension/medicationLastFillDate";
 export const LENS_EXTENSION_MEDICATION_LAST_PRESCRIBED_DATE =
@@ -63,5 +69,8 @@ export const LENS_EXTENSION_MEDICATION_LAST_PRESCRIBER =
   "https://zusapi.com/lens/extension/medicationLastPrescriber";
 export const LENS_EXTENSION_AGGREGATED_FROM =
   "https://zusapi.com/lens/extension/aggregatedFrom";
+
+// MISC
+
 export const CTW_EXTENSION_LENS_AGGREGATED_FROM =
   "https://zusapi.com/ctw-component-library/extension/lensAggregatedFrom";

--- a/src/fhir/types.ts
+++ b/src/fhir/types.ts
@@ -9,6 +9,7 @@ export type ResourceType<T extends ResourceTypeString> = Extract<
   { resourceType: T }
 >;
 
-export type ResourceMap = { [key: string]: fhir4.Resource };
+export type ResourceMap = { [key: string]: fhir4.Resource | undefined };
+export type ResourceArrayMap = { [key: string]: fhir4.Resource[] | undefined };
 
 export type Tag = { system: string; code: string };

--- a/src/services/patient-history/patient-history.ts
+++ b/src/services/patient-history/patient-history.ts
@@ -1,4 +1,3 @@
-import { parseISO } from "date-fns";
 import { PatientRefreshHistoryMessage } from "./patient-history-types";
 import { getZusApiBaseUrl } from "@/api/urls";
 import { CTWRequestContext } from "@/components/core/ctw-context";

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,6 +1,4 @@
-import { cloneDeep } from "lodash";
 import { OperationOutcomeModel } from "..";
-import { ActionReturn } from "@/components/content/forms/types";
 import { FhirError, fhirErrorResponse, isFhirError } from "@/fhir/errors";
 import { isOperationOutcome } from "@/fhir/operation-outcome";
 


### PR DESCRIPTION
CTW-569

**NOTE TO REVIEWER: Best to review commit by commit**

Add `Archive` and `Un-Archive` menu options to other provider records "..." menu. Archiving for the first time will create a new `Basic` resource and associate the resource with the summary condition and the user performing the action. Subsequent un-archiving/re-archiving is done by updating the existing basic resource with the proper meta tags AND the current user's info. 

Additional changes:
* Add ESLint rule to prevent unused imports.
* Refactored how we fetch practitioner references.
* Delete modal now shows disabled remove button with spinner.

**New ... Menu for other records**
<img width="198" alt="Screen Shot 2022-12-05 at 3 36 09 PM" src="https://user-images.githubusercontent.com/1568246/205738173-b7aa2120-0863-4cd9-bac9-b66bc48bee47.png">
<img width="441" alt="Screen Shot 2022-12-05 at 3 36 33 PM" src="https://user-images.githubusercontent.com/1568246/205738153-6ca66ca8-8ac1-4314-aa7c-117110714bc5.png">

**Spinner while toggling archive**
<img width="1011" alt="Screen Shot 2022-12-05 at 3 12 15 PM" src="https://user-images.githubusercontent.com/1568246/205737869-46a705c4-6628-4ff5-90b4-fd7a4baf33f9.png">

**Remove modal now shows spinner as action is performed**
<img width="494" alt="Screen Shot 2022-12-05 at 3 11 41 PM" src="https://user-images.githubusercontent.com/1568246/205737859-ede1ddc5-9d49-4b69-bc86-a2ec6bdf61a5.png">
