### PR TITLE
CTW-638/Add Medication Form to have hidden date field

### DIFF
--- a/.changeset/tasty-penguins-compare.md
+++ b/.changeset/tasty-penguins-compare.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Made the date field "hidden" on the Add Medication form. Additionally added toLower to the status field or it doesn't match a status value

--- a/src/components/content/conditions/conditions.stories.tsx
+++ b/src/components/content/conditions/conditions.stories.tsx
@@ -110,7 +110,7 @@ export const TestDelete: StoryObj<Props> = {
     await conditions.patientRecord.toHaveRowCount(1);
     conditions.toggleInactive();
     await conditions.patientRecord.toHaveRowCount(3);
-    conditions.patientRecord.toHaveRowWithText(0, /entered-in-error/i);
+    conditions.patientRecord.toHaveRowWithText(1, /entered-in-error/i);
     conditions.toggleInactive();
     await conditions.patientRecord.toHaveRowCount(1);
   },

--- a/src/components/content/forms/schemas/medication-schema.tsx
+++ b/src/components/content/forms/schemas/medication-schema.tsx
@@ -1,4 +1,5 @@
 import { format } from "date-fns";
+import { toLower } from "lodash/fp";
 import { z } from "zod";
 import { MedicationsAutoComplete } from "../medications-autocomplete";
 import { FormEntry } from "@/components/core/form/drawer-form-with-fields";
@@ -23,7 +24,6 @@ export const getMedicationFormData = (
     label: "Medication",
     field: "medication",
     value: medication.display,
-    readonly: false,
     render: (readonly: boolean | undefined, inputProps) => (
       <MedicationsAutoComplete
         readonly={readonly}
@@ -34,7 +34,7 @@ export const getMedicationFormData = (
   },
   {
     label: "Latest Status",
-    value: medication.status,
+    value: toLower(medication.status),
     field: "status",
   },
   {

--- a/src/components/content/forms/schemas/medication-schema.tsx
+++ b/src/components/content/forms/schemas/medication-schema.tsx
@@ -11,14 +11,13 @@ export const getMedicationFormData = (
     label: "Subject",
     value: medication.subjectID,
     field: "subjectID",
-    readonly: true,
     hidden: true,
   },
   {
     label: "Date Asserted",
     value: format(new Date(), "P"),
     field: "dateAsserted",
-    readonly: true,
+    hidden: true,
   },
   {
     label: "Medication",


### PR DESCRIPTION
Additional change to #360 to make the date field on the "Add Medication" form be hidden.

![Screen Shot 2023-01-03 at 12 04 38 PM](https://user-images.githubusercontent.com/6380075/210405292-586fb55c-a178-4774-b70f-f480a00df83f.png)

