### PR TITLE
Adding UPID to CPR query

### DIFF
--- a/.changeset/tall-islands-tickle.md
+++ b/.changeset/tall-islands-tickle.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Adding patient UPID to queries for medication data that may span builders, this triggers "CPR mode" in ODS.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "0.30.4",
+  "version": "0.32.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "0.30.4",
+      "version": "0.32.0",
       "dependencies": {
         "@headlessui/react": "^1.7.3",
         "@heroicons/react": "^1.0.6",

--- a/src/components/content/medications/add-new-med-drawer.tsx
+++ b/src/components/content/medications/add-new-med-drawer.tsx
@@ -39,10 +39,6 @@ export const AddNewMedDrawer = ({
     )
   );
 
-  if (!patient.data?.UPID) {
-    return null;
-  }
-
   return (
     <>
       {children}

--- a/src/fhir/conditions.ts
+++ b/src/fhir/conditions.ts
@@ -70,7 +70,7 @@ export function usePatientConditions() {
           "Condition",
           requestContext,
           {
-            patientUPID: patient.UPID as string,
+            patientUPID: patient.UPID,
           }
         );
         return filterAndSort(setupConditionModels(conditions, bundle));
@@ -94,7 +94,7 @@ export function useOtherProviderConditions() {
           requestContext,
           {
             _revinclude: "Basic:subject",
-            patientUPID: patient.UPID as string,
+            patientUPID: patient.UPID,
           }
         );
         return filterAndSort(setupConditionModels(conditions, bundle));
@@ -119,7 +119,7 @@ export function useConditionHistory(condition?: ConditionModel) {
         );
 
         const searchParams: SearchParams = {
-          patientUPID: patient.UPID as string,
+          patientUPID: patient.UPID,
           _include: ["Condition:patient", "Condition:encounter"],
           "_include:iterate": "Patient:organization",
         };

--- a/src/fhir/medications.ts
+++ b/src/fhir/medications.ts
@@ -104,7 +104,7 @@ export async function getBuilderMedications(
       "MedicationStatement",
       requestContext,
       {
-        patientUPID: patient.UPID as string,
+        patientUPID: patient.UPID,
         _include: "MedicationStatement:medication",
         ...omitClientFilters(searchFilters),
       }
@@ -132,7 +132,7 @@ export async function getActiveMedications(
       requestContext,
       "ActiveMedications",
       {
-        patientUPID: patient.UPID as string,
+        patientUPID: patient.UPID,
         _include: "MedicationStatement:medication",
         ...omitClientFilters(searchFilters),
       }
@@ -369,7 +369,10 @@ function searchWrapper<T extends ResourceTypeString>(
         ...included,
       ],
       "_include:iterate": "Patient:organization",
-      "patient.identifier": `${SYSTEM_ZUS_UNIVERSAL_ID}|${patientUPID}`, // UPID required as a query param to engage "CPR mode" and provide access to other builder's data
+      // UPID required as a query param to engage "CPR mode" and provide access to other builder's data.
+      // TODO: However, the CPR query will not run correctly if the Zus-Account header is set, thus
+      // this is incompatible with our current builder selector.
+      "patient.identifier": `${SYSTEM_ZUS_UNIVERSAL_ID}|${patientUPID}`,
     });
   }
   return { resources: [], bundle: undefined };

--- a/src/fhir/medications.ts
+++ b/src/fhir/medications.ts
@@ -32,6 +32,7 @@ import {
   LENS_EXTENSION_MEDICATION_LAST_PRESCRIBER,
   LENS_EXTENSION_MEDICATION_QUANTITY,
   LENS_EXTENSION_MEDICATION_REFILLS,
+  SYSTEM_ZUS_UNIVERSAL_ID,
 } from "./system-urls";
 import { ResourceMap, ResourceTypeString } from "./types";
 import { CTWRequestContext } from "@/components/core/ctw-context";
@@ -248,22 +249,26 @@ export function useMedicationHistory(medication?: fhir4.MedicationStatement) {
           searchWrapper(
             "MedicationStatement",
             requestContext,
+            patient.UPID,
             resources.MedicationStatement
           ),
           searchWrapper(
             "MedicationAdministration",
             requestContext,
+            patient.UPID,
             resources.MedicationAdministration
           ),
           searchWrapper(
             "MedicationRequest",
             requestContext,
+            patient.UPID,
             resources.MedicationRequest,
             ["MedicationRequest:requester"]
           ),
           searchWrapper(
             "MedicationDispense",
             requestContext,
+            patient.UPID,
             resources.MedicationDispense,
             ["MedicationDispense:performer", "MedicationDispense:prescription"]
           ),
@@ -351,6 +356,7 @@ type NoopSearchResults = { resources: []; bundle: undefined };
 function searchWrapper<T extends ResourceTypeString>(
   resourceType: T,
   requestContext: CTWRequestContext,
+  patientUPID: string,
   ids: string[] = [],
   included: string[] = []
 ): Promise<SearchReturn<T>> | NoopSearchResults {
@@ -363,6 +369,7 @@ function searchWrapper<T extends ResourceTypeString>(
         ...included,
       ],
       "_include:iterate": "Patient:organization",
+      "patient.identifier": `${SYSTEM_ZUS_UNIVERSAL_ID}|patientUPID`, //UPID required as a query param to engage "CPR mode" and provide access to other builder's data
     });
   }
   return { resources: [], bundle: undefined };

