### PR TITLE
Simplify authTokenURL usage

### DIFF
--- a/.changeset/famous-emus-draw.md
+++ b/.changeset/famous-emus-draw.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Simplify authTokenURL use by relying on exp from access token itself.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ The `CTWProvider` component provides authentication details needed for other com
 
 1. Add `<CTWProvider>` wrapper at a high level within your application.
 2. Pass in the desired environment, either `env="sandbox"` or `env="production"`.
-3. Pass in either the Zus `authToken` or the URL of an endpoint that will return one via `authTokenURL`.
+3. Setup `authTokenURL` to point to an endpoint that will return `{access_token: TOKEN}`. This is how we provide seamless logins for your users to access Zus APIs.
 4. Optioally pass in a `theme` to overwrite styles across all of the components.
+5. Optioally pass in a `enableTelemetry` to enable telemetry, see details below.
 
 Example:
 

--- a/src/components/core/providers/ctw-context.tsx
+++ b/src/components/core/providers/ctw-context.tsx
@@ -5,9 +5,7 @@ import { Theme } from "@/styles/tailwind.theme";
 
 export type CTWToken = {
   accessToken: string;
-  issuedTokenType: string;
-  tokenType: string;
-  expiresAt: number;
+  expiresAt: number; // Timestamp in ms.
 };
 
 export type CTWState = {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -49,6 +49,10 @@ export function claimsBuilderName(authToken: string): string | undefined {
   return getClaims(authToken)[AUTH_BUILDER_NAME];
 }
 
+export function claimsExp(authToken: string): number {
+  return getClaims(authToken).exp;
+}
+
 export function claimsPractitionerId(authToken: string): string | undefined {
   return getClaims(authToken)[AUTH_PRACTITIONER_ID];
 }


### PR DESCRIPTION
We now decode the access token to compute expiresAt. Also updated README and comments to encourage use of authTokenURL and not accessToken.