### PR TITLE
CTW-686 Updating logic for getting the identifying RxNorm code on a medication

### DIFF
--- a/.changeset/ninety-experts-taste.md
+++ b/.changeset/ninety-experts-taste.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Updating logic for getting identifying RxNorm on a medication.

--- a/src/fhir/medication.test.ts
+++ b/src/fhir/medication.test.ts
@@ -124,30 +124,4 @@ describe("getIdentifyingRxNormCode", () => {
 
     expect(getIdentifyingRxNormCode(testMed)).toEqual(testRxNormCode);
   });
-
-  test("chooses SCD when explicitly defined", () => {
-    const testMed = {
-      ...baseMed,
-      medicationCodeableConcept: {
-        coding: [
-          {
-            code: "the wrong code",
-            system: SYSTEM_RXNORM,
-          },
-          {
-            code: testRxNormCode,
-            system: SYSTEM_RXNORM,
-            extension: [
-              {
-                url: SYSTEM_ENRICHMENT,
-                valueString: "ClinicalDrug_TTY_SCD",
-              },
-            ],
-          },
-        ],
-      },
-    };
-
-    expect(getIdentifyingRxNormCode(testMed)).toEqual(testRxNormCode);
-  });
 });

--- a/src/fhir/medication.ts
+++ b/src/fhir/medication.ts
@@ -58,9 +58,7 @@ export function getIdentifyingRxNormCode(
   return getIdentifyingRxNormCoding(medication, includedResources)?.code;
 }
 
-/**
- * Gets the CodeableConcept.Coding for the pass in medication.
- */
+// Returns the best RxNorm code for uniquely identifying a medication.
 export function getIdentifyingRxNormCoding(
   medication: Medication,
   includedResources?: ResourceMap
@@ -70,40 +68,27 @@ export function getIdentifyingRxNormCoding(
     includedResources
   );
 
-  // look for an explicitly defined SCD on the medication
-  const scd = codeableConcept?.coding?.find(
+  // first check to see if the med has an RxNorm coding that wasn't provided via enrichment
+  const rxNorm = codeableConcept?.coding?.find(
     (code) =>
       // must be an RxNorm code
-      code.system === SYSTEM_RXNORM &&
-      code.extension?.some(
-        (e) =>
-          e.url === SYSTEM_ENRICHMENT &&
-          e.valueString === "ClinicalDrug_TTY_SCD"
-      ) &&
-      code.code &&
-      code.code !== "UNK"
+      code.system === SYSTEM_RXNORM && code.extension === undefined
   );
 
-  if (scd) {
-    return scd;
+  if (rxNorm) {
+    return rxNorm;
   }
 
-  // fall back to whatever RxNorm is available that isn't a brand or ingredient
-  const excludedExtensions = ["ActiveIngredient", "BrandName"];
+  // otherwise look for an RxNorm provided via the enrichment process
   return codeableConcept?.coding?.find(
     (code) =>
       // must be an RxNorm code
       code.system === SYSTEM_RXNORM &&
       // must have no extensions
-      (code.extension === undefined ||
-        // or the extensions must not contain
-        // any of the excluded extensions
-        !code.extension.some(
-          (e) =>
-            e.url === SYSTEM_ENRICHMENT &&
-            e.valueString &&
-            excludedExtensions.includes(e.valueString)
-        ))
+      code.extension?.some(
+        (e) =>
+          e.url === SYSTEM_ENRICHMENT && e.valueString === "Standardization"
+      )
   );
 }
 


### PR DESCRIPTION
Our logic to get the identifying RxNorm code on a medication statement should not have been preferring generics (ie. SCD RXCUIs). This has been causing an issue with duplicating resources via the reconciliation workflow in Canvas - when a user is presented with a branded drug (ie. an underlying SBD RXCUI) we are using the SCD to look up the medication in Canvas and thus creating a new unique lens resource after the reconciliation process.