### PR TITLE
CTW 582/Prescription Requests should show up before fills

### DIFF
--- a/src/components/content/medications/helpers.test.ts
+++ b/src/components/content/medications/helpers.test.ts
@@ -1,0 +1,167 @@
+import { pick } from "lodash/fp";
+import { sortMedHistory } from "./helpers";
+import { MedicationModel } from "@/fhir/models";
+
+describe("Medication Helpers", () => {
+  describe("sortMedHistory", () => {
+    it("should order by date", () => {
+      // Nothing complicated in this test. We want to see that our sort function
+      // puts the medication models in order by datetime.
+      const datesInOrder = [
+        "2022-09-23 10:00:00",
+        "2022-09-28 10:00:00",
+        "2022-09-28 11:00:00",
+        "2022-10-03 10:00:00",
+        "2022-10-03 17:00:00",
+        "2022-11-20 18:00:00",
+        "2022-11-20 19:00:00",
+      ];
+      const medications: MedicationModel[] = [
+        createDummyMedication("MedicationDispense", datesInOrder[0]),
+        createDummyMedication("MedicationRequest", datesInOrder[1]),
+        createDummyMedication("MedicationAdministration", datesInOrder[2]),
+        createDummyMedication("MedicationDispense", datesInOrder[3]),
+        createDummyMedication("MedicationStatement", datesInOrder[4]),
+        createDummyMedication("MedicationRequest", datesInOrder[5]),
+        createDummyMedication("MedicationStatement", datesInOrder[6]),
+      ];
+
+      const sorted = sortMedHistory(medications);
+      expect(sorted.map(pick(["resourceType", "date"]))).toEqual([
+        { resourceType: "MedicationStatement", date: datesInOrder[6] },
+        { resourceType: "MedicationRequest", date: datesInOrder[5] },
+        { resourceType: "MedicationStatement", date: datesInOrder[4] },
+        { resourceType: "MedicationDispense", date: datesInOrder[3] },
+        { resourceType: "MedicationAdministration", date: datesInOrder[2] },
+        { resourceType: "MedicationRequest", date: datesInOrder[1] },
+        { resourceType: "MedicationDispense", date: datesInOrder[0] },
+      ]);
+    });
+
+    it("should ignore time when sorting request/dispense", () => {
+      // This test is more complex. We want to see that our sort function can
+      // reorder medication models from the same date if the same medication
+      // was filled before it was ordered that day (as that makes no sense).
+      const medicationA = [{ code: "123", system: "example.com" }];
+      const medicationB = [{ code: "456", system: "example.com" }];
+      const medications: MedicationModel[] = [
+        // The request for medicationA was recorded 10 hours after dispense
+        createDummyMedication(
+          "MedicationRequest",
+          "2022-08-12 20:00:00",
+          medicationA
+        ),
+        createDummyMedication(
+          "MedicationDispense",
+          "2022-08-12 10:00:00",
+          medicationA
+        ),
+        // The request for medicationB is also out of order on same day
+        createDummyMedication(
+          "MedicationRequest",
+          "2022-08-12 19:00:00",
+          medicationB
+        ),
+        createDummyMedication(
+          "MedicationDispense",
+          "2022-08-12 08:00:00",
+          medicationB
+        ),
+        createDummyMedication("MedicationStatement", "2022-08-12 19:00:00"),
+      ];
+
+      const sorted = sortMedHistory(medications);
+      expect(sorted.map(pick(["resourceType", "date"]))).toEqual([
+        { resourceType: "MedicationStatement", date: "2022-08-12 19:00:00" },
+        { resourceType: "MedicationDispense", date: "2022-08-12 08:00:00" },
+        { resourceType: "MedicationRequest", date: "2022-08-12 19:00:00" },
+        { resourceType: "MedicationDispense", date: "2022-08-12 10:00:00" },
+        { resourceType: "MedicationRequest", date: "2022-08-12 20:00:00" },
+      ]);
+    });
+  });
+
+  it("should not reorder request/dispense from different days", () => {
+    // This test has out of order dispense then request, but we don't expect it
+    // to reorder them because they happen different dates. We likely won't see
+    // this happen, it's more to test the logic of the function.
+    const medicationA = [{ code: "123", system: "example.com" }];
+    const medicationB = [{ code: "456", system: "example.com" }];
+    const medications: MedicationModel[] = [
+      // The request for medicationA was recorded 10 hours after dispense
+      createDummyMedication(
+        "MedicationRequest",
+        "2022-08-12 20:00:00",
+        medicationA
+      ),
+      createDummyMedication(
+        "MedicationDispense",
+        "2022-08-11 10:00:00",
+        medicationA
+      ),
+      // The request for medicationB is also out of order on same day
+      createDummyMedication(
+        "MedicationRequest",
+        "2022-08-12 19:00:00",
+        medicationB
+      ),
+      createDummyMedication(
+        "MedicationDispense",
+        "2022-08-11 08:00:00",
+        medicationB
+      ),
+    ];
+
+    const sorted = sortMedHistory(medications);
+    expect(sorted.map(pick(["resourceType", "date"]))).toEqual([
+      { resourceType: "MedicationRequest", date: "2022-08-12 19:00:00" },
+      { resourceType: "MedicationRequest", date: "2022-08-12 20:00:00" },
+      { resourceType: "MedicationDispense", date: "2022-08-11 08:00:00" },
+      { resourceType: "MedicationDispense", date: "2022-08-11 10:00:00" },
+    ]);
+  });
+});
+
+function createDummyMedication(
+  resourceType: string,
+  date: string,
+  coding: { system: string; code: string }[] = []
+): MedicationModel {
+  switch (resourceType) {
+    case "MedicationRequest":
+      return new MedicationModel({
+        resourceType: "MedicationRequest",
+        intent: "order",
+        status: "active",
+        authoredOn: date,
+        subject: {},
+        medicationCodeableConcept: { coding },
+      });
+    case "MedicationDispense":
+      return new MedicationModel({
+        resourceType: "MedicationDispense",
+        status: "completed",
+        whenHandedOver: date,
+        medicationCodeableConcept: { coding },
+      });
+    case "MedicationAdministration":
+      return new MedicationModel({
+        id: "09876",
+        resourceType: "MedicationAdministration",
+        status: "in-progress",
+        subject: {},
+        effectivePeriod: {
+          start: date,
+        },
+      });
+    case "MedicationStatement":
+      return new MedicationModel({
+        resourceType: "MedicationStatement",
+        status: "active",
+        subject: {},
+        dateAsserted: date,
+      });
+    default:
+      throw new Error(`Unrecognized Medication type ${resourceType}`);
+  }
+}