--- a/src/fhir/medications.ts
+++ b/src/fhir/medications.ts
@@ -369,7 +369,7 @@ function searchWrapper<T extends ResourceTypeString>(
         ...included,
       ],
       "_include:iterate": "Patient:organization",
-      "patient.identifier": `${SYSTEM_ZUS_UNIVERSAL_ID}|patientUPID`, //UPID required as a query param to engage "CPR mode" and provide access to other builder's data
+      "patient.identifier": `${SYSTEM_ZUS_UNIVERSAL_ID}|${patientUPID}`, //UPID required as a query param to engage "CPR mode" and provide access to other builder's data
     });
   }
   return { resources: [], bundle: undefined };

--- a/src/fhir/medications.ts
+++ b/src/fhir/medications.ts
@@ -369,7 +369,7 @@ function searchWrapper<T extends ResourceTypeString>(
         ...included,
       ],
       "_include:iterate": "Patient:organization",
-      "patient.identifier": `${SYSTEM_ZUS_UNIVERSAL_ID}|${patientUPID}`, //UPID required as a query param to engage "CPR mode" and provide access to other builder's data
+      "patient.identifier": `${SYSTEM_ZUS_UNIVERSAL_ID}|${patientUPID}`, // UPID required as a query param to engage "CPR mode" and provide access to other builder's data
     });
   }
   return { resources: [], bundle: undefined };

--- a/src/fhir/models/patient.ts
+++ b/src/fhir/models/patient.ts
@@ -70,9 +70,16 @@ export class PatientModel extends FHIRModel<fhir4.Patient> {
     return this.bestName.use;
   }
 
-  get UPID(): string | undefined {
-    return find(this.resource.identifier, { system: SYSTEM_ZUS_UNIVERSAL_ID })
-      ?.value;
+  get UPID(): string {
+    const upid = find(this.resource.identifier, {
+      system: SYSTEM_ZUS_UNIVERSAL_ID,
+    })?.value;
+    if (!upid) {
+      throw Error(
+        `Patient with ID ${this.resource.identifier} does not have a UPID`
+      );
+    }
+    return upid;
   }
 
   getPhoneNumber(use?: fhir4.ContactPoint["use"]): string | undefined {


### PR DESCRIPTION
When retrieving the history for a given medication we look up a list of medicationX resources in ODS by ID.

In order to trigger "CPR mode" in ODS, where we surface data across builders, we must search by UPID. This was thought to be a redundant/unnecessary filter, but it is actually required in order to access the data. It's also worth noting that the CPR data is also only available via a search (ie. using the `_id` query parameter) and is not accessible directly by ID.

This does not impact conditions as the condition history fetch is already passing a UPID (see line 122 of `conditions.ts`).