### PR TITLE
CTW-648 3rd party tags

### DIFF
--- a/.changeset/wise-moons-tickle.md
+++ b/.changeset/wise-moons-tickle.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Updating list of 3rd party tags

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -19,6 +19,8 @@ const THIRD_PARTY_TAGS = [
   `${SYSTEM_ZUS_THIRD_PARTY}|surescripts`,
   `${SYSTEM_ZUS_THIRD_PARTY}|commonwell`,
   `${SYSTEM_ZUS_THIRD_PARTY}|elation`,
+  `${SYSTEM_ZUS_THIRD_PARTY}|collective-medical`,
+  `${SYSTEM_ZUS_THIRD_PARTY}|quest-connector`,
 ];
 
 // Enumerating ALL of the lens tags.


### PR DESCRIPTION
Updating 3rd party tags to account for Quest and Collective.