### PR TITLE
TabGroup as reusable component and empty state for tables

### DIFF
--- a/src/components/content/medications-table-base.tsx
+++ b/src/components/content/medications-table-base.tsx
@@ -9,16 +9,18 @@ import {
 import { useBreakpoints } from "@/hooks/use-breakpoints";
 
 export type MedicationsTableBaseProps<T extends MinRecordItem> = {
-  medicationStatements: MedicationStatementModel[];
-  hideMenu?: boolean;
-  className?: string;
-  telemetryNamespace?: string;
   children?: ReactNode;
+  className?: string;
+  emptyMessage?: string;
+  hideMenu?: boolean;
+  medicationStatements: MedicationStatementModel[];
+  telemetryNamespace?: string;
 } & TableBaseProps<MedicationStatementModel>;
 
 export const MedicationsTableBase = ({
   children,
   className = "",
+  emptyMessage = "No medications on record.",
   hideMenu = false,
   medicationStatements,
   telemetryNamespace,
@@ -108,7 +110,7 @@ export const MedicationsTableBase = ({
         stacked={breakpoints.sm}
         records={medicationStatements}
         columns={breakpoints.sm ? columnsStacked : columns}
-        emptyMessage="There are no medications to display."
+        emptyMessage={emptyMessage}
         {...tableProps}
       />
       {children}

--- a/src/components/content/medications/other-provider-meds-table.tsx
+++ b/src/components/content/medications/other-provider-meds-table.tsx
@@ -80,6 +80,7 @@ export const OtherProviderMedsTable = withErrorBoundary(
           getRowClassName={(medication) => ({
             "ctw-tr-archived": medication.isArchived,
           })}
+          emptyMessage="No records found."
           telemetryNamespace="MedicationsTableBase"
           medicationStatements={medicationModels}
           isLoading={isLoading}

--- a/src/components/content/medications/patient-medications.scss
+++ b/src/components/content/medications/patient-medications.scss
@@ -18,14 +18,6 @@
     }
   }
 
-  .ctw-tab {
-    @apply ctw-relative ctw-mr-5 ctw-cursor-pointer ctw-border-0 ctw-border-transparent ctw-bg-transparent ctw-py-4 ctw-px-1;
-    &:after {
-      @apply ctw-absolute ctw-left-0 ctw-bottom-0 ctw-block ctw-h-0.5 ctw-w-full;
-      content: "";
-    }
-  }
-
   .ctw-tab-list {
     width: 312px;
   }

--- a/src/components/core/pagination/pagination-list.tsx
+++ b/src/components/core/pagination/pagination-list.tsx
@@ -15,11 +15,11 @@ export const PaginationList = ({
   const hasPages = total > DEFAULT_PAGE_SIZE;
 
   return (
-    <div className="ctw-pagination">
+    <div className="ctw-pagination !ctw-mt-1 sm:!ctw-mt-2">
       <div className="ctw-text-gray-600 ctw-text-sm">
         Showing{" "}
         <span className="ctw-font-medium">{Math.min(count, total)}</span> of{" "}
-        <span className="ctw-font-medium">{total}</span> results
+        <span className="ctw-font-medium">{total}</span> records
       </div>
 
       {(!allShown || hasPages) && (

--- a/src/components/core/tab-group/tab-group.scss
+++ b/src/components/core/tab-group/tab-group.scss
@@ -1,0 +1,9 @@
+.ctw-tab-group {
+  .ctw-tab {
+    @apply ctw-relative ctw-mr-5 ctw-cursor-pointer ctw-border-0 ctw-border-transparent ctw-bg-transparent ctw-py-4 ctw-px-1;
+    &:after {
+      @apply ctw-absolute ctw-left-0 ctw-bottom-0 ctw-block ctw-h-0.5 ctw-w-full;
+      content: "";
+    }
+  }
+}

--- a/src/components/core/tab-group/tab-group.tsx
+++ b/src/components/core/tab-group/tab-group.tsx
@@ -1,0 +1,113 @@
+import { Tab } from "@headlessui/react";
+import cx from "classnames";
+import { ReactNode, useRef, useState } from "react";
+import { ListBox } from "@/components/core/list-box/list-box";
+import { useBreakpoints } from "@/hooks/use-breakpoints";
+import "./tab-group.scss";
+
+export type TabGroupProps<T> = {
+  children?: ReactNode;
+  className?: string;
+  content: TabGroupItem<T>[];
+  forceHorizontalTabs?: boolean;
+};
+
+export type TabGroupItem<T> = {
+  key: string;
+  display: () => string | ReactNode;
+  render: (sm: boolean) => string | ReactNode;
+  getPanelClassName?: (sm: boolean) => cx.Argument;
+};
+
+/**
+ * When rendered in a small breakpoint the component will change from horizontal
+ * tabs to a vertical dropdown menu. If this is undesired, you may set the
+ * property `forceHorizontalTabs` to true and the tabs will remain visible and
+ * horizontal.
+ */
+export function TabGroup<T>({
+  children,
+  className,
+  forceHorizontalTabs = false,
+  content,
+}: TabGroupProps<T>) {
+  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const breakpoints = useBreakpoints(containerRef);
+  const isVertical = !forceHorizontalTabs && breakpoints.sm;
+
+  return (
+    <div
+      ref={containerRef}
+      className={cx(className, "ctw-tab-group ctw-relative ctw-w-full")}
+    >
+      <Tab.Group
+        selectedIndex={selectedTabIndex}
+        onChange={setSelectedTabIndex}
+      >
+        {isVertical && (
+          <ListBox
+            btnClassName="ctw-tab ctw-capitalize"
+            optionsClassName="ctw-tab-list ctw-capitalize"
+            onChange={setSelectedTabIndex}
+            items={content}
+          />
+        )}
+        <Tab.List
+          className={cx(
+            "ctw-border-default ctw-flex ctw-justify-start ctw-border-b ctw-border-divider-light",
+            { "ctw-hidden": isVertical }
+          )}
+        >
+          {/* Renders button for each tab using "display | display()" */}
+          {content.map(({ key, display }) => (
+            <Tab
+              key={key}
+              onClick={onClickBlur}
+              className={({ selected }) =>
+                cx(
+                  [
+                    "ctw-tab ctw-text-sm ctw-capitalize",
+                    "hover:after:ctw-bg-content-black",
+                    "focus-visible:ctw-outline-primary-dark focus-visible:after:ctw-bg-transparent",
+                  ],
+                  {
+                    "after:ctw-bg-content-black": selected,
+                    "ctw-text-content-light": !selected,
+                  }
+                )
+              }
+            >
+              {display()}
+            </Tab>
+          ))}
+        </Tab.List>
+
+        {/* Children are always rendered and appear above the active panel */}
+        {children}
+
+        {/* Renders body of each tab using "render()" */}
+        <Tab.Panels>
+          {content.map((item) => (
+            <Tab.Panel
+              key={item.key}
+              className={cx(item.getPanelClassName?.(breakpoints.sm))}
+            >
+              {item.render(breakpoints.sm)}
+            </Tab.Panel>
+          ))}
+        </Tab.Panels>
+      </Tab.Group>
+    </div>
+  );
+}
+
+function onClickBlur() {
+  if (typeof document !== "undefined") {
+    requestAnimationFrame(() => {
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+    });
+  }
+}

--- a/src/components/core/table/table-rows.tsx
+++ b/src/components/core/table/table-rows.tsx
@@ -39,7 +39,9 @@ export const TableRows = <T extends MinRecordItem>({
   if (records.length === 0) {
     return (
       <TableFullLengthRow colSpan={columns.length}>
-        {emptyMessage}
+        <span className="ctw-empty-message -ctw-mt-3.5 sm:ctw-mt-0">
+          {emptyMessage}
+        </span>
       </TableFullLengthRow>
     );
   }

--- a/src/components/core/table/table.scss
+++ b/src/components/core/table/table.scss
@@ -96,7 +96,6 @@
 
   .ctw-pagination {
     @apply ctw-items-center ctw-justify-between ctw-gap-2.5 ctw-pl-4 ctw-pr-4;
-    margin: 8px 0 !important;
   }
 
   table {

--- a/src/components/core/table/table.tsx
+++ b/src/components/core/table/table.tsx
@@ -123,7 +123,7 @@ export const Table = <T extends MinRecordItem>({
               <TableHead columns={columns} sort={sort} onSort={switchSort} />
             )}
 
-            <tbody>
+            <tbody className={cx({ "ctw-h-[7rem]": records.length === 0 })}>
               <TableRows
                 getRowClassName={getRowClassName}
                 records={sortedRecords.slice(0, count)}
@@ -137,7 +137,7 @@ export const Table = <T extends MinRecordItem>({
           </table>
         </div>
       </div>
-      {!hidePagination && records.length > 0 && !isLoading && (
+      {!hidePagination && !isLoading && (
         <PaginationList
           total={records.length}
           count={count}


### PR DESCRIPTION
This just moves the tabs from meds component into a reusable component.. no code change, just movement.
It also updated the empty state on the table.

<img width="1073" alt="Screen Shot 2023-02-08 at 4 19 04 PM" src="https://user-images.githubusercontent.com/6380075/217653152-b0a1533c-6e5e-4ca2-b8f7-26eb69c4a89e.png">