--- a/src/components/content/medications/helpers.ts
+++ b/src/components/content/medications/helpers.ts
@@ -1,0 +1,76 @@
+import { get, groupBy, has, mapValues, orderBy, pipe } from "lodash/fp";
+import { dateToISO } from "@/fhir/formatters";
+import { MedicationModel } from "@/fhir/models";
+
+const getMedicationValue = (medication: MedicationModel) => {
+  const coding = get("resource.medicationCodeableConcept.coding.0", medication);
+  if (coding) {
+    return `${coding.system}_${coding.code}`;
+  }
+  return "";
+};
+const getDateValue = (medication: MedicationModel) => {
+  const uniformDate = new Date(medication.dateLocal ?? 0);
+  return dateToISO(uniformDate);
+};
+
+const getDateTimeValue = (medication: MedicationModel) => {
+  const uniformDate = new Date(medication.dateLocal ?? 0);
+  return uniformDate.getTime();
+};
+
+/**
+ * Sorts Medication models by date desc, insuring that med requests and med
+ * dispenses aren't out of order (need to request a med before filling it).
+ * - Group resources by date.
+ * - Map groups to tuples [resource, resourceType, order].
+ * - Iterate/Reduce over that list of tuples:
+ * ... - If we see a medRequest, cache mapping { [med]: order }.
+ * ... - If we see a medDispense, check for mapping of med in cache.
+ * ... - If we have a cache for that med, then the medDispense is out of order,
+ * ... ... and we can fix it by changing its order value to cache[med] + 0.5.
+ * - Recombine the sorted resources.
+ */
+export const sortMedHistory = (resources: MedicationModel[]) => {
+  const createTuples = (medication: MedicationModel, index: number) => [
+    medication,
+    medication.resourceType,
+    index,
+  ];
+
+  const sortedInGroups = pipe(
+    groupBy(getDateValue),
+    mapValues((group) => orderBy(getDateTimeValue, "desc", group)),
+    mapValues((group) => group.map(createTuples)),
+    mapValues((group: [MedicationModel, string, number][] = []) => {
+      const cache: Record<string, number> = {};
+
+      const updated = group.map(([model, type, sortOrder]) => {
+        const medicationName = getMedicationValue(model);
+        if (type === "MedicationRequest") {
+          cache[medicationName] = sortOrder;
+        } else if (
+          type === "MedicationDispense" &&
+          has(medicationName, cache)
+        ) {
+          // This MedicationDispense is out of order.
+          return { model, type, sortOrder: sortOrder + 0.5 };
+        }
+
+        return { model, type, sortOrder };
+      });
+
+      return orderBy(get("sortOrder"), "desc", updated).map(get("model"));
+    })
+  )(resources);
+
+  const sortedKeys = orderBy(
+    (key) => new Date(key).getTime(),
+    "desc",
+    Object.keys(sortedInGroups)
+  );
+
+  return sortedKeys
+    .map((key) => sortedInGroups[key])
+    .reduce((acc, group): MedicationModel[] => [...acc, ...group]);
+};

