### PR TITLE
Fix hover row actions, especially when stacked

### DIFF
--- a/.changeset/wild-birds-attend.md
+++ b/.changeset/wild-birds-attend.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix condition 2.0 hover button styles to work better when table is stacked.

--- a/src/components/core/table/table-rows.tsx
+++ b/src/components/core/table/table-rows.tsx
@@ -46,8 +46,9 @@ export const TableRows = <T extends MinRecordItem>({
     <>
       {records.map((record) => (
         <tr
-          className={cx("ctw-group ctw-relative", {
-            "ctw-z-10 ctw-cursor-pointer  hover:ctw-bg-bg-lighter":
+          // ctw-mx-px fixes bug where side borders disappear on hover when stacked.
+          className={cx("ctw-group ctw-relative ctw-mx-px", {
+            "ctw-z-10 ctw-cursor-pointer hover:ctw-bg-bg-lighter":
               isFunction(handleRowClick),
           })}
           key={record.id}
@@ -72,7 +73,7 @@ export const TableRows = <T extends MinRecordItem>({
             />
           ))}
           {rowActions && (
-            <td className="ctw-action-hover ctw-invisible ctw-absolute ctw-right-0 ctw-z-20 ctw-flex ctw-h-full ctw-items-center ctw-space-x-2 ctw-px-4 group-hover:ctw-visible">
+            <td className="ctw-table-row-actions group-hover:ctw-visible">
               {rowActions(record)}
             </td>
           )}

--- a/src/components/core/table/table.scss
+++ b/src/components/core/table/table.scss
@@ -70,6 +70,10 @@
   .ctw-table-action-column {
     @apply ctw-w-12 ctw-py-4 ctw-text-right;
   }
+
+  .ctw-table-row-actions {
+    @apply ctw-action-hover ctw-invisible ctw-absolute ctw-top-0 ctw-right-0 ctw-z-20 ctw-flex ctw-h-full ctw-items-center ctw-space-x-2 ctw-px-4;
+  }
 }
 
 .ctw-table-stacked {
@@ -105,8 +109,12 @@
       tr {
         @apply ctw-relative ctw-block ctw-p-3;
 
-        td:not(.ctw-table-full-length-row) {
+        td:not(.ctw-table-full-length-row):not(.ctw-table-row-actions) {
           @apply ctw-block ctw-w-full ctw-p-0 ctw-pr-7;
+        }
+
+        td.ctw-table-row-actions {
+          height: inherit;
         }
       }
     }


### PR DESCRIPTION
**Before**
<img width="700" alt="Screen Shot 2022-12-28 at 6 33 55 PM" src="https://user-images.githubusercontent.com/1568246/209885058-62f1d84f-d7dc-4747-9e03-5c2cd4dd8f56.png">

**After** (no more scrollbar)
<img width="708" alt="Screen Shot 2022-12-28 at 6 33 26 PM" src="https://user-images.githubusercontent.com/1568246/209885062-f451c975-f00c-4e33-bd24-bc36475fc10a.png">

**Before**
<img width="667" alt="Screen Shot 2022-12-28 at 6 34 10 PM" src="https://user-images.githubusercontent.com/1568246/209885029-7055e4c5-6961-4ec6-8158-a53d894bf330.png">

**After** (proper stacked styles)
<img width="666" alt="Screen Shot 2022-12-28 at 6 32 59 PM" src="https://user-images.githubusercontent.com/1568246/209885054-cd5206c8-d768-44d6-9a29-b6b1aecd32dc.png">