### PR TITLE
CTW-756 - Fix FilterBar types, language and edge cases

### DIFF
--- a/.changeset/hot-needles-swim.md
+++ b/.changeset/hot-needles-swim.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fixed types and text on the filter bar. Also added icons where missing.

--- a/.changeset/hot-needles-swim.md
+++ b/.changeset/hot-needles-swim.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Fixed types and text on the filter bar. Also added icons where missing.
+Fix types and text on the filter bar. Add icons that are missing.

--- a/src/components/content/medications/other-provider-meds-table.tsx
+++ b/src/components/content/medications/other-provider-meds-table.tsx
@@ -17,6 +17,7 @@ export type OtherProviderMedsTableProps = {
   showInactive?: boolean;
   sortColumn?: keyof MedicationStatementModel;
   sortOrder?: SortDir;
+  records?: MedicationStatementModel[];
 };
 
 /**
@@ -33,7 +34,9 @@ export const OtherProviderMedsTable = withErrorBoundary(
     showDismissed = false,
     showInactive = false,
     handleAddToRecord,
+    records,
   }: OtherProviderMedsTableProps) => {
+    const [overrideState, setOverrideState] = useState(!!records);
     const dismissMedication = useDismissMedication();
     const [medicationModels, setMedicationModels] = useState<
       MedicationStatementModel[]
@@ -56,10 +59,11 @@ export const OtherProviderMedsTable = withErrorBoundary(
     }
 
     useEffect(() => {
-      if (!otherProviderMedications) return;
+      const theRecords = records || otherProviderMedications;
+      if (!theRecords) return;
       setMedicationModels(
         sort(
-          otherProviderMedications
+          theRecords
             .filter((med) => !med.isArchived || showDismissed)
             .filter((med) => !med.isInactive || showInactive),
           pipe(get(sortColumn), toLower),
@@ -72,6 +76,7 @@ export const OtherProviderMedsTable = withErrorBoundary(
       sortOrder,
       showInactive,
       showDismissed,
+      records,
     ]);
 
     return (

--- a/src/components/content/medications/patient-medications-tabbed.tsx
+++ b/src/components/content/medications/patient-medications-tabbed.tsx
@@ -71,7 +71,7 @@ export function OtherProviderMedsTableTab({
   useEffect(() => {
     if (!isLoading && otherProviderMedications) {
       const filteredRecords = otherProviderMedications.filter((medication) => {
-        if (filters.providers.selected) {
+        if (filters.providers?.selected) {
           return filters.providers.selected === medication.lastPrescriber;
         }
         return true;

--- a/src/components/content/medications/patient-medications-tabbed.tsx
+++ b/src/components/content/medications/patient-medications-tabbed.tsx
@@ -3,7 +3,7 @@ import type {
   FilterItem,
 } from "@/components/core/filter-bar/filter-bar-types";
 import cx from "classnames";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   BadgeOtherProviderMedCount,
   OtherProviderMedsTable,
@@ -15,6 +15,9 @@ import { FilterBar } from "@/components/core/filter-bar/filter-bar";
 import { TabGroup, TabGroupItem } from "@/components/core/tab-group/tab-group";
 import { MedicationStatementModel } from "@/fhir/models";
 import "./patient-medications.scss";
+import { useQueryAllPatientMedications } from "@/hooks/use-medications";
+import { compact } from "@/utils/nodash";
+import { uniq } from "@/utils/nodash/fp";
 
 export type PatientMedicationsTabbedProps = {
   className?: string;
@@ -52,13 +55,39 @@ const tabbedContent = (
   },
 ];
 
-function OtherProviderMedsTableTab({
+export function OtherProviderMedsTableTab({
   handleAddToRecord,
 }: PatientMedicationsTabbedProps) {
   const [filters, setFilters] = useState<FilterChangeEvent>({});
+  const [records, setRecords] = useState<MedicationStatementModel[]>([]);
+  const { otherProviderMedications, isLoading } =
+    useQueryAllPatientMedications();
+
+  useEffect(() => {
+    if (!isLoading && otherProviderMedications) {
+      const filteredRecords = otherProviderMedications.filter((medication) => {
+        if (filters.providers?.selected) {
+          return filters.providers.selected === medication.lastPrescriber;
+        }
+        return true;
+      });
+      setRecords(filteredRecords);
+    }
+  }, [filters, otherProviderMedications, isLoading]);
+
   const showDismissed = "dismissed" in filters;
   const showInactive = "inactive" in filters;
-  const filterItems: FilterItem[] = [
+
+  // Create a list of prescriber names to use in a filter
+  const prescriberNames = !otherProviderMedications
+    ? []
+    : (uniq(
+        otherProviderMedications
+          .map((medication) => medication.lastPrescriber)
+          .filter((s) => typeof s === "string")
+      ) as string[]);
+
+  const filterItems: FilterItem[] = compact([
     {
       key: "dismissed",
       type: "tag",
@@ -66,12 +95,22 @@ function OtherProviderMedsTableTab({
       display: ({ active }) =>
         active ? "dismissed records" : "show dismissed records",
     },
-  ];
+    !otherProviderMedications || prescriberNames.length < 2
+      ? null
+      : {
+          key: "providers",
+          type: "checkbox",
+          icon: "clipboard",
+          values: prescriberNames,
+          display: "prescriber",
+        },
+  ]);
 
   return (
     <>
       <FilterBar filters={filterItems} handleOnChange={setFilters} />
       <OtherProviderMedsTable
+        records={records}
         showDismissed={showDismissed}
         showInactive={showInactive}
         handleAddToRecord={handleAddToRecord}

--- a/src/components/content/medications/story-helpers/mocks/other-provider-medications.ts
+++ b/src/components/content/medications/story-helpers/mocks/other-provider-medications.ts
@@ -435,7 +435,7 @@ export const otherProviderMedications: fhir4.Bundle = {
             valueReference: {
               reference: "Practitioner/a8b57218-3699-4354-bf39-b73175ba85e0",
               type: "Practitioner",
-              display: "Sally McCann",
+              display: "Mike McDonald",
             },
           },
           {
@@ -576,7 +576,7 @@ export const otherProviderMedications: fhir4.Bundle = {
             valueReference: {
               reference: "Practitioner/a8b57218-3699-4354-bf39-b73175ba85e0",
               type: "Practitioner",
-              display: "Sally McCann",
+              display: "Dr. People Person",
             },
           },
           {

--- a/src/components/core/dropdown-action-menu.tsx
+++ b/src/components/core/dropdown-action-menu.tsx
@@ -84,21 +84,23 @@ export function DropdownMenuAction({
               </RadixDropdownMenu.Item>
             ))}
 
-            {pinnedActions.length > 0 && <>
-              <RadixDropdownMenu.Separator className="ctw-dropdown-separator" />
-              {pinnedActions.map((menuItem) => (
-                <RadixDropdownMenu.Item
-                  onClick={() => menuItem.action()}
-                  key={menuItem.name}
-                  className={cx(
-                    menuItem.className,
-                    "ctw-dropdown-action-menu-item"
-                  )}
-                >
-                  {menuItem.decoration} {menuItem.name}
-                </RadixDropdownMenu.Item>
-              ))}
-            </>}
+            {pinnedActions.length > 0 && (
+              <>
+                <RadixDropdownMenu.Separator className="ctw-dropdown-separator" />
+                {pinnedActions.map((menuItem) => (
+                  <RadixDropdownMenu.Item
+                    onClick={() => menuItem.action()}
+                    key={menuItem.name}
+                    className={cx(
+                      menuItem.className,
+                      "ctw-dropdown-action-menu-item"
+                    )}
+                  >
+                    {menuItem.decoration} {menuItem.name}
+                  </RadixDropdownMenu.Item>
+                ))}
+              </>
+            )}
           </RadixDropdownMenu.Content>
         </RadixDropdownMenu.Portal>
       </RadixDropdownMenu.Root>

--- a/src/components/core/dropdown-action-menu.tsx
+++ b/src/components/core/dropdown-action-menu.tsx
@@ -35,8 +35,8 @@ export function DropdownMenuAction({
   items,
   onItemSelect,
   type,
-  pinnedActions,
   buttonClassName,
+  pinnedActions = [],
 }: DropdownMenuProps) {
   const { ctwProviderRef } = useCTW();
 
@@ -84,9 +84,9 @@ export function DropdownMenuAction({
               </RadixDropdownMenu.Item>
             ))}
 
-            <RadixDropdownMenu.Separator className="ctw-dropdown-separator" />
-            {pinnedActions &&
-              pinnedActions.map((menuItem) => (
+            {pinnedActions.length > 0 && <>
+              <RadixDropdownMenu.Separator className="ctw-dropdown-separator" />
+              {pinnedActions.map((menuItem) => (
                 <RadixDropdownMenu.Item
                   onClick={() => menuItem.action()}
                   key={menuItem.name}
@@ -98,6 +98,7 @@ export function DropdownMenuAction({
                   {menuItem.decoration} {menuItem.name}
                 </RadixDropdownMenu.Item>
               ))}
+            </>}
           </RadixDropdownMenu.Content>
         </RadixDropdownMenu.Portal>
       </RadixDropdownMenu.Root>

--- a/src/components/core/dropdown-action-menu.tsx
+++ b/src/components/core/dropdown-action-menu.tsx
@@ -6,9 +6,10 @@ import { useCTW } from "./providers/ctw-provider";
 import "./dropdown-menu.scss";
 
 export type MenuItem = {
-  name: string;
   action: () => void;
   className?: string;
+  decoration?: ReactNode;
+  name: string;
 };
 
 export type OptionsItem = { key: string; name: string; isSelected?: boolean };
@@ -92,7 +93,7 @@ export function DropdownMenuAction({
                   "ctw-dropdown-action-menu-item"
                 )}
               >
-                {menuItem.name}
+                {menuItem.decoration} {menuItem.name}
               </RadixDropdownMenu.Item>
             ))}
           </RadixDropdownMenu.Content>

--- a/src/components/core/filter-bar/filter-bar-pills.tsx
+++ b/src/components/core/filter-bar/filter-bar-pills.tsx
@@ -4,9 +4,10 @@ import { FilterBarSelectPill } from "./filter-bar-pills/select-pill";
 import { FilterBarTagPill } from "./filter-bar-pills/tag-pill";
 
 type FilterBarPillProps = {
-  addOrRemoveFilter: (key: string, remove: boolean) => void;
+  handleAddOrRemoveFilter: (key: string, remove: boolean) => void;
   filter: FilterItem;
   filterValues: FilterValuesRecord;
+  handleClearFilter: (key: string) => void;
   updateSelectedFilterValues: (valueKey: string, isSelected: boolean) => void;
 };
 
@@ -16,20 +17,21 @@ type FilterBarPillProps = {
  * will only be used by the FilterBar component.
  */
 export function FilterBarPill({
-  addOrRemoveFilter,
+  handleAddOrRemoveFilter,
+  handleClearFilter,
   filter,
   filterValues,
   updateSelectedFilterValues,
 }: FilterBarPillProps) {
-  const onRemove = () => addOrRemoveFilter(filter.key, true);
+  const handleRemove = () => handleAddOrRemoveFilter(filter.key, true);
   switch (filter.type) {
     case "tag":
-      return <FilterBarTagPill filter={filter} onRemove={onRemove} />;
+      return <FilterBarTagPill filter={filter} onRemove={handleRemove} />;
     case "select":
       return (
         <FilterBarSelectPill
           filter={filter}
-          onRemove={onRemove}
+          onRemove={handleRemove}
           onChange={updateSelectedFilterValues}
         />
       );
@@ -38,8 +40,9 @@ export function FilterBarPill({
         <FilterBarCheckboxPill
           filter={filter}
           filterValues={filterValues}
-          onRemove={onRemove}
+          onRemove={handleRemove}
           onChange={updateSelectedFilterValues}
+          onReset={() => handleClearFilter(filter.key)}
         />
       );
     default:

--- a/src/components/core/filter-bar/filter-bar-pills/checkbox-pill.tsx
+++ b/src/components/core/filter-bar/filter-bar-pills/checkbox-pill.tsx
@@ -9,13 +9,14 @@ import {
   getIcon,
 } from "@/components/core/filter-bar/filter-bar-utils";
 import { isString } from "@/utils/nodash";
-import { omit } from "@/utils/nodash/fp";
+import { compact, omit } from "@/utils/nodash/fp";
 
 type FilterBarCheckboxPillProps = {
   filter: FilterOptionCheckbox;
   filterValues: FilterValuesRecord;
   onChange: (key: string, isSelected: boolean) => void;
-  onRemove: () => void;
+  onRemove?: () => void;
+  onReset?: () => void;
 };
 
 const buttonClassName =
@@ -26,6 +27,7 @@ export function FilterBarCheckboxPill({
   filterValues,
   onRemove,
   onChange,
+  onReset,
 }: FilterBarCheckboxPillProps) {
   const selected = filter.key in filterValues ? filterValues[filter.key] : [];
   const items = filter.values.map((item) => ({
@@ -42,12 +44,22 @@ export function FilterBarCheckboxPill({
     <DropdownMenuAction
       items={items}
       type="checkbox"
-      pinnedActions={[
-        {
-          name: "Remove Filter",
-          action: onRemove,
-        },
-      ]}
+      pinnedActions={compact([
+        onReset
+          ? {
+              decoration: getIcon("reset"),
+              name: "Reset Filter",
+              action: onReset,
+            }
+          : null,
+        onRemove
+          ? {
+              decoration: getIcon("trash"),
+              name: "Remove Filter",
+              action: onRemove,
+            }
+          : null,
+      ])}
       buttonClassName={cx(filter.className, buttonClassName)}
       onItemSelect={(item) => onChange(item.key, item.value)}
     >

--- a/src/components/core/filter-bar/filter-bar-pills/select-pill.tsx
+++ b/src/components/core/filter-bar/filter-bar-pills/select-pill.tsx
@@ -4,6 +4,7 @@ import {
   FilterItemStatus,
   FilterOptionSelect,
 } from "@/components/core/filter-bar/filter-bar-types";
+import { getIcon } from "@/components/core/filter-bar/filter-bar-utils";
 import {
   ListBox,
   ListBoxOptionStatus,
@@ -18,22 +19,33 @@ type FilterBarSelectPillProps = {
 };
 
 const buttonClassName =
-  "ctw-flex ctw-items-center ctw-max-w-[15rem] ctw-capitalize ctw-text-content-black ctw-bg-bg-dark ctw-text-sm ctw-rounded ctw-my-2 ctw-py-2 ctw-px-3 ctw-relative ctw-mr-1 ctw-cursor-pointer ctw-border-0 ctw-border-transparent";
+  "ctw-flex ctw-items-center ctw-capitalize ctw-text-content-black ctw-bg-bg-dark ctw-text-sm ctw-rounded ctw-my-2 ctw-py-2 ctw-px-3 ctw-relative ctw-mr-1 ctw-cursor-pointer ctw-border-0 ctw-border-transparent";
+const renderDisplay = (
+  display: string | ((status: FilterItemStatus) => string | ReactNode)
+) => (isFunction(display) ? display({ active: false }) : display);
+const builtInButton = (name: string, key: string, icon: string) => ({
+  key,
+  display: ({ listView, filter }: ListBoxOptionStatus) =>
+    listView ? (
+      <span>
+        {getIcon(icon)} {name}
+      </span>
+    ) : (
+      filter && renderDisplay(filter.display)
+    ),
+});
+const resetButton = builtInButton("reset filter", "_reset", "reset");
+const removeButton = builtInButton("remove filter", "_remove", "trash");
 
 export function FilterBarSelectPill({
   filter,
   onChange,
   onRemove,
 }: FilterBarSelectPillProps) {
-  const renderDisplay = (
-    display: string | ((status: FilterItemStatus) => string | ReactNode)
-  ) => (isFunction(display) ? display({ active: false }) : display);
-  const clearButton = {
-    display: ({ listView }: ListBoxOptionStatus) =>
-      listView ? "clear filter" : renderDisplay(filter.display),
-    key: "_clear",
-  };
-  const items = [...filter.values, clearButton];
+  const filterNames = filter.values.map((value) =>
+    isString(value) ? value : value.display
+  );
+  const items = [...filterNames, resetButton, removeButton];
   return (
     <ListBox
       useBasicStyles
@@ -43,28 +55,27 @@ export function FilterBarSelectPill({
       items={items.map((item) => ({
         // eslint-disable-next-line react/no-unstable-nested-components
         display: ({ listView }: ListBoxOptionStatus) => {
-          if (item === clearButton) {
-            return item.display({ listView });
+          if (item === resetButton || item === removeButton) {
+            return item.display({ listView, filter });
           }
-          const title = isString(item) ? item : renderDisplay(item.display);
           return listView ? (
-            title
+            <span className="ctw-whitespace-nowrap">{item}</span>
           ) : (
             <>
-              {renderDisplay(filter.display)}: {title}
+              {renderDisplay(filter.display)}: {item}
             </>
           );
         },
         key: isString(item) ? item : item.key,
         className: cx("ctw-capitalize", {
-          "ctw-border ctw-capitalize ctw-border-solid ctw-border-divider-light":
-            item === clearButton,
+          "ctw-border ctw-capitalize ctw-border-solid ctw-border-divider-light ctw-border-b-0":
+            item === resetButton,
         }),
       }))}
       onChange={(index, item) => {
-        if (item.key === "reset") {
+        if (item.key === "_remove") {
           onRemove();
-        } else if (item.key === "clear") {
+        } else if (item.key === "_reset") {
           onChange("", false);
         } else {
           onChange(item.key, true);

--- a/src/components/core/filter-bar/filter-bar-types.ts
+++ b/src/components/core/filter-bar/filter-bar-types.ts
@@ -13,6 +13,7 @@ export type FilterItemStatus = {
 };
 
 export type MinFilterItem = {
+  belowTheFold?: boolean; // should the filter be below divider in main menu?
   className?: cx.Argument;
   display: string | ((status: FilterItemStatus) => ReactNode | string);
   icon?: string;

--- a/src/components/core/filter-bar/filter-bar-types.ts
+++ b/src/components/core/filter-bar/filter-bar-types.ts
@@ -41,9 +41,20 @@ export type FilterValuesRecord = Record<string, string | string[]>;
 
 export type FilterChangeEvent = Record<
   string,
-  {
-    key: string;
-    selected: boolean | string | string[];
-    type: "tag" | "checkbox" | "select";
-  }
+  | undefined
+  | {
+      key: string;
+      selected: boolean;
+      type: "tag";
+    }
+  | {
+      key: string;
+      selected: string[];
+      type: "checkbox";
+    }
+  | {
+      key: string;
+      selected: string;
+      type: "select";
+    }
 >;

--- a/src/components/core/filter-bar/filter-bar-utils.tsx
+++ b/src/components/core/filter-bar/filter-bar-utils.tsx
@@ -1,13 +1,16 @@
 import type { FilterItem, FilterItemStatus } from "./filter-bar-types";
 import {
   ArrowDownIcon,
+  CalendarIcon,
   CheckIcon,
   ChevronDownIcon,
+  ClipboardIcon,
   EyeIcon,
   EyeOffIcon,
   PlusIcon,
   QuestionMarkCircleIcon,
   TrashIcon,
+  XCircleIcon,
   XIcon,
 } from "@heroicons/react/solid";
 import cx from "classnames";
@@ -20,24 +23,30 @@ export function getIcon(icon: string) {
   switch (icon) {
     case "arrow-down":
       return <ArrowDownIcon />;
-    case "check":
+    case "calendar":
       return <CheckIcon className={iconClassNames} />;
+    case "check":
+      return <CalendarIcon className={iconClassNames} />;
     case "chevron-down":
       return (
         <ChevronDownIcon className={cx(iconClassNames, " ctw-h-[1.25rem]")} />
       );
+    case "clipboard":
+      return <ClipboardIcon className={iconClassNames} />;
     case "eye":
       return <EyeIcon className={iconClassNames} />;
     case "eye-off":
       return <EyeOffIcon className={iconClassNames} />;
     case "plus":
       return <PlusIcon className={iconClassNames} />;
+    case "reset":
+      return <XCircleIcon className={iconClassNames} />;
     case "trash":
       return <TrashIcon className={iconClassNames} />;
     case "x":
       return <XIcon className={iconClassNames} />;
     default:
-      return <QuestionMarkCircleIcon />;
+      return <QuestionMarkCircleIcon className={iconClassNames} />;
   }
 }
 
@@ -77,10 +86,14 @@ export function filterChangeEventToValuesRecord(
   state: FilterChangeEvent
 ): FilterValuesRecord {
   return Object.keys(state).reduce((acc, key) => {
-    const { selected, type } = state[key];
-    if (type === "tag") {
-      return set(key, [], acc);
+    const filterState = state[key];
+    if (typeof filterState !== "undefined") {
+      const { type } = filterState;
+      if (type === "tag") {
+        return set(key, [], acc);
+      }
+      return set(key, filterState.selected, acc);
     }
-    return set(key, selected, acc);
+    return acc;
   }, {});
 }

--- a/src/components/core/filter-bar/filter-bar-utils.tsx
+++ b/src/components/core/filter-bar/filter-bar-utils.tsx
@@ -17,7 +17,7 @@ import cx from "classnames";
 import { FilterChangeEvent, FilterValuesRecord } from "./filter-bar-types";
 import { isFunction, set } from "@/utils/nodash/fp";
 
-const iconClassNames = "ctw-text-content-light ctw-h-3.5 ctw-mr-1";
+const iconClassNames = "ctw-text-content-light ctw-h-3.5 ctw-mr-1 ctw-my-auto";
 
 export function getIcon(icon: string) {
   switch (icon) {

--- a/src/components/core/filter-bar/filter-bar.tsx
+++ b/src/components/core/filter-bar/filter-bar.tsx
@@ -142,20 +142,42 @@ export const FilterBar = <T extends FilterItem>({
     handleOnChange(filterChangeEvent(filters, activeFilterKeys, activeValues));
   };
 
+  const toFilterMenuItem = (filter: FilterItem) => ({
+    display: () => displayFilterItem(filter, { active: false }),
+    key: filter.key,
+    className: cx("ctw-capitalize", filter.className),
+  });
+
+  const [aboveTheFold, belowTheFold] = partition(
+    (filter) => !filter.belowTheFold,
+    inactiveFilters
+  );
+  const hasBelowTheFoldItems = belowTheFold.length > 0;
+  if (hasBelowTheFoldItems) {
+    // We need to add the ccs border top divider to first item under fold
+    belowTheFold[0] = {
+      ...belowTheFold[0],
+      className: cx(
+        belowTheFold[0].className,
+        "ctw-border-solid ctw-border-divider-light ctw-border-b-0"
+      ),
+    };
+  }
   // Creates the main filter list dropdown
   const inactiveFilterMenuItems = [
-    ...inactiveFilters.map((filter) => ({
-      display: () => displayFilterItem(filter, { active: false }),
-      key: filter.key,
-      className: cx("ctw-capitalize", filter.className),
-    })),
+    ...aboveTheFold.map(toFilterMenuItem),
+    // Need to add class for the first menu item under the fold
+    ...belowTheFold.slice(0, 1).map(toFilterMenuItem),
+    ...belowTheFold.slice(1).map(toFilterMenuItem),
     {
       // eslint-disable-next-line react/no-unstable-nested-components
       display: () => <>{getIcon("trash")} remove all filters</>,
       key: "_remove",
       icon: "trash",
-      className:
-        "ctw-border ctw-capitalize ctw-border-solid ctw-border-divider-light",
+      className: cx("ctw-border ctw-capitalize", {
+        // This adds divider to this item if needed
+        "ctw-border-solid ctw-border-divider-light": !hasBelowTheFoldItems,
+      }),
     },
   ];
 

--- a/src/components/core/filter-bar/filter-bar.tsx
+++ b/src/components/core/filter-bar/filter-bar.tsx
@@ -151,7 +151,7 @@ export const FilterBar = <T extends FilterItem>({
     })),
     {
       // eslint-disable-next-line react/no-unstable-nested-components
-      display: () => <>{getIcon("trash")} clear all filters</>,
+      display: () => <>{getIcon("trash")} remove all filters</>,
       key: "_remove",
       icon: "trash",
       className:

--- a/src/components/core/list-box/list-box.tsx
+++ b/src/components/core/list-box/list-box.tsx
@@ -3,6 +3,7 @@ import { CheckIcon, ChevronDownIcon } from "@heroicons/react/solid";
 import cx from "classnames";
 import React, { Fragment, useState } from "react";
 import type { ReactNode } from "react";
+import { FilterOptionSelect } from "@/components/core/filter-bar/filter-bar-types";
 import { isFunction } from "@/utils/nodash";
 
 export type MinListBoxItem = {
@@ -23,6 +24,7 @@ export type ListBoxProps<T> = {
 
 export type ListBoxOptionStatus = {
   active?: boolean;
+  filter?: FilterOptionSelect;
   listView?: boolean;
   selected?: boolean;
 };


### PR DESCRIPTION
Some finishing touches/fixes on FilterBar
- "Clear all filters" is now "Remove all filters" and has an icon.
<img width="455" alt="Screen Shot 2023-02-08 at 2 55 13 PM" src="https://user-images.githubusercontent.com/6380075/217637328-a0035289-d431-4ef2-a877-c7cfcc2ab77d.png">
- Individual active filters have reset and remove actions with icons now. 
<img width="438" alt="Screen Shot 2023-02-08 at 2 56 01 PM" src="https://user-images.githubusercontent.com/6380075/217637464-71765c9d-e629-4548-b4e0-e24865789c92.png">
- Modified some types to support the above
- Improved some types on the FilterChangeEvent
- Added prescriber medication to filters
<img width="729" alt="Screen Shot 2023-02-08 at 5 06 43 PM" src="https://user-images.githubusercontent.com/6380075/217662045-183b6a77-2c4a-4930-ac84-9914f9b5a841.png">
