### PR TITLE
Query Invalidation Helpers

### DIFF
--- a/.changeset/strong-turkeys-impress.md
+++ b/.changeset/strong-turkeys-impress.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Added query invalidation helpers for both internal and external use
+Add query invalidation helpers for both internal and external use

--- a/.changeset/strong-turkeys-impress.md
+++ b/.changeset/strong-turkeys-impress.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Added query invalidation helpers for both internal and external use

--- a/src/components/content/medications/medication-actions.tsx
+++ b/src/components/content/medications/medication-actions.tsx
@@ -1,8 +1,7 @@
 import type { MedicationStatementModel } from "@/fhir/models";
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
 import { recordProfileAction } from "@/fhir/basic";
-import { QUERY_KEY_OTHER_PROVIDER_MEDICATIONS } from "@/utils/query-keys";
-import { queryClient } from "@/utils/request";
+import { invalidateOtherProviderMedsQueries } from "@/utils/invalidate-queries";
 
 export const handleMedicationDismissal = async (
   medication: MedicationStatementModel,
@@ -19,5 +18,5 @@ export const handleMedicationDismissal = async (
   );
 
   // Invalidate related queries
-  await queryClient.invalidateQueries([QUERY_KEY_OTHER_PROVIDER_MEDICATIONS]);
+  await invalidateOtherProviderMedsQueries();
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,4 +31,5 @@ export * from "@/components/core/toggle-control";
 export * from "@/fhir/models";
 export * from "@/hooks/use-medications";
 // Utility
+export * from "@/utils/invalidate-queries";
 export { version } from "../package.json";

--- a/src/utils/invalidate-queries.ts
+++ b/src/utils/invalidate-queries.ts
@@ -1,0 +1,29 @@
+import {
+  QUERY_KEY_MEDICATION_HISTORY,
+  QUERY_KEY_OTHER_PROVIDER_MEDICATIONS,
+  QUERY_KEY_PATIENT_BUILDER_MEDICATIONS,
+} from "./query-keys";
+import { queryClient } from "@/utils/request";
+
+export const invalidateQueriesFrom = (queryKey: unknown[]) =>
+  queryClient.invalidateQueries({ queryKey });
+
+export function invalidateBuilderMedsQueries() {
+  return invalidateQueriesFrom([QUERY_KEY_PATIENT_BUILDER_MEDICATIONS]);
+}
+
+export function invalidateOtherProviderMedsQueries() {
+  return invalidateQueriesFrom([QUERY_KEY_OTHER_PROVIDER_MEDICATIONS]);
+}
+
+export function invalidateMedicationHistoryQueries() {
+  return invalidateQueriesFrom([QUERY_KEY_MEDICATION_HISTORY]);
+}
+
+export async function invalidateAnyMedicationBasedQueries() {
+  return Promise.all([
+    invalidateBuilderMedsQueries(),
+    invalidateOtherProviderMedsQueries(),
+    invalidateMedicationHistoryQueries(),
+  ]);
+}

--- a/src/utils/invalidate-queries.ts
+++ b/src/utils/invalidate-queries.ts
@@ -20,7 +20,7 @@ export function invalidateMedicationHistoryQueries() {
   return invalidateQueriesFrom([QUERY_KEY_MEDICATION_HISTORY]);
 }
 
-export async function invalidateAnyMedicationBasedQueries() {
+export function invalidateAllMedicationQueries() {
   return Promise.all([
     invalidateBuilderMedsQueries(),
     invalidateOtherProviderMedsQueries(),


### PR DESCRIPTION
These helper functions can be used internally or externally. The need came up to be able to invalidate medication query caches from code that uses the ctw-component-library. It is possible that a builder app knows a medication has been modified or stopped via some mechanism that isn't a component library component, and thus wishes to helpfully clear a cache.
Rather than have consumers of the library know about cache keys and which query library we use, they can just call a helper like `invalidateOtherProviderMedsQueries()` or `invalidateMedicationHistoryQueries()`.