### PR TITLE
CTW-621/Add to Record button on other provider meds

### DIFF
--- a/.changeset/fuzzy-seahorses-shop.md
+++ b/.changeset/fuzzy-seahorses-shop.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Created an "Add to Record" button in the hamburger menu of <OtherProviderMedsTable/>

--- a/src/components/content/forms/medications.tsx
+++ b/src/components/content/forms/medications.tsx
@@ -124,7 +124,7 @@ export const getMedicationFormData = (
       <MedicationsAutoComplete
         readonly={readonly}
         {...inputProps}
-        defaultCoding={{}}
+        defaultCoding={medication.rxNormCoding ?? {}}
       />
     ),
   },

--- a/src/components/content/forms/medications.tsx
+++ b/src/components/content/forms/medications.tsx
@@ -1,4 +1,5 @@
 import type { FormEntry } from "../../core/form/drawer-form-with-fields";
+import { format } from "date-fns";
 import { z } from "zod";
 import { MedicationsAutoComplete } from "./medications-autocomplete";
 import { CTWRequestContext } from "@/components/core/ctw-context";
@@ -111,7 +112,7 @@ export const getMedicationFormData = (
   },
   {
     label: "Date Asserted",
-    value: medication.dateAsserted,
+    value: medication.dateAsserted ?? format(new Date(), "P"),
     field: "dateAsserted",
     readonly: true,
   },

--- a/src/components/content/medications/add-new-med-drawer.tsx
+++ b/src/components/content/medications/add-new-med-drawer.tsx
@@ -1,4 +1,5 @@
 import { format } from "date-fns";
+import type { MedicationStatement } from "fhir/r4";
 import { ReactElement } from "react";
 import {
   createMedicationStatement,
@@ -12,22 +13,30 @@ import { MedicationStatementModel } from "@/fhir/models/medication-statement";
 type Props = {
   isOpen: boolean;
   handleOnClose: () => void;
-  children: ReactElement;
+  children?: ReactElement;
+  medication?: MedicationStatement;
 };
 
-export const AddNewMedDrawer = ({ isOpen, handleOnClose, children }: Props) => {
+export const AddNewMedDrawer = ({
+  isOpen,
+  handleOnClose,
+  medication,
+  children,
+}: Props) => {
   const patient = usePatient();
 
   const createMedData = getMedicationFormData(
-    new MedicationStatementModel({
-      resourceType: "MedicationStatement",
-      status: "active",
-      subject: {
-        reference: `Patient/${patient.data?.id}`,
-        display: patient.data?.display,
-      },
-      dateAsserted: format(new Date(), "yyyy-MM-dd"),
-    })
+    new MedicationStatementModel(
+      medication ?? {
+        resourceType: "MedicationStatement",
+        status: "active",
+        subject: {
+          reference: `Patient/${patient.data?.id}`,
+          display: patient.data?.display,
+        },
+        dateAsserted: format(new Date(), "yyyy-MM-dd"),
+      }
+    )
   );
 
   if (!patient.data?.UPID) {

--- a/src/components/content/medications/medication-history.stories.tsx
+++ b/src/components/content/medications/medication-history.stories.tsx
@@ -3,6 +3,8 @@ import {
   MedicationHistory,
   MedicationHistoryProps,
 } from "./medication-history";
+import { otherProviderMedications } from "./story-helpers/mocks/other-provider-medications";
+import { providerMedications } from "./story-helpers/mocks/provider-medications";
 import { setupMedicationMocks } from "./story-helpers/mocks/requests";
 import { aggregatedFromMedStatement } from "@/components/content/medications/story-helpers/mocks/aggregated-from-med-statement";
 import { CTWProvider } from "@/components/core/ctw-provider";
@@ -28,11 +30,11 @@ export default {
       </CTWProvider>
     ),
   ],
-  ...setupMedicationMocks(),
 } as Meta<Props>;
 
 export const Basic: StoryObj<Props> = {
   args: {
     medication: medicationStatementModel,
   },
+  ...setupMedicationMocks({ providerMedications, otherProviderMedications }),
 };

--- a/src/components/content/medications/other-provider-meds-table.stories.tsx
+++ b/src/components/content/medications/other-provider-meds-table.stories.tsx
@@ -4,6 +4,8 @@ import {
   OtherProviderMedsTable,
   OtherProviderMedsTableProps,
 } from "@/components/content/medications/other-provider-meds-table";
+import { otherProviderMedications } from "@/components/content/medications/story-helpers/mocks/other-provider-medications";
+import { providerMedications } from "@/components/content/medications/story-helpers/mocks/provider-medications";
 import { CTWProvider } from "@/components/core/ctw-provider";
 import { PatientProvider } from "@/components/core/patient-provider";
 import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
@@ -22,7 +24,6 @@ export default {
       </CTWProvider>
     ),
   ],
-  ...setupMedicationMocks(),
 } as Meta<Props>;
 
 export const Basic: StoryObj<Props> = {
@@ -30,4 +31,5 @@ export const Basic: StoryObj<Props> = {
     sortColumn: "display",
     sortOrder: "asc",
   },
+  ...setupMedicationMocks({ providerMedications, otherProviderMedications }),
 };

