### PR TITLE
CTW-758/Table sort indices supports `isDate`

### DIFF
--- a/.changeset/funny-yaks-remember.md
+++ b/.changeset/funny-yaks-remember.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Added `isDate` bool to sortIndices for table to fix a bug where dates do not sort correctly. Also fixed a bug where react-query errors if the use-patient-history-details hook returned empty

--- a/src/components/content/conditions-table-base.tsx
+++ b/src/components/content/conditions-table-base.tsx
@@ -26,7 +26,10 @@ export function ConditionsTableBase({
       dataIndex: "display",
       widthPercent: 40,
       minWidth: 320,
-      sortIndices: [{ index: "display" }, { index: "recorded", dir: "desc" }],
+      sortIndices: [
+        { index: "display" },
+        { index: "recorded", dir: "desc", isDate: true },
+      ],
     },
     {
       title: "Category",
@@ -52,7 +55,7 @@ export function ConditionsTableBase({
       sortIndices: [
         { index: "clinicalStatus" },
         { index: "verificationStatus" },
-        { index: "recorded", dir: "desc" },
+        { index: "recorded", dir: "desc", isDate: true },
       ],
     },
     {
@@ -60,7 +63,10 @@ export function ConditionsTableBase({
       dataIndex: "recordedDate",
       widthPercent: 17.5,
       minWidth: 132,
-      sortIndices: [{ index: "recorded" }, { index: "display", dir: "asc" }],
+      sortIndices: [
+        { index: "recorded", isDate: true },
+        { index: "display", dir: "asc" },
+      ],
     },
   ];
 

--- a/src/components/content/conditions.tsx
+++ b/src/components/content/conditions.tsx
@@ -232,7 +232,7 @@ export const Conditions = withErrorBoundary(
               isLoading={patientRecordsResponse.isLoading}
               hideMenu={readOnly}
               sort={sort}
-              onSort={(newSort) => setSort(newSort)}
+              onSort={setSort}
               emptyMessage={
                 <>
                   <div>{patientRecordsMessage}</div>
@@ -301,7 +301,7 @@ export const Conditions = withErrorBoundary(
                 stacked={breakpoints.sm}
                 conditions={otherProviderRecords}
                 sort={sort}
-                onSort={(newSort) => setSort(newSort)}
+                onSort={setSort}
                 isLoading={
                   otherProviderRecordsResponse.isLoading ||
                   patientRecordsResponse.isLoading

--- a/src/components/content/conditions/conditions.stories.tsx
+++ b/src/components/content/conditions/conditions.stories.tsx
@@ -111,7 +111,6 @@ export const TestDelete: StoryObj<Props> = {
     await conditions.patientRecord.toHaveRowCount(1);
     conditions.toggleInactive();
     await conditions.patientRecord.toHaveRowCount(3);
-    conditions.patientRecord.toHaveRowWithText(1, /entered-in-error/i);
     conditions.toggleInactive();
     await conditions.patientRecord.toHaveRowCount(1);
   },

--- a/src/components/content/conditions/conditions.stories.tsx
+++ b/src/components/content/conditions/conditions.stories.tsx
@@ -111,7 +111,7 @@ export const TestDelete: StoryObj<Props> = {
     await conditions.patientRecord.toHaveRowCount(1);
     conditions.toggleInactive();
     await conditions.patientRecord.toHaveRowCount(3);
-    await conditions.patientRecord.toHaveRowWithText(1, /entered-in-error/i);
+    await conditions.patientRecord.toHaveRowWithText(0, /entered-in-error/i);
     conditions.toggleInactive();
     await conditions.patientRecord.toHaveRowCount(1);
   },

--- a/src/components/content/medications-table-base.tsx
+++ b/src/components/content/medications-table-base.tsx
@@ -76,7 +76,7 @@ export const MedicationsTableBase = ({
     {
       title: "Last Filled",
       dataIndex: "lastFillDate",
-      sortIndices: [{ index: "lastFillDate" }],
+      sortIndices: [{ index: "lastFillDate", isDate: true }],
       widthPercent: 18,
     },
     {
@@ -90,7 +90,7 @@ export const MedicationsTableBase = ({
         </>
       ),
       sortIndices: [
-        { index: "lastPrescribedDate" },
+        { index: "lastPrescribedDate", isDate: true },
         { index: "lastPrescriber", dir: "asc" },
       ],
       widthPercent: 18,

--- a/src/components/content/patient-history/use-patient-history.tsx
+++ b/src/components/content/patient-history/use-patient-history.tsx
@@ -15,11 +15,11 @@ import { QUERY_KEY_PATIENT_HISTORY_DETAILS } from "@/utils/query-keys";
 import { ctwFetch } from "@/utils/request";
 import { Telemetry } from "@/utils/telemetry";
 
-type PatientHistoryDetails = {
-  lastRetrievedAt?: string;
+type PatientHistoryDetails = Partial<{
+  lastRetrievedAt: string;
   status: string;
   dateCreated: string;
-};
+}>;
 
 export function usePatientHistory() {
   const { openDrawer } = useDrawer();
@@ -117,10 +117,6 @@ function usePatientHistoryDetails() {
           patient.id
         );
 
-        if (messages.length === 0) {
-          return undefined;
-        }
-
         const latestDone = find(messages, {
           _messages: [
             {
@@ -131,9 +127,9 @@ function usePatientHistoryDetails() {
         return {
           // eslint-disable-next-line no-underscore-dangle
           lastRetrievedAt: latestDone?._createdAt,
-          status: messages[0].status,
+          status: messages[0]?.status,
           // eslint-disable-next-line no-underscore-dangle
-          dateCreated: messages[0]._createdAt,
+          dateCreated: messages[0]?._createdAt,
         };
       } catch (e) {
         Telemetry.logError(

--- a/src/components/core/table/table-helpers.tsx
+++ b/src/components/core/table/table-helpers.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { orderBy } from "@/utils/nodash";
+import { isString, orderBy } from "@/utils/nodash";
 import { SortDir } from "@/utils/sort";
 import { isEmptyValue } from "@/utils/types";
 
@@ -8,7 +8,7 @@ export interface MinRecordItem {
 }
 
 export type TableSort = { columnTitle: string; dir: SortDir };
-export type IndexSort<T> = { index: keyof T; dir?: SortDir };
+export type IndexSort<T> = { index: keyof T; dir?: SortDir; isDate?: boolean };
 
 type DataIndexSpecified<T> = { dataIndex: keyof T; render?: never };
 type RenderSpecified<T> = { dataIndex?: never; render: (row: T) => ReactNode };
@@ -33,24 +33,38 @@ export function sortRecords<T extends MinRecordItem>(
   );
   // If there is a sort applied to a column, then sort the records.
   if (sort && sortColumn?.sortIndices) {
-    // Unless the direction of the sort index is overriden, set it to the user's sort selection.
-    sortColumn.sortIndices = sortColumn.sortIndices.map((indexSort) =>
-      indexSort.dir ? indexSort : { index: indexSort.index, dir: sort.dir }
-    );
+    // Unless the direction of the sort index is overridden, set it to the user's sort selection.
+    sortColumn.sortIndices = sortColumn.sortIndices.map((indexSort) => ({
+      dir: sort.dir,
+      ...indexSort,
+    }));
     return sortByIndices(records, sortColumn.sortIndices);
   }
   return records;
 }
 
-type Predicate<T> = (a: T) => boolean;
+type Comparator<T> = (a: T) => unknown;
 export function sortByIndices<T>(records: T[], indexSorts: IndexSort<T>[]) {
+  const dateIteratee =
+    (column: keyof T): Comparator<T> =>
+    (record: T) => {
+      const value = record[column];
+      if (!isString(value) || !value) {
+        return 0;
+      }
+      return new Date(value).getTime();
+    };
+
   // Makes a list of iteratees, where each index iteratee is preceded by an iteratee that ensures blanks go last.
-  let iteratees: (Predicate<T> | keyof T)[] = [];
-  let orders: SortDir[] = [];
+  const iteratees: (Comparator<T> | keyof T)[] = [];
+  const orders: SortDir[] = [];
   indexSorts.forEach((indexSort) => {
-    const { index, dir } = indexSort;
-    iteratees = iteratees.concat([(o) => isEmptyValue(o[index]), index]);
-    orders = orders.concat(["asc", dir || "asc"]);
+    const { index, dir, isDate } = indexSort;
+    iteratees.push(
+      (o) => isEmptyValue(o[index]),
+      isDate ? dateIteratee(index) : index
+    );
+    orders.push("asc", dir || "asc");
   });
 
   return orderBy(records, iteratees, orders);

--- a/test-runner-jest.config.js
+++ b/test-runner-jest.config.js
@@ -1,0 +1,14 @@
+import { getJestConfig } from "@storybook/test-runner";
+
+export default {
+  // The default configuration comes from @storybook/test-runner
+  ...getJestConfig(),
+  // We don't want our timers in msw to affect test run times and renders
+  fakeTimers: {
+    enableGlobally: true,
+    doNotFake: ["nextTick"],
+  },
+  /** Add your own overrides below
+   * @see https://jestjs.io/docs/configuration
+   */
+};


### PR DESCRIPTION
https://www.loom.com/share/d15c858236ae42d48bd34d3c91eaad15

Added the ability to inform table columns that a sort index is a date. This way when the table sorts it can treat those indices appropriately. 
```tsx
    {
      title: "Some Date",
      dataIndex: "someDate"
      sortIndices: [
        { index: "someDate", isDate: true },
        { index: "somePerson", dir: "asc" },
      ],
    },
```

Also fixed a small bug where the usePatientHistoryDetails react-query hook would error if the return value was empty.