### PR TITLE
CTW-759 Add to Record can be hidden on medications table

### DIFF
--- a/.changeset/ten-jeans-relate.md
+++ b/.changeset/ten-jeans-relate.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+The OtherProviderMedsTable, along with curated components PatientMedications and PatientMedicationsTabbed now accept an optional prop hideAddToRecord which will omit the "Add to Record" button from other providermedications tables.

--- a/src/components/content/medications/other-provider-meds-table.stories.tsx
+++ b/src/components/content/medications/other-provider-meds-table.stories.tsx
@@ -33,3 +33,12 @@ export const Basic: StoryObj<Props> = {
   },
   ...setupMedicationMocks({ providerMedications, otherProviderMedications }),
 };
+
+export const HideAddToRecord: StoryObj<Props> = {
+  ...Basic,
+  args: {
+    sortColumn: "display",
+    sortOrder: "asc",
+    hideAddToRecord: true,
+  },
+};

--- a/src/components/content/medications/patient-medications-tabbed.stories.tsx
+++ b/src/components/content/medications/patient-medications-tabbed.stories.tsx
@@ -31,8 +31,15 @@ export const Basic: StoryObj<Props> = {
 };
 
 export const ForceHorizontalTabs: StoryObj<Props> = {
+  ...Basic,
   args: {
     forceHorizontalTabs: true,
   },
-  ...setupMedicationMocks({ providerMedications, otherProviderMedications }),
+};
+
+export const HideAddToRecord: StoryObj<Props> = {
+  ...Basic,
+  args: {
+    hideAddToRecord: true,
+  },
 };

--- a/src/components/content/medications/patient-medications-tabbed.tsx
+++ b/src/components/content/medications/patient-medications-tabbed.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import {
   BadgeOtherProviderMedCount,
   OtherProviderMedsTable,
+  OtherProviderMedsTableProps,
 } from "@/components/content/medications/other-provider-meds-table";
 import { ProviderInactiveMedicationsTable } from "@/components/content/medications/provider-inactive-medications-table";
 import { ProviderMedsTable } from "@/components/content/medications/provider-meds-table";