--- a/src/components/content/medications/other-provider-meds-table.tsx
+++ b/src/components/content/medications/other-provider-meds-table.tsx
@@ -2,6 +2,7 @@ import { get, pipe, toLower } from "lodash/fp";
 import { useEffect, useState } from "react";
 import { MedicationDrawer } from "@/components/content/medication-drawer";
 import { MedicationsTableBase } from "@/components/content/medications-table-base";
+import { AddNewMedDrawer } from "@/components/content/medications/add-new-med-drawer";
 import { MedicationStatementModel } from "@/fhir/models/medication-statement";
 import { useQueryAllPatientMedications } from "@/hooks/use-medications";
 import { sort, SortDir } from "@/utils/sort";
@@ -26,7 +27,8 @@ export function OtherProviderMedsTable({
   const [medicationModels, setMedicationModels] = useState<
     MedicationStatementModel[]
   >([]);
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [medDrawerOpen, setMedicationDrawerOpen] = useState(false);
+  const [addNewMedDrawerOpen, setAddNewMedDrawerOpen] = useState(false);
   const [selectedMedication, setSelectedMedication] =
     useState<MedicationStatementModel>();
   const { otherProviderMedications, isLoading } =
@@ -34,7 +36,12 @@ export function OtherProviderMedsTable({
 
   function openMedicationDrawer(row: MedicationStatementModel) {
     setSelectedMedication(row);
-    setDrawerOpen(true);
+    setMedicationDrawerOpen(true);
+  }
+
+  function openAddNewMedicationDrawer(row: MedicationStatementModel) {
+    setSelectedMedication(row);
+    setAddNewMedDrawerOpen(true);
   }
 
   useEffect(() => {
@@ -56,12 +63,23 @@ export function OtherProviderMedsTable({
               openMedicationDrawer(medication);
             },
           },
+          {
+            name: "Add to Record",
+            action: async () => {
+              openAddNewMedicationDrawer(medication);
+            },
+          },
         ]}
       />
       <MedicationDrawer
         medication={selectedMedication}
-        isOpen={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
+        isOpen={medDrawerOpen}
+        onClose={() => setMedicationDrawerOpen(false)}
+      />
+      <AddNewMedDrawer
+        medication={selectedMedication?.resource}
+        isOpen={addNewMedDrawerOpen}
+        handleOnClose={() => setAddNewMedDrawerOpen(false)}
       />
     </>
   );

--- a/src/components/content/medications/patient-medications.stories.tsx
+++ b/src/components/content/medications/patient-medications.stories.tsx
@@ -4,6 +4,8 @@ import {
   PatientMedications,
   PatientMedicationsProps,
 } from "@/components/content/medications/patient-medications";
+import { otherProviderMedications } from "@/components/content/medications/story-helpers/mocks/other-provider-medications";
+import { providerMedications } from "@/components/content/medications/story-helpers/mocks/provider-medications";
 import { CTWProvider } from "@/components/core/ctw-provider";
 import { PatientProvider } from "@/components/core/patient-provider";
 import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
@@ -22,7 +24,8 @@ export default {
       </CTWProvider>
     ),
   ],
-  ...setupMedicationMocks(),
 } as Meta<Props>;
 
-export const Basic: StoryObj<Props> = {};
+export const Basic: StoryObj<Props> = {
+  ...setupMedicationMocks({ providerMedications, otherProviderMedications }),
+};

--- a/src/components/content/medications/provider-meds-table.stories.tsx
+++ b/src/components/content/medications/provider-meds-table.stories.tsx
@@ -4,6 +4,8 @@ import {
   ProviderMedsTable,
   ProviderMedsTableProps,
 } from "@/components/content/medications/provider-meds-table";
+import { otherProviderMedications } from "@/components/content/medications/story-helpers/mocks/other-provider-medications";
+import { providerMedications } from "@/components/content/medications/story-helpers/mocks/provider-medications";
 import { CTWProvider } from "@/components/core/ctw-provider";
 import { PatientProvider } from "@/components/core/patient-provider";
 import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
@@ -13,6 +15,10 @@ type Props = ProviderMedsTableProps;
 export default {
   tags: ["docsPage"],
   component: ProviderMedsTable,
+  args: {
+    sortColumn: "display",
+    sortOrder: "asc",
+  },
   decorators: [
     (Story, { args }) => (
       <CTWProvider env="dev" authToken="12345" builderId="12345">
@@ -22,12 +28,8 @@ export default {
       </CTWProvider>
     ),
   ],
-  ...setupMedicationMocks(),
 } as Meta<Props>;
 
 export const Basic: StoryObj<Props> = {
-  args: {
-    sortColumn: "display",
-    sortOrder: "asc",
-  },
+  ...setupMedicationMocks({ providerMedications, otherProviderMedications }),
 };

--- a/src/components/content/medications/story-helpers/mocks/other-provider-medications.ts
+++ b/src/components/content/medications/story-helpers/mocks/other-provider-medications.ts
@@ -1,4 +1,4 @@
-export const otherProviderMedications = {
+export const otherProviderMedications: fhir4.Bundle = {
   resourceType: "Bundle",
   id: "7c7a1c16",
   type: "searchset",

--- a/src/components/content/medications/story-helpers/mocks/provider-medications.ts
+++ b/src/components/content/medications/story-helpers/mocks/provider-medications.ts
@@ -1,4 +1,4 @@
-export const providerMedications = {
+export const providerMedications: fhir4.Bundle = {
   resourceType: "Bundle",
   id: "0b13191b",
   meta: {

--- a/src/components/core/form/drawer-form.tsx
+++ b/src/components/core/form/drawer-form.tsx
@@ -82,7 +82,6 @@ export const DrawerForm = <T,>({
     try {
       response = await action(formResult.data, getRequestContext);
     } catch (e) {
-      console.warn(e);
       responseIsSuccess = false;
       requestErrors = [];
     }

--- a/src/fhir/medication.ts
+++ b/src/fhir/medication.ts
@@ -55,6 +55,16 @@ export function getIdentifyingRxNormCode(
   medication: Medication,
   includedResources?: ResourceMap
 ): string | undefined {
+  return getIdentifyingRxNormCoding(medication, includedResources)?.code;
+}
+
+/**
+ * Gets the CodeableConcept.Coding for the pass in medication.
+ */
+export function getIdentifyingRxNormCoding(
+  medication: Medication,
+  includedResources?: ResourceMap
+): fhir4.Coding | undefined {
   const codeableConcept = getMedicationCodeableConcept(
     medication,
     includedResources
@@ -76,7 +86,7 @@ export function getIdentifyingRxNormCode(
             e.valueString &&
             excludedExtensions.includes(e.valueString)
         ))
-  )?.code;
+  );
 }
 
 // Returns the organization name of any performer for the medication.

--- a/src/fhir/models/medication-statement.ts
+++ b/src/fhir/models/medication-statement.ts
@@ -5,6 +5,7 @@ import { codeableConceptLabel } from "@/fhir/codeable-concept";
 import { dateToISO, formatDateISOToLocal } from "@/fhir/formatters";
 import {
   getIdentifyingRxNormCode,
+  getIdentifyingRxNormCoding,
   getMedicationCodeableConcept,
   patientStatus,
 } from "@/fhir/medication";
@@ -68,6 +69,10 @@ export class MedicationStatementModel extends FHIRModel<fhir4.MedicationStatemen
     return codeableConceptLabel(
       getMedicationCodeableConcept(this.resource, this.includedResources)
     );
+  }
+
+  get rxNormCoding() {
+    return getIdentifyingRxNormCoding(this.resource, this.includedResources);
   }
 
   get dosage(): string | undefined {


### PR DESCRIPTION
Created an "Add to Record" button in the hamburger menu of `<OtherProviderMedsTable/>`.

Added to storybook (based on conditions mocked cache that @WesleyKapow did) so when someone adds an "other provider" med to their record in storybook, that change is updated in their provider meds table. Note: you will only see this happen when looking at the  `<PatientMedications />` story as the `<OtherProviderMedsTable />` story doesn't show the `<ProviderMedsTable />` and the cache doesn't persist story to story.