### PR TITLE
CTW-706/Eslint rule to disallow lodash and lodash/fp imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -84,6 +84,8 @@ module.exports = {
             message:
               "`useLayoutEffect` causes a warning in SSR. Use `useIsomorphicLayoutEffect` instead.",
           },
+          { name: "lodash" },
+          { name: "lodash/fp" },
         ],
       },
     ],

--- a/package.json
+++ b/package.json
@@ -122,11 +122,5 @@
   },
   "msw": {
     "workerDirectory": "public"
-  },
-  "overrides": {
-    "react-json-view": {
-      "react": "^16.9.0 || ^17 || ^18",
-      "react-dom": "^16.9.0 || ^17 || ^18"
-    }
   }
 }

--- a/src/components/content/CCDA/reactViewer.tsx
+++ b/src/components/content/CCDA/reactViewer.tsx
@@ -1,5 +1,0 @@
-export function reactJSONViewer() {
-  // call import as a function
-  // eslint-disable-next-line global-require
-  return require("react-json-view");
-}

--- a/src/components/core/table/table-helpers.tsx
+++ b/src/components/core/table/table-helpers.tsx
@@ -1,4 +1,3 @@
-import type { ListIteratee } from "lodash";
 import { ReactNode } from "react";
 import { orderBy } from "@/utils/nodash";
 import { SortDir } from "@/utils/sort";
@@ -43,9 +42,10 @@ export function sortRecords<T extends MinRecordItem>(
   return records;
 }
 
+type Predicate<T> = (a: T) => boolean;
 export function sortByIndices<T>(records: T[], indexSorts: IndexSort<T>[]) {
   // Makes a list of iteratees, where each index iteratee is preceded by an iteratee that ensures blanks go last.
-  let iteratees: ListIteratee<T>[] = [];
+  let iteratees: (Predicate<T> | keyof T)[] = [];
   let orders: SortDir[] = [];
   indexSorts.forEach((indexSort) => {
     const { index, dir } = indexSort;


### PR DESCRIPTION
To avoid accidentally leaking the lodash `_` into the global scope we are disallowing imports directly from base packages "lodash" or "lodash/fp". Preferred usage would be to import and export lodash functions directly within the project modules "@/utils/nodash" and "@/utils/nodash/fp". See #413 