### PR TITLE
CTW-733 Notification badge styling

### DIFF
--- a/.changeset/healthy-gorillas-attack.md
+++ b/.changeset/healthy-gorillas-attack.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Added notification color palette for badge

--- a/.changeset/healthy-gorillas-attack.md
+++ b/.changeset/healthy-gorillas-attack.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Added notification color palette for badge
+Add notification color palette for badge.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,10 +24,11 @@ const {
   VITE_ENV = "dev",
 } = import.meta.env;
 
+// Feel free to play with this theme object
 const theme = {
   colors: {
     notification: {
-      main: "#FFFFFF", // Inverting these for Canvas theming
+      main: "#FFFFFF",
       light: "#BD0B00",
     },
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,15 @@ const {
   VITE_ENV = "dev",
 } = import.meta.env;
 
+const theme = {
+  colors: {
+    caution: {
+      main: "#FFFFFF",
+      light: "#BD0B00",
+    },
+  },
+};
+
 type DemoComponent = {
   render: () => ReactNode;
   title: string;
@@ -62,6 +71,7 @@ const DemoApp = ({ accessToken = "" }) => (
     authToken={accessToken}
     builderId={VITE_BUILDER_ID}
     enableTelemetry
+    theme={theme}
   >
     <PatientProvider patientID={VITE_PATIENT_ID} systemURL={VITE_SYSTEM_URL}>
       <div className="App">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,8 +26,8 @@ const {
 
 const theme = {
   colors: {
-    caution: {
-      main: "#FFFFFF",
+    notification: {
+      main: "#FFFFFF", // Inverting these for Canvas theming
       light: "#BD0B00",
     },
   },

--- a/src/components/content/conditions/patient-conditions-tabs.tsx
+++ b/src/components/content/conditions/patient-conditions-tabs.tsx
@@ -80,7 +80,7 @@ export function PatientConditionsTabs({
               }
             >
               <span>Other Provider Records</span>
-              <Badge text={`${activeCount}`} color="primary" />
+              <Badge text={`${activeCount}`} color="caution" />
             </Tab>
           </Tab.List>
         </Tab.Group>

--- a/src/components/content/conditions/patient-conditions-tabs.tsx
+++ b/src/components/content/conditions/patient-conditions-tabs.tsx
@@ -80,7 +80,7 @@ export function PatientConditionsTabs({
               }
             >
               <span>Other Provider Records</span>
-              <Badge text={`${activeCount}`} color="caution" />
+              <Badge text={`${activeCount}`} color="notification" />
             </Tab>
           </Tab.List>
         </Tab.Group>

--- a/src/components/content/medications/other-provider-meds-table.tsx
+++ b/src/components/content/medications/other-provider-meds-table.tsx
@@ -145,7 +145,7 @@ export const BadgeOtherProviderMedCount = () => {
   if (activeUnarchivedMedications.length > 0) {
     return (
       <Badge
-        color="primary"
+        color="caution"
         text={activeUnarchivedMedications.length.toString()}
         className="ctw-h-5"
       />

--- a/src/components/content/medications/other-provider-meds-table.tsx
+++ b/src/components/content/medications/other-provider-meds-table.tsx
@@ -145,7 +145,7 @@ export const BadgeOtherProviderMedCount = () => {
   if (activeUnarchivedMedications.length > 0) {
     return (
       <Badge
-        color="caution"
+        color="notification"
         text={activeUnarchivedMedications.length.toString()}
         className="ctw-h-5"
       />

--- a/src/components/core/badge.tsx
+++ b/src/components/core/badge.tsx
@@ -2,7 +2,14 @@ import cx from "classnames";
 
 export type BadgeProps = {
   className?: string;
-  color: "primary" | "gray" | "info" | "success" | "caution" | "error";
+  color:
+    | "primary"
+    | "gray"
+    | "info"
+    | "success"
+    | "caution"
+    | "error"
+    | "notification";
   text: string;
 };
 
@@ -14,6 +21,7 @@ export const Badge = ({ className, color, text }: BadgeProps) => {
     success: "ctw-bg-success-light ctw-text-success-main",
     caution: "ctw-bg-caution-light ctw-text-caution-main",
     error: "ctw-bg-error-light ctw-text-error-main",
+    notification: "ctw-bg-notification-light ctw-text-notification-main",
   }[color];
 
   return (

--- a/src/styles/tailwind.theme.ts
+++ b/src/styles/tailwind.theme.ts
@@ -59,6 +59,10 @@ export const TailwindTheme = {
       bg: "#FFFBEB",
       icon: "#FBBF24",
     },
+    notification: {
+      light: "#F3E8FF",
+      main: "#A855F7",
+    },
     info: {
       main: "#0EA5E9",
       light: "#E0F2FE",


### PR DESCRIPTION
Added new color palette in our theming for "notifications" (discussed with Tai). Defaulting to the same colors as our primary color palette, but for Canvas we will be setting to red/white per their theming needs.

![image](https://user-images.githubusercontent.com/97455910/217610977-9e8ade78-df16-44f5-8208-5d56a3f0cde1.png)
