### PR TITLE
CTW-765 pushable issue

### DIFF
--- a/.changeset/nervous-phones-shave.md
+++ b/.changeset/nervous-phones-shave.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Expose functions that run when opening a drawer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "0.46.0",
+  "version": "0.46.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "0.46.0",
+      "version": "0.46.2",
       "dependencies": {
         "@datadog/browser-logs": "^4.30.1",
         "@datadog/browser-rum-slim": "^4.30.1",

--- a/src/components/content/medication-drawer.tsx
+++ b/src/components/content/medication-drawer.tsx
@@ -11,7 +11,7 @@ import { isFunction } from "@/utils/nodash/fp";
 export type MedicationDrawerProps = {
   medication?: MedicationStatementModel;
   onDismissal?: (m: MedicationStatementModel) => void;
-} & Pick<DrawerProps, "isOpen" | "onClose">;
+} & Pick<DrawerProps, "isOpen" | "onOpen"|"onAfterOpen"|"onClose">;
 
 function getDataEntriesFromMedicationStatement(
   medication?: MedicationStatementModel,

--- a/src/components/content/medication-drawer.tsx
+++ b/src/components/content/medication-drawer.tsx
@@ -11,7 +11,7 @@ import { isFunction } from "@/utils/nodash/fp";
 export type MedicationDrawerProps = {
   medication?: MedicationStatementModel;
   onDismissal?: (m: MedicationStatementModel) => void;
-} & Pick<DrawerProps, "isOpen" | "onOpen"|"onAfterOpen"|"onClose">;
+} & Pick<DrawerProps, "isOpen" | "onOpen" | "onAfterOpen" | "onClose">;
 
 function getDataEntriesFromMedicationStatement(
   medication?: MedicationStatementModel,

--- a/src/components/content/medications-table-base.tsx
+++ b/src/components/content/medications-table-base.tsx
@@ -8,6 +8,11 @@ import {
 } from "@/components/core/table/table-helpers";
 import { useBreakpoints } from "@/hooks/use-breakpoints";
 
+export type MedsHistoryTempProps = Partial<{
+  onOpenHistoryDrawer: () => void;
+  onAfterOpenHistoryDrawer: () => void;
+}>;
+
 export type MedicationsTableBaseProps<T extends MinRecordItem> = {
   children?: ReactNode;
   className?: string;

--- a/src/components/content/medications/medication-history-drawer.tsx
+++ b/src/components/content/medications/medication-history-drawer.tsx
@@ -1,30 +1,14 @@
-import { MedicationModel } from "../../../fhir/models/medication";
 import { MedicationDrawer } from "@/components/content/medication-drawer";
 import { useDrawer } from "@/components/core/providers/drawer-provider";
 import { MedicationStatementModel } from "@/fhir/models";
 
 export function useMedicationHistory() {
   const { openDrawer } = useDrawer();
-  return ({
-    medication,
-  }: {
-    medication: MedicationStatementModel;
-  }) => {
+  return ({ medication }: { medication: MedicationStatementModel }) => {
     openDrawer({
       component: (props) => (
-        <MedicationDrawer
-          medication={medication}
-          {...props}
-        />
+        <MedicationDrawer medication={medication} {...props} />
       ),
     });
   };
 }
-
-export type MedicationHistoryDrawerProps = {
-  className?: string;
-  medication: MedicationModel;
-  isOpen: boolean;
-  onClose: () => void;
-  onEdit?: () => void;
-};

--- a/src/components/content/medications/medication-history-drawer.tsx
+++ b/src/components/content/medications/medication-history-drawer.tsx
@@ -1,27 +1,19 @@
 import { MedicationModel } from "../../../fhir/models/medication";
-import { Drawer } from "../../core/drawer";
-import { useEditMedicationForm } from "../medications/medication-hooks";
-import { MedicationHistory } from "./medication-history";
+import { MedicationDrawer } from "@/components/content/medication-drawer";
 import { useDrawer } from "@/components/core/providers/drawer-provider";
+import { MedicationStatementModel } from "@/fhir/models";
 
 export function useMedicationHistory() {
   const { openDrawer } = useDrawer();
-  const showEditMedicationForm = useEditMedicationForm();
-
   return ({
     medication,
-    readOnly,
   }: {
-    medication: MedicationModel;
-    readOnly: boolean;
+    medication: MedicationStatementModel;
   }) => {
     openDrawer({
       component: (props) => (
-        <MedicationHistoryDrawer
+        <MedicationDrawer
           medication={medication}
-          onEdit={
-            readOnly ? undefined : () => showEditMedicationForm(medication)
-          }
           {...props}
         />
       ),
@@ -36,29 +28,3 @@ export type MedicationHistoryDrawerProps = {
   onClose: () => void;
   onEdit?: () => void;
 };
-
-export function MedicationHistoryDrawer({
-  className,
-  medication,
-  isOpen,
-  onClose,
-  onEdit,
-}: MedicationHistoryDrawerProps) {
-  return (
-    <Drawer
-      className={className}
-      title="Medication History"
-      isOpen={isOpen}
-      onClose={onClose}
-      showCloseFooter
-    >
-      <Drawer.Body>
-        <MedicationHistory
-          medication={medication}
-          onClose={onClose}
-          onEdit={onEdit}
-        />
-      </Drawer.Body>
-    </Drawer>
-  );
-}

--- a/src/components/content/medications/medication-history-drawer.tsx
+++ b/src/components/content/medications/medication-history-drawer.tsx
@@ -1,0 +1,64 @@
+import { MedicationModel } from "../../../fhir/models/medication";
+import { Drawer } from "../../core/drawer";
+import { useEditMedicationForm } from "../medications/medication-hooks";
+import { MedicationHistory } from "./medication-history";
+import { useDrawer } from "@/components/core/providers/drawer-provider";
+
+export function useMedicationHistory() {
+  const { openDrawer } = useDrawer();
+  const showEditMedicationForm = useEditMedicationForm();
+
+  return ({
+    medication,
+    readOnly,
+  }: {
+    medication: MedicationModel;
+    readOnly: boolean;
+  }) => {
+    openDrawer({
+      component: (props) => (
+        <MedicationHistoryDrawer
+          medication={medication}
+          onEdit={
+            readOnly ? undefined : () => showEditMedicationForm(medication)
+          }
+          {...props}
+        />
+      ),
+    });
+  };
+}
+
+export type MedicationHistoryDrawerProps = {
+  className?: string;
+  medication: MedicationModel;
+  isOpen: boolean;
+  onClose: () => void;
+  onEdit?: () => void;
+};
+
+export function MedicationHistoryDrawer({
+  className,
+  medication,
+  isOpen,
+  onClose,
+  onEdit,
+}: MedicationHistoryDrawerProps) {
+  return (
+    <Drawer
+      className={className}
+      title="Medication History"
+      isOpen={isOpen}
+      onClose={onClose}
+      showCloseFooter
+    >
+      <Drawer.Body>
+        <MedicationHistory
+          medication={medication}
+          onClose={onClose}
+          onEdit={onEdit}
+        />
+      </Drawer.Body>
+    </Drawer>
+  );
+}

--- a/src/components/content/medications/other-provider-meds-table.tsx
+++ b/src/components/content/medications/other-provider-meds-table.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { MedicationDrawer } from "@/components/content/medication-drawer";
+import { useMedicationHistory } from "./medication-history-drawer"
 import { MedicationsTableBase } from "@/components/content/medications-table-base";
 import { AddNewMedDrawer } from "@/components/content/medications/add-new-med-drawer";
 import { Badge } from "@/components/core/badge";
@@ -7,8 +7,13 @@ import { withErrorBoundary } from "@/components/core/error-boundary";
 import { useDismissMedication } from "@/fhir/medications";
 import { MedicationStatementModel } from "@/fhir/models/medication-statement";
 import { useQueryAllPatientMedications } from "@/hooks/use-medications";
-import { get, pipe, toLower } from "@/utils/nodash/fp";
+import { get, isFunction, pipe, toLower } from "@/utils/nodash/fp";
 import { sort, SortDir } from "@/utils/sort";
+
+export type MedsHistoryTempProps = Partial<{
+  onOpen: () => void;
+  onAfterOpen: () => void;
+}>
 
 export type OtherProviderMedsTableProps = {
   className?: string;
@@ -19,7 +24,7 @@ export type OtherProviderMedsTableProps = {
   sortColumn?: keyof MedicationStatementModel;
   sortOrder?: SortDir;
   records?: MedicationStatementModel[];
-};
+} & MedsHistoryTempProps;
 
 /**
  * Displays a table of medications that are not scoped to the current builder.
@@ -37,12 +42,14 @@ export const OtherProviderMedsTable = withErrorBoundary(
     hideAddToRecord = false,
     handleAddToRecord,
     records,
+    onAfterOpen,
+    onOpen,
   }: OtherProviderMedsTableProps) => {
     const dismissMedication = useDismissMedication();
+    const medicationHistoryDrawer = useMedicationHistory();
     const [medicationModels, setMedicationModels] = useState<
       MedicationStatementModel[]
     >([]);
-    const [historyDrawerOpen, setHistoryDrawerOpen] = useState(false);
     const [addNewMedDrawerOpen, setAddNewMedDrawerOpen] = useState(false);
     const [hasZeroRowActions, setHasZeroRowActions] = useState(false);
     const [selectedMedication, setSelectedMedication] =
@@ -51,8 +58,19 @@ export const OtherProviderMedsTable = withErrorBoundary(
       useQueryAllPatientMedications();
 
     function openHistoryDrawer(row: MedicationStatementModel) {
+      // Temp - onOpen and onAfterOpen should be side-effect free as
+      // they may be called after component unmounts. We added
+      // this to support a bug-fix workaround in canvas.
+      if (isFunction(onOpen)) {
+        onOpen();
+      }
+      setTimeout(() => {
+        if (isFunction(onAfterOpen)) {
+          onAfterOpen();
+        }
+      }, 0)
       setSelectedMedication(row);
-      setHistoryDrawerOpen(true);
+      medicationHistoryDrawer({ medication: row });
     }
 
     function openAddNewMedicationDrawer(row: MedicationStatementModel) {
@@ -135,12 +153,6 @@ export const OtherProviderMedsTable = withErrorBoundary(
                   </div>
                 )
           }
-        />
-        <MedicationDrawer
-          medication={selectedMedication}
-          isOpen={historyDrawerOpen}
-          onClose={() => setHistoryDrawerOpen(false)}
-          onDismissal={dismissMedication}
         />
         <AddNewMedDrawer
           medication={selectedMedication?.resource}

--- a/src/components/content/medications/other-provider-meds-table.tsx
+++ b/src/components/content/medications/other-provider-meds-table.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
-import { useMedicationHistory } from "./medication-history-drawer"
-import { MedicationsTableBase } from "@/components/content/medications-table-base";
+import { useMedicationHistory } from "./medication-history-drawer";
+import {
+  MedicationsTableBase,
+  MedsHistoryTempProps,
+} from "@/components/content/medications-table-base";
 import { AddNewMedDrawer } from "@/components/content/medications/add-new-med-drawer";
 import { Badge } from "@/components/core/badge";
 import { withErrorBoundary } from "@/components/core/error-boundary";
@@ -9,11 +12,6 @@ import { MedicationStatementModel } from "@/fhir/models/medication-statement";
 import { useQueryAllPatientMedications } from "@/hooks/use-medications";
 import { get, isFunction, pipe, toLower } from "@/utils/nodash/fp";
 import { sort, SortDir } from "@/utils/sort";
-
-export type MedsHistoryTempProps = Partial<{
-  onOpen: () => void;
-  onAfterOpen: () => void;
-}>
 
 export type OtherProviderMedsTableProps = {
   className?: string;
@@ -42,11 +40,11 @@ export const OtherProviderMedsTable = withErrorBoundary(
     hideAddToRecord = false,
     handleAddToRecord,
     records,
-    onAfterOpen,
-    onOpen,
+    onAfterOpenHistoryDrawer,
+    onOpenHistoryDrawer,
   }: OtherProviderMedsTableProps) => {
     const dismissMedication = useDismissMedication();
-    const medicationHistoryDrawer = useMedicationHistory();
+    const openMedHistoryDrawer = useMedicationHistory();
     const [medicationModels, setMedicationModels] = useState<
       MedicationStatementModel[]
     >([]);
@@ -61,16 +59,16 @@ export const OtherProviderMedsTable = withErrorBoundary(
       // Temp - onOpen and onAfterOpen should be side-effect free as
       // they may be called after component unmounts. We added
       // this to support a bug-fix workaround in canvas.
-      if (isFunction(onOpen)) {
-        onOpen();
+      if (isFunction(onOpenHistoryDrawer)) {
+        onOpenHistoryDrawer();
       }
-      setTimeout(() => {
-        if (isFunction(onAfterOpen)) {
-          onAfterOpen();
-        }
-      }, 0)
       setSelectedMedication(row);
-      medicationHistoryDrawer({ medication: row });
+      openMedHistoryDrawer({ medication: row });
+      setTimeout(() => {
+        if (isFunction(onAfterOpenHistoryDrawer)) {
+          onAfterOpenHistoryDrawer();
+        }
+      }, 0);
     }
 
     function openAddNewMedicationDrawer(row: MedicationStatementModel) {

--- a/src/components/content/medications/patient-medications-tabbed.tsx
+++ b/src/components/content/medications/patient-medications-tabbed.tsx
@@ -4,6 +4,7 @@ import type {
 } from "@/components/core/filter-bar/filter-bar-types";
 import cx from "classnames";
 import { useEffect, useState } from "react";
+import { MedsHistoryTempProps } from "@/components/content/medications-table-base";
 import {
   BadgeOtherProviderMedCount,
   OtherProviderMedsTable,
@@ -23,29 +24,41 @@ import { uniq } from "@/utils/nodash/fp";
 export type PatientMedicationsTabbedProps = {
   className?: string;
   forceHorizontalTabs?: boolean;
-} & SubsetOtherProviderTableProps;
-type SubsetOtherProviderTableProps = Pick<
+} & TabbedContentProps;
+
+type TabbedContentProps = Pick<
   OtherProviderMedsTableProps,
   "hideAddToRecord" | "handleAddToRecord"
->;
+> &
+  MedsHistoryTempProps;
 
 // We use getPanelClassName on all tabs except for the other-provider-records
 // tab because without the FilterBar there is no margin between tab and panel
 // when md - lg sized.
 const tabbedContent = (
-  otherProviderTableProps: SubsetOtherProviderTableProps
+  tabbedContentProps: TabbedContentProps
 ): TabGroupItem<MedicationStatementModel>[] => [
   {
     key: "medication-list",
     getPanelClassName: (sm: boolean) => (sm ? "ctw-mt-0" : "ctw-mt-2"),
     display: () => "medication list",
-    render: () => <ProviderMedsTable />,
+    render: () => (
+      <ProviderMedsTable
+        onOpenHistoryDrawer={tabbedContentProps.onOpenHistoryDrawer}
+        onAfterOpenHistoryDrawer={tabbedContentProps.onOpenHistoryDrawer}
+      />
+    ),
   },
   {
     key: "inactive-provider-records",
     getPanelClassName: (sm: boolean) => (sm ? "ctw-mt-0" : "ctw-mt-2"),
     display: () => "inactive",
-    render: () => <ProviderInactiveMedicationsTable />,
+    render: () => (
+      <ProviderInactiveMedicationsTable
+        onOpenHistoryDrawer={tabbedContentProps.onOpenHistoryDrawer}
+        onAfterOpenHistoryDrawer={tabbedContentProps.onOpenHistoryDrawer}
+      />
+    ),
   },
   {
     key: "other-provider-records",
@@ -55,7 +68,7 @@ const tabbedContent = (
         <BadgeOtherProviderMedCount />
       </>
     ),
-    render: () => <OtherProviderMedsTableTab {...otherProviderTableProps} />,
+    render: () => <OtherProviderMedsTableTab {...tabbedContentProps} />,
   },
 ];
 

--- a/src/components/content/medications/patient-medications-tabbed.tsx
+++ b/src/components/content/medications/patient-medications-tabbed.tsx
@@ -45,7 +45,7 @@ const tabbedContent = (
     render: () => (
       <ProviderMedsTable
         onOpenHistoryDrawer={tabbedContentProps.onOpenHistoryDrawer}
-        onAfterOpenHistoryDrawer={tabbedContentProps.onOpenHistoryDrawer}
+        onAfterOpenHistoryDrawer={tabbedContentProps.onAfterOpenHistoryDrawer}
       />
     ),
   },
@@ -56,7 +56,7 @@ const tabbedContent = (
     render: () => (
       <ProviderInactiveMedicationsTable
         onOpenHistoryDrawer={tabbedContentProps.onOpenHistoryDrawer}
-        onAfterOpenHistoryDrawer={tabbedContentProps.onOpenHistoryDrawer}
+        onAfterOpenHistoryDrawer={tabbedContentProps.onAfterOpenHistoryDrawer}
       />
     ),
   },
@@ -75,6 +75,8 @@ const tabbedContent = (
 export function OtherProviderMedsTableTab({
   handleAddToRecord,
   hideAddToRecord,
+  onOpenHistoryDrawer,
+  onAfterOpenHistoryDrawer,
 }: PatientMedicationsTabbedProps) {
   const [filters, setFilters] = useState<FilterChangeEvent>({});
   const [records, setRecords] = useState<MedicationStatementModel[]>([]);
@@ -133,6 +135,8 @@ export function OtherProviderMedsTableTab({
         hideAddToRecord={hideAddToRecord}
         showDismissed={showDismissed}
         showInactive={showInactive}
+        onOpenHistoryDrawer={onOpenHistoryDrawer}
+        onAfterOpenHistoryDrawer={onAfterOpenHistoryDrawer}
       />
     </>
   );
@@ -150,9 +154,9 @@ export function OtherProviderMedsTableTab({
 export function PatientMedicationsTabbed({
   className,
   forceHorizontalTabs = false,
-  ...otherProviderTableProps
+  ...tabbedContentProps
 }: PatientMedicationsTabbedProps) {
-  const tabItems = tabbedContent(otherProviderTableProps);
+  const tabItems = tabbedContent(tabbedContentProps);
 
   return (
     <CTWBox.StackedWrapper

--- a/src/components/content/medications/patient-medications.tsx
+++ b/src/components/content/medications/patient-medications.tsx
@@ -1,6 +1,7 @@
 import type { ClinicalStatus } from "@/fhir/medication";
 import cx from "classnames";
 import { useState } from "react";
+import { MedsHistoryTempProps } from "@/components/content/medications-table-base";
 import { AddNewMedDrawer } from "@/components/content/medications/add-new-med-drawer";
 import {
   OtherProviderMedsTable,
@@ -21,7 +22,8 @@ export type PatientMedicationsProps = {
   showOtherProvidersMedsTable?: boolean;
   // should we show the button to add new meds (default true)?
   readOnly?: boolean;
-} & Pick<OtherProviderMedsTableProps, "hideAddToRecord" | "handleAddToRecord">;
+} & Pick<OtherProviderMedsTableProps, "hideAddToRecord" | "handleAddToRecord"> &
+  MedsHistoryTempProps;
 
 export const PatientMedications = withErrorBoundary(
   ({
@@ -29,6 +31,8 @@ export const PatientMedications = withErrorBoundary(
     readOnly = false,
     showConfirmedMedsTable = true,
     showOtherProvidersMedsTable = true,
+    onOpenHistoryDrawer,
+    onAfterOpenHistoryDrawer,
     ...otherProviderTableProps
   }: PatientMedicationsProps) => {
     const [drawerIsOpen, setDrawerIsOpen] = useState(false);
@@ -70,13 +74,21 @@ export const PatientMedications = withErrorBoundary(
                 }}
               />
             </CTWBox.Title>
-            <ProviderMedsTable showInactive={includeInactiveMeds} />
+            <ProviderMedsTable
+              showInactive={includeInactiveMeds}
+              onOpenHistoryDrawer={onOpenHistoryDrawer}
+              onAfterOpenHistoryDrawer={onAfterOpenHistoryDrawer}
+            />
           </CTWBox.Body>
         )}
 
         {showOtherProvidersMedsTable && (
           <CTWBox.Body title="Other Provider Records">
-            <OtherProviderMedsTable {...otherProviderTableProps} />
+            <OtherProviderMedsTable
+              {...otherProviderTableProps}
+              onOpenHistoryDrawer={onOpenHistoryDrawer}
+              onAfterOpenHistoryDrawer={onAfterOpenHistoryDrawer}
+            />
           </CTWBox.Body>
         )}
       </CTWBox.StackedWrapper>

--- a/src/components/content/medications/provider-inactive-medications-table.tsx
+++ b/src/components/content/medications/provider-inactive-medications-table.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useState } from "react";
-import { MedicationDrawer } from "@/components/content/medication-drawer";
-import { MedicationsTableBase } from "@/components/content/medications-table-base";
+import { useMedicationHistory } from "./medication-history-drawer";
+import {
+  MedsHistoryTempProps as MedHistoryTempProps,
+  MedicationsTableBase,
+} from "@/components/content/medications-table-base";
 import { MedicationStatementModel } from "@/fhir/models/medication-statement";
 import { useQueryAllPatientMedications } from "@/hooks/use-medications";
-import { get, pipe, toLower } from "@/utils/nodash/fp";
+import { get, isFunction, pipe, toLower } from "@/utils/nodash/fp";
 import { sort } from "@/utils/sort";
 
 export type InactiveMedRecordsTableProps = {
   className?: string;
-};
+} & MedHistoryTempProps;
 
 /**
  * Displays a table of inactive medication records. These are builder-owned medications
@@ -17,18 +20,28 @@ export type InactiveMedRecordsTableProps = {
  */
 export function ProviderInactiveMedicationsTable({
   className,
+  onAfterOpenHistoryDrawer,
+  onOpenHistoryDrawer,
 }: InactiveMedRecordsTableProps) {
   const [medicationModels, setMedicationModels] = useState<
     MedicationStatementModel[]
   >([]);
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [selectedMedication, setSelectedMedication] =
-    useState<MedicationStatementModel>();
+  const openMedHistoryDrawer = useMedicationHistory();
   const { builderMedications, isLoading } = useQueryAllPatientMedications();
 
-  function openMedicationDrawer(row: MedicationStatementModel) {
-    setSelectedMedication(row);
-    setDrawerOpen(true);
+  function openHistoryDrawer(row: MedicationStatementModel) {
+    // Temp - onOpen and onAfterOpen should be side-effect free as
+    // they may be called after component unmounts. We added
+    // this to support a bug-fix workaround in canvas.
+    if (isFunction(onOpenHistoryDrawer)) {
+      onOpenHistoryDrawer();
+    }
+    openMedHistoryDrawer({ medication: row });
+    setTimeout(() => {
+      if (isFunction(onAfterOpenHistoryDrawer)) {
+        onAfterOpenHistoryDrawer();
+      }
+    }, 0);
   }
 
   useEffect(() => {
@@ -48,12 +61,7 @@ export function ProviderInactiveMedicationsTable({
         className={className}
         medicationStatements={medicationModels}
         isLoading={isLoading}
-        handleRowClick={(medication) => openMedicationDrawer(medication)}
-      />
-      <MedicationDrawer
-        medication={selectedMedication}
-        isOpen={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
+        handleRowClick={openHistoryDrawer}
       />
     </>
   );

--- a/src/components/core/drawer.tsx
+++ b/src/components/core/drawer.tsx
@@ -8,6 +8,8 @@ export type DrawerProps = {
   className?: string;
   children: ReactNode;
   isOpen: boolean;
+  onOpen?: () => void;
+  onAfterOpen?: () => void;
   onClose: () => void;
   /** Called after drawer closing animation has ended. Use this for
    * any cleanup that would affect the content displayed in the drawer.
@@ -33,6 +35,8 @@ export function Drawer({
   isOpen,
   onClose,
   onAfterClosed,
+  onOpen,
+  onAfterOpen,
   showCloseFooter,
   title,
   disableCloseOnBlur = false,
@@ -62,6 +66,8 @@ export function Drawer({
           leaveFrom="ctw-opacity-100"
           leaveTo="ctw-opacity-0"
           afterLeave={onAfterClosed}
+          beforeEnter={onOpen}
+          afterEnter={onAfterOpen}
         >
           <div className="ctw-fixed ctw-inset-0  ctw-transition-opacity">
             <div className="ctw-h-full ctw-w-full ctw-bg-content-light ctw-opacity-75" />

--- a/src/components/core/providers/drawer-context.ts
+++ b/src/components/core/providers/drawer-context.ts
@@ -5,7 +5,11 @@ export type OpenDrawerProps = {
   component: ({
     isOpen,
     onClose,
-  }: Pick<DrawerProps, "isOpen" | "onClose">) => JSX.Element | undefined;
+    onOpen,
+    onAfterOpen,
+  }: Pick<DrawerProps, "isOpen" | "onClose" | "onOpen" | "onAfterOpen">) =>
+    | JSX.Element
+    | undefined;
 };
 
 export type DrawerState = {


### PR DESCRIPTION
In some EHRs we have this issue where opening a CTW drawer causes the entire chart to shift. We had previously gotten around this by adding logic to temporarily remove this `pushable` class from the chart just while the drawer is opening. Now that we've reduced our footprint by simply dropping in our `PatientMedicationsTabbed` component we no longer have the flexibility to add this kind of workaround when opening our drawer.

This PR exposes some props on the medications component that can be used to execute a function when opening the history drawer. 

Longer term we should find a way to more generally expose these kinds of functions to run upon opening a drawer because they are obviously not specific to medications.

https://user-images.githubusercontent.com/97455910/218780622-83e3853c-ab07-4544-b63f-9fba17beefac.mov


