### PR TITLE
CTW-589 Hover Menu

### DIFF
--- a/src/components/content/conditions-table-base.tsx
+++ b/src/components/content/conditions-table-base.tsx
@@ -1,5 +1,5 @@
-import { DotsHorizontalIcon } from "@heroicons/react/outline";
-import { DropdownMenu, MenuItem } from "../core/dropdown-menu";
+import { ReactElement } from "react";
+import { MenuItem } from "../core/dropdown-menu";
 import { Table, TableBaseProps } from "../core/table/table";
 import { TableColumn } from "../core/table/table-helpers";
 import { ConditionModel } from "@/fhir/models/condition";
@@ -7,6 +7,7 @@ import { ConditionModel } from "@/fhir/models/condition";
 export type ConditionsTableBaseProps = {
   className?: string;
   conditions: ConditionModel[];
+  onRowClick?: (condition: ConditionModel) => Promise<void>;
   rowActions: (condition: ConditionModel) => MenuItem[];
   readOnly: boolean;
 } & TableBaseProps<ConditionModel>;
@@ -14,6 +15,7 @@ export type ConditionsTableBaseProps = {
 export function ConditionsTableBase({
   className,
   conditions,
+  onRowClick,
   rowActions,
   readOnly,
   sort = { columnTitle: "Last Recorded", dir: "desc" },
@@ -64,22 +66,32 @@ export function ConditionsTableBase({
     },
   ];
 
+  let rowSibling: (condition: ConditionModel) => ReactElement = (condition) => (
+    <></>
+  );
   if (!readOnly) {
-    columns.push({
-      className: "ctw-table-action-column",
-      render: (condition: ConditionModel) => (
-        <DropdownMenu menuItems={rowActions(condition)}>
-          <DotsHorizontalIcon className="ctw-w-5" />
-        </DropdownMenu>
-      ),
-    });
+    rowSibling = (condition: ConditionModel) => (
+      <div className="ctw-invisible ctw-absolute ctw-right-0 ctw-space-x-2 ctw-px-4 group-hover:ctw-visible">
+        {rowActions(condition).map((rowAction) => (
+          <button
+            type="button"
+            className="ctw-btn-primary ctw-z-50"
+            onClick={rowAction.action}
+          >
+            {rowAction.name}
+          </button>
+        ))}
+      </div>
+    );
   }
 
   return (
     <Table
       className={className}
       records={conditions}
+      onRowClick={onRowClick}
       columns={columns}
+      rowSibling={rowSibling}
       sort={sort}
       onSort={onSort}
       {...tableProps}

--- a/src/components/content/conditions-table-base.tsx
+++ b/src/components/content/conditions-table-base.tsx
@@ -1,4 +1,3 @@
-import { ReactElement } from "react";
 import { MenuItem } from "../core/dropdown-menu";
 import { Table, TableBaseProps } from "../core/table/table";
 import { TableColumn } from "../core/table/table-helpers";
@@ -66,23 +65,24 @@ export function ConditionsTableBase({
     },
   ];
 
-  let rowSibling: (condition: ConditionModel) => ReactElement = (condition) => (
-    <></>
-  );
   if (!readOnly) {
-    rowSibling = (condition: ConditionModel) => (
-      <div className="ctw-invisible ctw-absolute ctw-right-0 ctw-space-x-2 ctw-px-4 group-hover:ctw-visible">
-        {rowActions(condition).map((rowAction) => (
-          <button
-            type="button"
-            className="ctw-btn-primary ctw-z-50"
-            onClick={rowAction.action}
-          >
-            {rowAction.name}
-          </button>
-        ))}
-      </div>
-    );
+    columns.push({
+      className: "ctw-table-action-column",
+      render: (condition: ConditionModel) => (
+        <div className="ctw-invisible ctw-absolute ctw-right-0 ctw-space-x-2 ctw-px-4 group-hover:ctw-visible">
+          {rowActions(condition).map((rowAction) => (
+            <button
+              key={rowAction.name}
+              type="button"
+              className="ctw-btn-primary ctw-z-50"
+              onClick={rowAction.action}
+            >
+              {rowAction.name}
+            </button>
+          ))}
+        </div>
+      ),
+    });
   }
 
   return (
@@ -91,7 +91,6 @@ export function ConditionsTableBase({
       records={conditions}
       onRowClick={onRowClick}
       columns={columns}
-      rowSibling={rowSibling}
       sort={sort}
       onSort={onSort}
       {...tableProps}

--- a/src/components/content/conditions-table-base.tsx
+++ b/src/components/content/conditions-table-base.tsx
@@ -8,14 +8,14 @@ export type ConditionsTableBaseProps = {
   className?: string;
   conditions: ConditionModel[];
   rowActions: (condition: ConditionModel) => MenuItem[];
-  hideMenu: boolean;
+  readOnly: boolean;
 } & TableBaseProps<ConditionModel>;
 
 export function ConditionsTableBase({
   className,
   conditions,
   rowActions,
-  hideMenu,
+  readOnly,
   sort = { columnTitle: "Last Recorded", dir: "desc" },
   onSort,
   ...tableProps
@@ -64,7 +64,7 @@ export function ConditionsTableBase({
     },
   ];
 
-  if (!hideMenu) {
+  if (!readOnly) {
     columns.push({
       className: "ctw-table-action-column",
       render: (condition: ConditionModel) => (

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -278,18 +278,15 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
                 )}
               </>
             }
+            onRowClick={async (condition) => {
+              setHistoryDrawerIsOpen(true);
+              setSelectedCondition(condition);
+            }}
             rowActions={(condition) => [
               {
                 name: "Edit",
                 action: async () => {
                   handleEditCondition(condition);
-                },
-              },
-              {
-                name: "View History",
-                action: async () => {
-                  setHistoryDrawerIsOpen(true);
-                  setSelectedCondition(condition);
                 },
               },
               {
@@ -328,18 +325,15 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
               }
               readOnly={readOnly}
               message={otherProviderRecordMessage}
+              onRowClick={async (condition) => {
+                setHistoryDrawerIsOpen(true);
+                setSelectedCondition(condition);
+              }}
               rowActions={(condition) => [
                 {
                   name: "Add",
                   action: async () => {
                     handleAddOtherProviderCondition(condition);
-                  },
-                },
-                {
-                  name: "View History",
-                  action: async () => {
-                    setHistoryDrawerIsOpen(true);
-                    setSelectedCondition(condition);
                   },
                 },
                 {

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -267,7 +267,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
             stacked={breakpoints.sm}
             conditions={patientRecords}
             isLoading={patientRecordsResponse.isLoading}
-            hideMenu={readOnly}
+            readOnly={readOnly}
             sort={sort}
             onSort={(newSort) => setSort(newSort)}
             message={
@@ -326,7 +326,7 @@ export function Conditions({ className, readOnly = false }: ConditionsProps) {
                 otherProviderRecordsResponse.isLoading ||
                 patientRecordsResponse.isLoading
               }
-              hideMenu={readOnly}
+              readOnly={readOnly}
               message={otherProviderRecordMessage}
               rowActions={(condition) => [
                 {

--- a/src/components/content/medications-table-base.tsx
+++ b/src/components/content/medications-table-base.tsx
@@ -10,7 +10,7 @@ import { useBreakpoints } from "@/hooks/use-breakpoints";
 export type MedicationsTableBaseProps<T extends MinRecordItem> = {
   medicationStatements: MedicationStatementModel[];
   rowActions?: (condition: MedicationStatementModel) => MenuItem[];
-  hideMenu?: boolean;
+  readOnly?: boolean;
   className?: string;
   children?: ReactNode;
 } & TableBaseProps<MedicationStatementModel>;
@@ -19,7 +19,7 @@ export const MedicationsTableBase = ({
   children,
   className = "",
   rowActions,
-  hideMenu = false,
+  readOnly = false,
   medicationStatements,
   ...tableProps
 }: MedicationsTableBaseProps<MedicationStatementModel>) => {
@@ -62,7 +62,7 @@ export const MedicationsTableBase = ({
     },
   ]) as TableColumn<MedicationStatementModel>[];
 
-  if (!hideMenu && isFunction(rowActions)) {
+  if (!readOnly && isFunction(rowActions)) {
     columns.push({
       className: "ctw-table-action-column",
       render: (medication) => (

--- a/src/components/core/table/table-full-length-row.tsx
+++ b/src/components/core/table/table-full-length-row.tsx
@@ -1,13 +1,16 @@
+import cx from "classnames";
 import { ReactNode } from "react";
 
 export const TableFullLengthRow = ({
   children,
   colSpan,
+  className,
 }: {
   children: ReactNode;
   colSpan: number;
+  className?: cx.Argument;
 }) => (
-  <tr>
+  <tr className={cx(className)}>
     <td className="ctw-table-full-length-row" colSpan={colSpan}>
       {children}
     </td>

--- a/src/components/core/table/table-rows.tsx
+++ b/src/components/core/table/table-rows.tsx
@@ -19,7 +19,6 @@ export const TableRows = <T extends MinRecordItem>({
   columns,
   isLoading,
   emptyMessage,
-  rowSibling,
   handleRowClick,
 }: TableRowsProps<T>) => {
   if (isLoading) {
@@ -50,7 +49,8 @@ export const TableRows = <T extends MinRecordItem>({
           })}
           key={record.id}
           onClick={(event) => {
-            if (event.target.nodeName === "BUTTON") {
+            // Cast because the event target is always a Node.
+            if ((event.target as Node).nodeName === "BUTTON") {
               event.preventDefault();
               event.stopPropagation();
             } else if (handleRowClick) handleRowClick(record);
@@ -64,7 +64,6 @@ export const TableRows = <T extends MinRecordItem>({
               index={index}
             />
           ))}
-          {rowSibling && rowSibling(record)}
         </tr>
       ))}
     </>

--- a/src/components/core/table/table-rows.tsx
+++ b/src/components/core/table/table-rows.tsx
@@ -11,6 +11,7 @@ type TableRowsProps<T extends MinRecordItem> = {
   isLoading: boolean;
   emptyMessage: string | ReactElement;
   handleRowClick?: (record: T) => void;
+  rowSibling?: (record: T) => ReactElement;
 };
 
 export const TableRows = <T extends MinRecordItem>({
@@ -18,6 +19,7 @@ export const TableRows = <T extends MinRecordItem>({
   columns,
   isLoading,
   emptyMessage,
+  rowSibling,
   handleRowClick,
 }: TableRowsProps<T>) => {
   if (isLoading) {
@@ -43,12 +45,15 @@ export const TableRows = <T extends MinRecordItem>({
     <>
       {records.map((record) => (
         <tr
-          className={cx({
+          className={cx("ctw-group", {
             "ctw-cursor-pointer": typeof handleRowClick === "function",
           })}
           key={record.id}
-          onClick={() => {
-            if (handleRowClick) handleRowClick(record);
+          onClick={(event) => {
+            if (event.target.nodeName === "BUTTON") {
+              event.preventDefault();
+              event.stopPropagation();
+            } else if (handleRowClick) handleRowClick(record);
           }}
         >
           {columns.map((column, index) => (
@@ -59,6 +64,7 @@ export const TableRows = <T extends MinRecordItem>({
               index={index}
             />
           ))}
+          {rowSibling && rowSibling(record)}
         </tr>
       ))}
     </>

--- a/src/components/core/table/table.tsx
+++ b/src/components/core/table/table.tsx
@@ -22,7 +22,6 @@ export type TableProps<T extends MinRecordItem> = {
   showTableHead?: boolean;
   stacked?: boolean;
   onRowClick?: (record: T) => void;
-  rowSibling?: (record: T) => ReactElement;
   sort?: TableSort;
   onSort?: (sort: TableSort) => void;
 };
@@ -40,7 +39,6 @@ export const Table = <T extends MinRecordItem>({
   message = "No records found",
   showTableHead = true,
   stacked,
-  rowSibling,
   sort,
   onSort,
   onRowClick,
@@ -118,7 +116,6 @@ export const Table = <T extends MinRecordItem>({
                 columns={columns}
                 isLoading={isLoading}
                 emptyMessage={message}
-                rowSibling={rowSibling}
               />
             </tbody>
           </table>

--- a/src/components/core/table/table.tsx
+++ b/src/components/core/table/table.tsx
@@ -21,7 +21,8 @@ export type TableProps<T extends MinRecordItem> = {
   message?: string | ReactElement;
   showTableHead?: boolean;
   stacked?: boolean;
-  handleRowClick?: (record: T) => void;
+  onRowClick?: (record: T) => void;
+  rowSibling?: (record: T) => ReactElement;
   sort?: TableSort;
   onSort?: (sort: TableSort) => void;
 };
@@ -39,9 +40,10 @@ export const Table = <T extends MinRecordItem>({
   message = "No records found",
   showTableHead = true,
   stacked,
+  rowSibling,
   sort,
   onSort,
-  handleRowClick,
+  onRowClick,
 }: TableProps<T>) => {
   const tableRef = useRef<HTMLTableElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -112,10 +114,11 @@ export const Table = <T extends MinRecordItem>({
             <tbody>
               <TableRows
                 records={sortedRecords.slice(0, count)}
-                handleRowClick={handleRowClick}
+                handleRowClick={onRowClick}
                 columns={columns}
                 isLoading={isLoading}
                 emptyMessage={message}
+                rowSibling={rowSibling}
               />
             </tbody>
           </table>


### PR DESCRIPTION
CTW-589

Current state:
- On hover, the edit and delete buttons appear
- Clicking the buttons opens the correct respective drawer
- Clicking on the row opens the Condition History

Still needs work:
- The hover menu doesn't have a gradient background
- The buttons don't have customizable renders (they're styled the same). I think there should be a HoverMenuButton type that defines the button name, action, and an optional render function if there's a special way of styling it.