### PR TITLE
Datadog - Improving view context

### DIFF
--- a/.changeset/little-parrots-add.md
+++ b/.changeset/little-parrots-add.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+RUM views will now use component names instead of url path name.

--- a/src/components/core/error-boundary.tsx
+++ b/src/components/core/error-boundary.tsx
@@ -6,6 +6,7 @@ import { Telemetry } from "@/utils/telemetry";
 interface Props {
   children?: ReactNode;
   name?: string;
+  trackView?: boolean;
 }
 
 interface State {
@@ -31,6 +32,9 @@ export class ErrorBoundary extends Component<Props, State> {
     const { props } = this;
     if (props.name) {
       Telemetry.logger.info(`Loaded component ${props.name}`);
+      if (props.trackView) {
+        Telemetry.trackView(props.name);
+      }
     }
   }
 
@@ -83,9 +87,12 @@ export class ErrorBoundary extends Component<Props, State> {
 
 export function withErrorBoundary<T>(
   wrappedComponent: (props: T) => ReactNode,
-  name?: string
+  name?: string,
+  trackView = true
 ) {
   return (props: T) => (
-    <ErrorBoundary name={name}>{wrappedComponent(props)}</ErrorBoundary>
+    <ErrorBoundary name={name} trackView={trackView}>
+      {wrappedComponent(props)}
+    </ErrorBoundary>
   );
 }

--- a/src/components/core/tab-group/tab-group.tsx
+++ b/src/components/core/tab-group/tab-group.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useRef, useState } from "react";
 import { ListBox } from "@/components/core/list-box/list-box";
 import { useBreakpoints } from "@/hooks/use-breakpoints";
 import "./tab-group.scss";
+import { withErrorBoundary } from "@/components/core/error-boundary";
 
 export type TabGroupProps<T> = {
   children?: ReactNode;
@@ -26,7 +27,7 @@ export type TabGroupItem<T> = {
  * property `forceHorizontalTabs` to true and the tabs will remain visible and
  * horizontal.
  */
-export function TabGroup<T>({
+function TabGroupComponent<T>({
   children,
   className,
   forceHorizontalTabs = false,
@@ -69,6 +70,7 @@ export function TabGroup<T>({
           {content.map(({ key, display }) => (
             <Tab
               key={key}
+              data-zus-telemetry-click={`Tab[${key}]`}
               onClick={onClickBlur}
               className={({ selected }) =>
                 cx(
@@ -107,6 +109,8 @@ export function TabGroup<T>({
     </div>
   );
 }
+
+export const TabGroup = withErrorBoundary(TabGroupComponent, "TabGroup", false);
 
 function onClickBlur() {
   if (typeof document !== "undefined") {

--- a/src/components/core/tab-group/tab-group.tsx
+++ b/src/components/core/tab-group/tab-group.tsx
@@ -1,10 +1,10 @@
 import { Tab } from "@headlessui/react";
 import cx from "classnames";
 import { ReactNode, useRef, useState } from "react";
+import { withErrorBoundary } from "@/components/core/error-boundary";
 import { ListBox } from "@/components/core/list-box/list-box";
 import { useBreakpoints } from "@/hooks/use-breakpoints";
 import "./tab-group.scss";
-import { withErrorBoundary } from "@/components/core/error-boundary";
 
 export type TabGroupProps<T> = {
   children?: ReactNode;


### PR DESCRIPTION
Ensured builder context is on both RUM and logging.

Improved page view names, for example:
 - www.somebuilder.com/patient-portal
 - ctw.zusapi.com/patients
We don't need to know if a person is on view named `/patients` or `/patient-portal`, instead we will tell RUM that view `PatientMedications` has loaded.

`TabGroup` component will now log when a tab changes.
