### PR TITLE
CTW-638/Add To Record Date and MedicationCodeableConcept text

### DIFF
--- a/.changeset/perfect-dancers-know.md
+++ b/.changeset/perfect-dancers-know.md
@@ -1,0 +1,9 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+When adding medication to record from the other provider table:
+
+- Asserted Date will now be set as the current date rather than the original medication statement date asserted.
+- The display text is now also properly set on the medication resources `medicationCodeableConcept` value.
+- When using "Add to Record" button from Storybook, the mocked response is now intercepting `POST /fhir` rather than `/fhir/MedicationStatement` to reflect that medication statements from this form are now created in a Bundle-transaction.

--- a/src/components/content/forms/schemas/medication-schema.tsx
+++ b/src/components/content/forms/schemas/medication-schema.tsx
@@ -16,7 +16,7 @@ export const getMedicationFormData = (
   },
   {
     label: "Date Asserted",
-    value: medication.dateAsserted ?? format(new Date(), "P"),
+    value: format(new Date(), "P"),
     field: "dateAsserted",
     readonly: true,
   },
@@ -29,7 +29,7 @@ export const getMedicationFormData = (
       <MedicationsAutoComplete
         readonly={readonly}
         {...inputProps}
-        defaultCoding={medication.rxNormCoding ?? {}}
+        defaultCoding={medication.rxNormCodeableConcept}
       />
     ),
   },

--- a/src/components/content/medications/story-helpers/mocks/requests.ts
+++ b/src/components/content/medications/story-helpers/mocks/requests.ts
@@ -1,4 +1,5 @@
-import { cloneDeep } from "lodash";
+import { MedicationStatement } from "fhir/r4";
+import { cloneDeep, find } from "lodash/fp";
 import { rest } from "msw";
 import { ComponentType, createElement } from "react";
 import { v4 as uuidv4 } from "uuid";
@@ -53,18 +54,30 @@ const mockMedicationStatementGet = rest.get(
   }
 );
 
-// Mocked post will add the new medication
+// Mocked post will add the new medication to patientProviderMedsCache
 const mockMedicationStatementPost = rest.post(
-  "https://api.dev.zusapi.com/fhir/MedicationStatement",
+  "https://api.dev.zusapi.com/fhir",
   async (req, res, ctx) => {
-    const newMedication = await req.json();
+    const delayMs = 500;
+    const findMedStatementInBundleFn = find({
+      resource: { resourceType: "MedicationStatement" },
+    });
+    const bundle = await req.json();
+    const newMedication = findMedStatementInBundleFn(bundle.entry)?.resource as
+      | MedicationStatement
+      | undefined;
+    if (!newMedication) {
+      return res(ctx.status(400));
+    }
+
     newMedication.id = uuidv4();
     patientProviderMedsCache.entry?.push({
       resource: newMedication,
       search: { mode: "match" },
     });
     patientProviderMedsCache.total = patientProviderMedsCache.entry?.length;
-    return res(ctx.status(200), ctx.json(newMedication));
+
+    return res(ctx.delay(delayMs), ctx.status(200), ctx.json(newMedication));
   }
 );
 

--- a/src/components/content/medications/story-helpers/mocks/requests.ts
+++ b/src/components/content/medications/story-helpers/mocks/requests.ts
@@ -58,7 +58,6 @@ const mockMedicationStatementGet = rest.get(
 const mockMedicationStatementPost = rest.post(
   "https://api.dev.zusapi.com/fhir",
   async (req, res, ctx) => {
-    const delayMs = 500;
     const findMedStatementInBundleFn = find({
       resource: { resourceType: "MedicationStatement" },
     });
@@ -77,7 +76,7 @@ const mockMedicationStatementPost = rest.post(
     });
     patientProviderMedsCache.total = patientProviderMedsCache.entry?.length;
 
-    return res(ctx.delay(delayMs), ctx.status(200), ctx.json(newMedication));
+    return res(ctx.delay(500), ctx.status(200), ctx.json(newMedication));
   }
 );
 

--- a/src/fhir/models/medication-statement.ts
+++ b/src/fhir/models/medication-statement.ts
@@ -112,8 +112,7 @@ export class MedicationStatementModel extends FHIRModel<fhir4.MedicationStatemen
   }
 
   /**
-   * Shakes out non-rxNorm and enriched codings. Get medicationCodeableConcept
-   * with only the medication label and the rxNorm coding.
+   * Get RxNorm coding with "display" defaulting to this Med-Statement label.
    */
   get rxNormCodeableConcept() {
     const coding = getIdentifyingRxNormCoding(
@@ -123,7 +122,7 @@ export class MedicationStatementModel extends FHIRModel<fhir4.MedicationStatemen
 
     return {
       ...(coding ?? {}),
-      display: this.display,
+      display: coding?.display ?? this.display,
     };
   }
 

--- a/src/fhir/models/medication-statement.ts
+++ b/src/fhir/models/medication-statement.ts
@@ -65,14 +65,10 @@ export class MedicationStatementModel extends FHIRModel<fhir4.MedicationStatemen
     return compact(extension.extension.map(get("valueReference")));
   }
 
-  get display(): string {
+  get display() {
     return codeableConceptLabel(
       getMedicationCodeableConcept(this.resource, this.includedResources)
     );
-  }
-
-  get rxNormCoding() {
-    return getIdentifyingRxNormCoding(this.resource, this.includedResources);
   }
 
   get dosage(): string | undefined {
@@ -113,6 +109,22 @@ export class MedicationStatementModel extends FHIRModel<fhir4.MedicationStatemen
 
   get rxNorm(): string | undefined {
     return getIdentifyingRxNormCode(this.resource, this.includedResources);
+  }
+
+  /**
+   * Shakes out non-rxNorm and enriched codings. Get medicationCodeableConcept
+   * with only the medication label and the rxNorm coding.
+   */
+  get rxNormCodeableConcept() {
+    const coding = getIdentifyingRxNormCoding(
+      this.resource,
+      this.includedResources
+    );
+
+    return {
+      ...(coding ?? {}),
+      display: this.display,
+    };
   }
 
   get reason(): string | undefined {


### PR DESCRIPTION
When adding medication to record from the other provider table:
 - Asserted Date will now be set as the current date rather than the original medication statement date asserted.
 - The display text is now also properly set on the medication resources `medicationCodeableConcept` value.
 - When using "Add to Record" button from Storybook, the mocked response is now intercepting `POST /fhir` rather than `/fhir/MedicationStatement` to reflect that medication statements from this form are now created in a Bundle-transaction.