@@ -19,14 +20,17 @@ import "./patient-medications.scss";
 export type PatientMedicationsTabbedProps = {
   className?: string;
   forceHorizontalTabs?: boolean;
-  handleAddToRecord: (m: MedicationStatementModel) => void;
-};
+} & SubsetOtherProviderTableProps;
+type SubsetOtherProviderTableProps = Pick<
+  OtherProviderMedsTableProps,
+  "hideAddToRecord" | "handleAddToRecord"
+>;
 
 // We use getPanelClassName on all tabs except for the other-provider-records
 // tab because without the FilterBar there is no margin between tab and panel
 // when md - lg sized.
 const tabbedContent = (
-  addToRecord: (m: MedicationStatementModel) => void
+  otherProviderTableProps: SubsetOtherProviderTableProps
 ): TabGroupItem<MedicationStatementModel>[] => [
   {
     key: "medication-list",
@@ -48,12 +52,13 @@ const tabbedContent = (
         <BadgeOtherProviderMedCount />
       </>
     ),
-    render: () => <OtherProviderMedsTableTab handleAddToRecord={addToRecord} />,
+    render: () => <OtherProviderMedsTableTab {...otherProviderTableProps} />,
   },
 ];
 
 function OtherProviderMedsTableTab({
   handleAddToRecord,
+  hideAddToRecord,
 }: PatientMedicationsTabbedProps) {
   const [filters, setFilters] = useState<FilterChangeEvent>({});
   const showDismissed = "dismissed" in filters;
@@ -72,9 +77,10 @@ function OtherProviderMedsTableTab({
     <>
       <FilterBar filters={filterItems} handleOnChange={setFilters} />
       <OtherProviderMedsTable
+        handleAddToRecord={handleAddToRecord}
+        hideAddToRecord={hideAddToRecord}
         showDismissed={showDismissed}
         showInactive={showInactive}
-        handleAddToRecord={handleAddToRecord}
       />
     </>
   );
@@ -92,9 +98,9 @@ function OtherProviderMedsTableTab({
 export function PatientMedicationsTabbed({
   className,
   forceHorizontalTabs = false,
-  handleAddToRecord,
+  ...otherProviderTableProps
 }: PatientMedicationsTabbedProps) {
-  const tabItems = tabbedContent(handleAddToRecord);
+  const tabItems = tabbedContent(otherProviderTableProps);
 
   return (
     <CTWBox.StackedWrapper

--- a/src/components/content/medications/patient-medications.stories.tsx
+++ b/src/components/content/medications/patient-medications.stories.tsx
@@ -33,6 +33,13 @@ export const Basic: StoryObj<Props> = {
   ...setupMedicationMocks({ providerMedications, otherProviderMedications }),
 };
 
+export const HideAddToRecord: StoryObj<Props> = {
+  ...Basic,
+  args: {
+    hideAddToRecord: true,
+  },
+};
+
 export const TestAddNewMed: StoryObj<Props> = {
   ...Basic,
   play: async ({ canvasElement }) => {

--- a/src/components/content/medications/patient-medications.tsx
+++ b/src/components/content/medications/patient-medications.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { AddNewMedDrawer } from "@/components/content/medications/add-new-med-drawer";
 import {
   OtherProviderMedsTable,
-  OtherProviderMedsTableProps
+  OtherProviderMedsTableProps,
 } from "@/components/content/medications/other-provider-meds-table";
 import { ProviderMedsTable } from "@/components/content/medications/provider-meds-table";
 import * as CTWBox from "@/components/core/ctw-box";
@@ -21,10 +21,7 @@ export type PatientMedicationsProps = {
   showOtherProvidersMedsTable?: boolean;
   // should we show the button to add new meds (default true)?
   readOnly?: boolean;
-} & Pick<
-  OtherProviderMedsTableProps,
-  "hideAddToRecord" | "handleAddToRecord"
->;
+} & Pick<OtherProviderMedsTableProps, "hideAddToRecord" | "handleAddToRecord">;
 
 export const PatientMedications = withErrorBoundary(
   ({

--- a/src/components/content/medications/patient-medications.tsx
+++ b/src/components/content/medications/patient-medications.tsx
@@ -2,7 +2,10 @@ import type { ClinicalStatus } from "@/fhir/medication";
 import cx from "classnames";
 import { useState } from "react";
 import { AddNewMedDrawer } from "@/components/content/medications/add-new-med-drawer";
-import { OtherProviderMedsTable } from "@/components/content/medications/other-provider-meds-table";
+import {
+  OtherProviderMedsTable,
+  OtherProviderMedsTableProps
+} from "@/components/content/medications/other-provider-meds-table";
 import { ProviderMedsTable } from "@/components/content/medications/provider-meds-table";
 import * as CTWBox from "@/components/core/ctw-box";
 import { withErrorBoundary } from "@/components/core/error-boundary";
@@ -18,7 +21,10 @@ export type PatientMedicationsProps = {
   showOtherProvidersMedsTable?: boolean;
   // should we show the button to add new meds (default true)?
   readOnly?: boolean;
-};
+} & Pick<
+  OtherProviderMedsTableProps,
+  "hideAddToRecord" | "handleAddToRecord"
+>;
 
 export const PatientMedications = withErrorBoundary(
   ({
@@ -26,6 +32,7 @@ export const PatientMedications = withErrorBoundary(
     readOnly = false,
     showConfirmedMedsTable = true,
     showOtherProvidersMedsTable = true,
+    ...otherProviderTableProps
   }: PatientMedicationsProps) => {
     const [drawerIsOpen, setDrawerIsOpen] = useState(false);
     const [includeInactiveMeds, setIncludeInactiveMeds] = useState(false);
@@ -72,7 +79,7 @@ export const PatientMedications = withErrorBoundary(
 
         {showOtherProvidersMedsTable && (
           <CTWBox.Body title="Other Provider Records">
-            <OtherProviderMedsTable />
+            <OtherProviderMedsTable {...otherProviderTableProps} />
           </CTWBox.Body>
         )}
       </CTWBox.StackedWrapper>


### PR DESCRIPTION
The `OtherProviderMedsTable`, along with curated components `PatientMedications` and `PatientMedicationsTabbed` now accept an optional prop `hideAddToRecord`.

### OtherProviderMedsTable
<img width="1027" alt="Screen Shot 2023-02-09 at 11 53 03 AM" src="https://user-images.githubusercontent.com/6380075/217882980-c705f9e8-3c7f-44e9-8a11-b578b71bce68.png">

### PatientMedicationsTabbed
<img width="568" alt="Screen Shot 2023-02-09 at 11 53 52 AM" src="https://user-images.githubusercontent.com/6380075/217883227-fb420dfd-0ae4-485f-a886-c40c90100316.png">


### PatientMedications
<img width="1027" alt="Screen Shot 2023-02-09 at 11 51 01 AM" src="https://user-images.githubusercontent.com/6380075/217882429-93db6499-0ff3-435d-b528-3c69d2188907.png">