### PR TITLE
CTW-737 Adding managing org to med statement in history

### DIFF
--- a/.changeset/chilly-lies-obey.md
+++ b/.changeset/chilly-lies-obey.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Adding patient managing organization to medication statement cards in history
+Add patient managing organization to medication statement cards in history.

--- a/.changeset/chilly-lies-obey.md
+++ b/.changeset/chilly-lies-obey.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Adding patient managing organization to medication statement cards in history

--- a/src/components/content/medications/medication-history.tsx
+++ b/src/components/content/medications/medication-history.tsx
@@ -64,14 +64,17 @@ export const MedicationHistory = withErrorBoundary(
 
 function createMedicationStatementCard(medication: MedicationModel) {
   const resource = medication.resource as fhir4.MedicationStatement;
-  const medStatement = new MedicationStatementModel(resource);
+  const medStatement = new MedicationStatementModel(
+    resource,
+    medication.includedResources
+  );
 
   return {
     date: medication.dateLocal,
     id: medication.id,
     title: "Medication Reviewed",
     hideEmpty: false,
-    subtitle: medStatement.informationSource?.display || "",
+    subtitle: medStatement.patient?.organization?.name,
     data: [
       {
         label: "Status",

--- a/src/fhir/models/medication-statement.ts
+++ b/src/fhir/models/medication-statement.ts
@@ -1,5 +1,6 @@
 import type { Reference } from "fhir/r4";
 import { FHIRModel } from "./fhir-model";
+import { PatientModel } from "./patient";
 import { codeableConceptLabel } from "@/fhir/codeable-concept";
 import { dateToISO, formatDateISOToLocal } from "@/fhir/formatters";
 import {
@@ -162,6 +163,21 @@ export class MedicationStatementModel extends FHIRModel<fhir4.MedicationStatemen
   get subjectID(): string {
     const [, subjectID] = this.resource.subject.reference?.split("/") || [];
     return subjectID || "";
+  }
+
+  get patient(): PatientModel | undefined {
+    const reference = findReference(
+      "Patient",
+      this.resource.contained,
+      this.includedResources,
+      this.resource.subject.reference
+    );
+
+    if (reference) {
+      return new PatientModel(reference, this.includedResources);
+    }
+
+    return undefined;
   }
 
   // lens extensions


### PR DESCRIPTION
Added patient managing organization to med statements in history. The majority of our med statements are produced either via CommonWell or Canvas. This will show the CommonWell org that we pulled the data from or "Firsthand" in the case of Canvas (though I need a follow-up task to ensure that managing org is set on firsthand patients, I'm not confident that's true). 

<img width="579" alt="image" src="https://user-images.githubusercontent.com/97455910/216700704-c9f100c0-b3b1-4c43-a3d4-2c139d371323.png">
