### PR TITLE
Timeline updates

### DIFF
--- a/.changeset/eighty-radios-laugh.md
+++ b/.changeset/eighty-radios-laugh.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Add headers to patient timeline columns. Adjust data displayed, particularly how "Type" is computed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "0.46.2",
+  "version": "0.46.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "0.46.2",
+      "version": "0.46.8",
       "dependencies": {
         "@datadog/browser-logs": "^4.30.1",
         "@datadog/browser-rum-slim": "^4.30.1",

--- a/src/components/content/timeline/patient-timeline-columns.tsx
+++ b/src/components/content/timeline/patient-timeline-columns.tsx
@@ -6,20 +6,26 @@ import { EncounterModel } from "@/fhir/models/encounter";
 export const patientTimelineColumns = (includeViewFhirResource = true) => {
   const timellineColumns: TableColumn<EncounterModel>[] = [
     {
+      title: "Date",
+      widthPercent: 10,
+      minWidth: 120,
+      dataIndex: "periodStart",
+    },
+    {
+      title: "Type",
       widthPercent: 20,
       minWidth: 150,
       render: (encounter) => (
         <div>
-          <div className="ctw-cell-title group-hover:ctw-underline">
-            {encounter.periodStart}
-          </div>
+          <div>Encounter</div>
           <div>{encounter.typeDisplay}</div>
         </div>
       ),
     },
     {
-      widthPercent: 30,
-      minWidth: 250,
+      title: "Provider",
+      widthPercent: 25,
+      minWidth: 200,
       render: (encounter) => {
         const { participant } = encounter.resource;
         if (!participant || participant.length === 0) return null;
@@ -38,26 +44,25 @@ export const patientTimelineColumns = (includeViewFhirResource = true) => {
 
         return (
           <div>
-            <div className="ctw-cell-title">{encounter.location}</div>
             <SimpleMoreList
               items={items}
-              limit={3}
+              limit={6}
               total={participant.length}
             />
+            <div>{encounter.location}</div>
           </div>
         );
       },
     },
     {
-      widthPercent: 40,
-      minWidth: 200,
+      widthPercent: 45,
+      minWidth: 250,
       render: (encounter) => {
         const { diagnosis } = encounter.resource;
         if (!diagnosis || diagnosis.length === 0) return null;
 
         return (
           <div>
-            <div className="ctw-cell-title">Diagnosis</div>
             <SimpleMoreList
               items={diagnosis.map((d) => d.condition.display ?? "")}
               limit={3}

--- a/src/components/content/timeline/patient-timeline.tsx
+++ b/src/components/content/timeline/patient-timeline.tsx
@@ -28,7 +28,6 @@ export function PatientTimeline({
       <Heading title="Encounter Timeline" />
       <Table
         className="-ctw-mx-px !ctw-rounded-none"
-        showTableHead={false}
         isLoading={patientEncounterQuery.isLoading}
         records={encounters}
         columns={patientTimelineColumns(includeViewFhirResource)}

--- a/src/fhir/models/encounter.ts
+++ b/src/fhir/models/encounter.ts
@@ -73,7 +73,7 @@ export class EncounterModel extends FHIRModel<fhir4.Encounter> {
     // first type coding.
     const isNullFlavor = classSystem === SYSTEM_NULL_FLAVOR;
     const code = isNullFlavor ? typeCode : classCode;
-    const display = isNullFlavor ? typeText : classDisplay;
+    let display = isNullFlavor ? typeText : classDisplay;
 
     // Optionally add expanded version of the code
     // if code is AMB, IMP, EMER and display isn't already the expanded version.

--- a/src/fhir/models/encounter.ts
+++ b/src/fhir/models/encounter.ts
@@ -71,15 +71,9 @@ export class EncounterModel extends FHIRModel<fhir4.Encounter> {
 
     // Grab our code and display, first from class if valid, otherwise from
     // first type coding.
-    let code;
-    let display;
-    if (classSystem !== SYSTEM_NULL_FLAVOR) {
-      code = classCode;
-      display = classDisplay;
-    } else {
-      code = typeCode;
-      display = typeText;
-    }
+    const isNullFlavor = classSystem === SYSTEM_NULL_FLAVOR;
+    const code = isNullFlavor ? typeCode : classCode;
+    const display = isNullFlavor ? typeText : classDisplay;
 
     // Optionally add expanded version of the code
     // if code is AMB, IMP, EMER and display isn't already the expanded version.

--- a/src/fhir/models/encounter.ts
+++ b/src/fhir/models/encounter.ts
@@ -1,9 +1,9 @@
 import { Coding } from "fhir/r4";
-import { codeableConceptLabel, findCoding } from "../codeable-concept";
+import { codeableConceptLabel } from "../codeable-concept";
 import { formatDateISOToLocal } from "../formatters";
-import { SYSTEM_ACT_CODE } from "../system-urls";
+import { SYSTEM_NULL_FLAVOR } from "../system-urls";
 import { FHIRModel } from "./fhir-model";
-import { compact, find, flatten } from "@/utils/nodash";
+import { compact, flatten } from "@/utils/nodash";
 
 export class EncounterModel extends FHIRModel<fhir4.Encounter> {
   get class(): string | undefined {
@@ -63,10 +63,42 @@ export class EncounterModel extends FHIRModel<fhir4.Encounter> {
   }
 
   get typeDisplay(): string | undefined {
-    const codeableConcept = find(this.resource.type, {
-      coding: [{ system: SYSTEM_ACT_CODE }],
-    });
-    const coding = findCoding(SYSTEM_ACT_CODE, codeableConcept);
-    return coding?.display || coding?.code;
+    const { display: classDisplay, system: classSystem } = this.resource.class;
+    const classCode = (this.resource.class.code ?? "").toUpperCase();
+    const firstTypeCoding = this.resource.type?.[0]?.coding?.[0] ?? {};
+    const { text: typeText } = this.resource.type?.[0] ?? {};
+    const typeCode = (firstTypeCoding.code ?? "").toUpperCase();
+
+    // Grab our code and display, first from class if valid, otherwise from
+    // first type coding.
+    let code;
+    let display;
+    if (classSystem !== SYSTEM_NULL_FLAVOR) {
+      code = classCode;
+      display = classDisplay;
+    } else {
+      code = typeCode;
+      display = typeText;
+    }
+
+    // Optionally add expanded version of the code
+    // if code is AMB, IMP, EMER and display isn't already the expanded version.
+    const mappings: Record<string, string> = {
+      AMB: "Ambulatory",
+      IMP: "Inpatient",
+      EMER: "Emergency",
+    };
+    if (code && Object.keys(mappings).includes(code)) {
+      const codeDisplay = mappings[code];
+      if (!display) {
+        return codeDisplay;
+      }
+
+      if (display.toLowerCase() !== codeDisplay.toLowerCase()) {
+        display += `, ${mappings[code]}`;
+      }
+    }
+
+    return display ?? "Unknown";
   }
 }

--- a/src/fhir/system-urls.ts
+++ b/src/fhir/system-urls.ts
@@ -9,6 +9,8 @@ export const SYSTEM_CONDITION_VERIFICATION_STATUS =
   "http://terminology.hl7.org/CodeSystem/condition-ver-status";
 export const SYSTEM_MARITAL_STATUS =
   "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus";
+export const SYSTEM_NULL_FLAVOR =
+  "http://terminology.hl7.org/CodeSystem/v3-NullFlavor";
 export const SYSTEM_PROVENANCE_ACTIVITY_TYPE =
   "http://terminology.hl7.org/3.1.0/CodeSystem-v3-DataOperation.html";
 export const SYSTEM_PROVENANCE_AGENT_TYPE =


### PR DESCRIPTION
CTW-741
CTW-740

* Added timeline table headers.
* Adjusted columns.
* Tweaked how encounter type is computed / what gets displayed.
* Bumped # of participants to display from 3 -> 6. This should handle the majority of cases. This was done to avoid the `+ # more` text, which will now appear above encounter location.

### Storybook
![Screenshot 2023-02-21 at 1 37 54 PM](https://user-images.githubusercontent.com/1568246/220432836-1b8d386a-f934-431a-9603-bb9cd4b518f6.png)