### PR TITLE
logout button in App.tsx will now logout

### DIFF
--- a/src/SecuredApp.tsx
+++ b/src/SecuredApp.tsx
@@ -9,6 +9,7 @@ type SecuredAppProps = {
 const SecuredAppComponent = ({ AppComponent }: SecuredAppProps) => {
   const { getAccessTokenSilently, logout } = useAuth0();
   const [authToken, setAuthToken] = useState("");
+  const returnTo = new URL("login", window.location.origin).toString();
 
   useEffect(() => {
     const getToken = async () => {
@@ -21,7 +22,7 @@ const SecuredAppComponent = ({ AppComponent }: SecuredAppProps) => {
     <>
       <button
         type="button"
-        onClick={() => logout({ returnTo: window.location.origin })}
+        onClick={() => logout({ returnTo })}
         className="ctw-w-full ctw-cursor-pointer ctw-bg-transparent ctw-p-0 ctw-text-base ctw-outline-none"
       >
         Log Out


### PR DESCRIPTION
Previously when using the logout button in App.tsx we would see an auth0 error page. This PR changes the `returnTo` value to point at `/login` which is an allowed logout redirect for this app, resulting in the user landing at the auth0 login page for our app.

If in the future we find a use-case where this returnTo path doesn't work we could convert it into an env var.