### PR TITLE
CTW-527 Updating logic for getting identifying RxNorm

### DIFF
--- a/.changeset/wise-steaks-bake.md
+++ b/.changeset/wise-steaks-bake.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+More explicitly targeting SCD on summary med

--- a/src/fhir/medication.test.ts
+++ b/src/fhir/medication.test.ts
@@ -124,4 +124,30 @@ describe("getIdentifyingRxNormCode", () => {
 
     expect(getIdentifyingRxNormCode(testMed)).toEqual(testRxNormCode);
   });
+
+  test("chooses SCD when explicitly defined", () => {
+    const testMed = {
+      ...baseMed,
+      medicationCodeableConcept: {
+        coding: [
+          {
+            code: "the wrong code",
+            system: SYSTEM_RXNORM,
+          },
+          {
+            code: testRxNormCode,
+            system: SYSTEM_RXNORM,
+            extension: [
+              {
+                url: SYSTEM_ENRICHMENT,
+                valueString: "ClinicalDrug_TTY_SCD",
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(getIdentifyingRxNormCode(testMed)).toEqual(testRxNormCode);
+  });
 });

--- a/src/fhir/medication.ts
+++ b/src/fhir/medication.ts
@@ -79,10 +79,12 @@ export function getIdentifyingRxNormCoding(
         (e) =>
           e.url === SYSTEM_ENRICHMENT &&
           e.valueString === "ClinicalDrug_TTY_SCD"
-      )
+      ) &&
+      code.code &&
+      code.code !== "UNK"
   );
 
-  if (scd && scd.code !== "UNK") {
+  if (scd) {
     return scd;
   }
 

--- a/src/fhir/medication.ts
+++ b/src/fhir/medication.ts
@@ -70,8 +70,24 @@ export function getIdentifyingRxNormCoding(
     includedResources
   );
 
-  const excludedExtensions = ["ActiveIngredient", "BrandName"];
+  // look for an explicitly defined SCD on the medication
+  const scd = codeableConcept?.coding?.find(
+    (code) =>
+      // must be an RxNorm code
+      code.system === SYSTEM_RXNORM &&
+      code.extension?.some(
+        (e) =>
+          e.url === SYSTEM_ENRICHMENT &&
+          e.valueString === "ClinicalDrug_TTY_SCD"
+      )
+  );
 
+  if (scd && scd.code !== "UNK") {
+    return scd;
+  }
+
+  // fall back to whatever RxNorm is available that isn't a brand or ingredient
+  const excludedExtensions = ["ActiveIngredient", "BrandName"];
   return codeableConcept?.coding?.find(
     (code) =>
       // must be an RxNorm code


### PR DESCRIPTION
Through our enrichment process we write a handful of RxNorm codes to medications - a code for the brand name, a code for the active ingredient, and the "SCD" code for the "Semantic Clinical Drug" which is the most granular way of how you can specify a medication - the chemical, the strength, the form. That's the code we want to use as _the_ RxNorm code for a med when we're adding it to the record, and this is especially important for the Canvas integration where they actually need to map the RxNorm to an FDB ID (the coding used as input in their system) and that specifically requires an SCD.

Because of some nuance in how SCDs are written to medications (see this Slack thread https://zushealth.slack.com/archives/C03DAL2K3NG/p1672950691733669) the best way for us to get these codes is by first looking for a coding with the `ClinicalDrug_TTY_SCD` extension. However that's not guaranteed to be there if the original RxNorm code on the medication is already an SCD. Thus we end up with somewhat complicated logic to first look for an SCD, and if one is not found, fall back to the old logic.