### PR TITLE
Use basic.code instead of meta.tag for archive/unarchive

### DIFF
--- a/.changeset/calm-poems-tie.md
+++ b/.changeset/calm-poems-tie.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix how archive/unarchive actions are recorded. We still use a FHIR Basic resource, but we now use a code instead of a meta.tag.

--- a/src/fhir/basic.ts
+++ b/src/fhir/basic.ts
@@ -1,7 +1,6 @@
 import { FhirResource } from "fhir-kit-client";
 import { Basic } from "fhir/r4";
-import { filter } from "lodash";
-import { createOrEditFhirResource, deleteMetaTags } from "./action-helper";
+import { createOrEditFhirResource } from "./action-helper";
 import { FHIRModel } from "./models/fhir-model";
 import { getUsersPractitionerReference } from "./practitioner";
 import {
@@ -26,34 +25,9 @@ export async function recordProfileAction<T extends fhir4.Resource>(
     throw new Error(`Tried to ${profileAction} a patient record resource.`);
   }
 
-  // First remove existing profile action meta tag first.
-  // We have to do this using special $meta-delete, otherwise
-  // meta tags get merged.
-  if (existingBasic) {
-    const tags = filter(existingBasic.meta?.tag, {
-      system: SYSTEM_ZUS_PROFILE_ACTION,
-    });
-
-    try {
-      await deleteMetaTags(existingBasic, requestContext, tags);
-    } catch (e) {
-      throw new Error(
-        `There was an error setting ${profileAction} for a resource.`
-      );
-    }
-  }
-
   const basic: fhir4.Basic = {
     resourceType: "Basic",
     id: existingBasic?.id,
-    meta: {
-      tag: [
-        {
-          system: SYSTEM_ZUS_PROFILE_ACTION,
-          code: profileAction,
-        },
-      ],
-    },
     code: {
       coding: [
         {
@@ -61,8 +35,11 @@ export async function recordProfileAction<T extends fhir4.Resource>(
           code: "adminact",
           display: "Administrative Activity",
         },
+        {
+          system: SYSTEM_ZUS_PROFILE_ACTION,
+          code: profileAction,
+        },
       ],
-      text: "Administrative Activity",
     },
     subject: {
       reference: `${model.resourceType}/${model.id}`,

--- a/src/fhir/models/fhir-model.ts
+++ b/src/fhir/models/fhir-model.ts
@@ -38,8 +38,8 @@ export abstract class FHIRModel<T extends fhir4.Resource> {
   getBasicResourceByAction(profileAction: string): Basic | undefined {
     return find(this.revIncludes, {
       resourceType: "Basic",
-      meta: {
-        tag: [{ system: SYSTEM_ZUS_PROFILE_ACTION, code: profileAction }],
+      code: {
+        coding: [{ system: SYSTEM_ZUS_PROFILE_ACTION, code: profileAction }],
       },
     }) as Basic | undefined;
   }


### PR DESCRIPTION
This fixes two issues:
1. There could be permission issues around updating meta tags.
2. Meta tags are applied to all versions of the resource. Meaning if we were to archive and then unarchive, we'd lose the history of the archive action.