### PR TITLE
CTW-640 Including meds without an RxNorm code in builder meds table

### DIFF
--- a/.changeset/short-tomatoes-mix.md
+++ b/.changeset/short-tomatoes-mix.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Now displaying medications without an RxNorm code in builder medications list.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "dependencies": {
         "@headlessui/react": "^1.7.3",
         "@heroicons/react": "^1.0.6",

--- a/src/fhir/medications.ts
+++ b/src/fhir/medications.ts
@@ -66,12 +66,12 @@ const omitClientFilters = omit(["informationSourceNot", "informationSource"]);
 
 function applySearchFiltersToResponse(
   response: SearchReturn<"MedicationStatement">,
-  searchFilters: MedicationFilter = {}
+  searchFilters: MedicationFilter = {},
+  removeMedsWithNoRxNorm = false
 ) {
-  let medications = filterMedicationsWithNoRxNorms(
-    response.resources,
-    response.bundle
-  );
+  let medications = removeMedsWithNoRxNorm
+    ? filterMedicationsWithNoRxNorms(response.resources, response.bundle)
+    : response.resources;
 
   if (searchFilters.informationSource) {
     medications = medications.filter(
@@ -110,7 +110,11 @@ export async function getBuilderMedications(
       }
     );
 
-    const medications = applySearchFiltersToResponse(response, searchFilters);
+    const medications = applySearchFiltersToResponse(
+      response,
+      searchFilters,
+      false
+    );
 
     return { bundle: response.bundle, medications };
   } catch (e) {
@@ -118,7 +122,8 @@ export async function getBuilderMedications(
   }
 }
 
-/* Note when filtering the bundle may contain data that will no longer be in the returned medications. */
+/* Note when filtering the bundle may contain data that will no longer 
+be in the returned medications, such as medications with no RxNorm code. */
 export async function getActiveMedications(
   requestContext: CTWRequestContext,
   patient: PatientModel,
@@ -138,7 +143,11 @@ export async function getActiveMedications(
       }
     );
 
-    const medications = applySearchFiltersToResponse(response, searchFilters);
+    const medications = applySearchFiltersToResponse(
+      response,
+      searchFilters,
+      true
+    );
 
     return { bundle: response.bundle, medications };
   } catch (e) {


### PR DESCRIPTION
Modifying medication filtering logic so that we include medications without an RxNorm code in the builder meds table. Added a unit test for RxNorm filtering function. See video below for manual testing flow using Canvas to create a medication without an RxNorm code (ketamine apparently doesn't have an RxNorm code in Canvas, just an FDB ID).

https://user-images.githubusercontent.com/97455910/209273902-44fdece8-3019-4de2-baba-5142190edb1f.mov