--- a/src/components/content/medications/helpers.ts
+++ b/src/components/content/medications/helpers.ts
@@ -39,6 +39,9 @@ const getDateTimeValue = (medication: MedicationModel) => {
  * - Recombine the sorted resources.
  */
 export const sortMedHistory = (resources: MedicationModel[]) => {
+  if (resources.length === 0) {
+    return resources;
+  }
   const createTuples = (medication: MedicationModel, index: number) => [
     medication,
     medication.resourceType,

--- a/src/components/content/medications/medication-history.tsx
+++ b/src/components/content/medications/medication-history.tsx
@@ -1,5 +1,6 @@
 import { capitalize, compact } from "lodash";
 import { useEffect, useState } from "react";
+import { sortMedHistory } from "./helpers";
 import { CollapsibleDataListProps } from "@/components/core/collapsible-data-list";
 import { CollapsibleDataListStack } from "@/components/core/collapsible-data-list-stack";
 import { Loading } from "@/components/core/loading";
@@ -27,7 +28,7 @@ export function MedicationHistory({ medication }: MedicationHistoryProps) {
   useEffect(() => {
     if (medHistoryQuery.data) {
       const { medications } = medHistoryQuery.data;
-      setEntries(medications.map(createMedicationDetailsCard));
+      setEntries(sortMedHistory(medications).map(createMedicationDetailsCard));
     }
   }, [medHistoryQuery.data]);
 

--- a/src/components/core/form/drawer-form.tsx
+++ b/src/components/core/form/drawer-form.tsx
@@ -82,7 +82,6 @@ export const DrawerForm = <T,>({
     try {
       response = await action(formResult.data, getRequestContext);
     } catch (e) {
-      console.warn(e);
       responseIsSuccess = false;
       requestErrors = [];
     }


### PR DESCRIPTION
Sort the med history list. For each day, if there is a MedicationRequest that appears exactly at or after the corresponding med dispense then we should shift the order of the MedicationRequest in the history list to come before the dispense.