### PR TITLE
Remove entered in error audit trail

### DIFF
--- a/.changeset/early-candles-design.md
+++ b/.changeset/early-candles-design.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Do not fetch condition history for conditions with verification status of entered-in-error. Also do not remove entered-in-error from conditions with entered-in-error from the audit trail.

--- a/src/components/content/condition-history/condition-history-filters.tsx
+++ b/src/components/content/condition-history/condition-history-filters.tsx
@@ -8,9 +8,9 @@ export const applyConditionHistoryFilters = (
 ) => {
   let conditionsDataDeduped = [];
 
-  const conditionModels = data
-    .map((c) => new ConditionModel(c, includedResources))
-    .filter((c) => c.verificationStatus !== "entered-in-error");
+  const conditionModels = data.map(
+    (c) => new ConditionModel(c, includedResources)
+  );
 
   const sortedConditions = orderBy(
     conditionModels,

--- a/src/components/content/condition-history/conditions-history.tsx
+++ b/src/components/content/condition-history/conditions-history.tsx
@@ -39,11 +39,8 @@ export function ConditionHistory({
   const [conditionsWithoutDate, setConditionsWithoutDate] =
     useState<CollapsibleDataListStackEntries>([]);
   const [isHistoryLoading, setIsHistoryLoading] = useState(true);
-
   const [binaryDocument, setBinaryDocument] = useState<fhir4.Binary>();
-
   const [isModalOpen, setIsModalOpen] = useState(false);
-
   const [ccdaViewerTitle, setCCDAViewerTitle] = useState<string>();
 
   // Fetching

--- a/src/fhir/conditions.ts
+++ b/src/fhir/conditions.ts
@@ -161,7 +161,15 @@ export function useConditionHistory(condition?: ConditionModel) {
     QUERY_KEY_CONDITION_HISTORY,
     [condition],
     async (requestContext, patient) => {
-      if (!condition) return undefined;
+      if (!condition) {
+        return undefined;
+      }
+      if (condition.verificationStatus === "entered-in-error") {
+        return {
+          conditions: [],
+          bundle: { resourceType: "Bundle", entry: [] },
+        };
+      }
       try {
         const tokens = condition.knownCodings.map(
           (coding) => `${coding.system}|${coding.code}`


### PR DESCRIPTION
Do not fetch condition history for conditions with verification status of entered-in-error. Also do not remove entered-in-error from conditions with entered-in-error from the audit trail.