### PR TITLE
Removing default padding for components

### DIFF
--- a/.changeset/popular-seahorses-give.md
+++ b/.changeset/popular-seahorses-give.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Remove padding that is added by default.

--- a/src/components/content/conditions/patient-conditions.tsx
+++ b/src/components/content/conditions/patient-conditions.tsx
@@ -82,7 +82,7 @@ export const PatientConditions = withErrorBoundary(
       <div
         ref={containerRef}
         className={cx(
-          "ctw-patient-resource-component ctw-patient-conditions ctw-items-center ctw-justify-between ctw-py-5",
+          "ctw-patient-conditions ctw-items-center ctw-justify-between ctw-py-5",
           className,
           {
             "ctw-patient-conditions-stacked": breakpoints.sm,

--- a/src/components/content/medications/patient-medications-tabbed.tsx
+++ b/src/components/content/medications/patient-medications-tabbed.tsx
@@ -160,10 +160,7 @@ export function PatientMedicationsTabbed({
 
   return (
     <CTWBox.StackedWrapper
-      className={cx(
-        "ctw-patient-resource-component ctw-patient-medications ctw-space-y-3",
-        className
-      )}
+      className={cx("ctw-patient-medications ctw-space-y-3", className)}
     >
       <TabGroup
         content={tabItems}

--- a/src/components/core/main.scss
+++ b/src/components/core/main.scss
@@ -110,10 +110,6 @@
     hyphens: auto;
   }
 
-  .ctw-patient-resource-component {
-    @apply ctw-bg-white ctw-p-5;
-  }
-
   select.ctw-error,
   input.ctw-error {
     @apply ctw-border-error-main ctw-pr-10 focus:ctw-border-error-main focus:ctw-outline-none focus:ctw-ring-1 focus:ctw-ring-error-main;


### PR DESCRIPTION
[We had previously updated the default padding for components](https://github.com/zeus-health/ctw-component-library/commit/385304f13e14b0ae28d602195739abd12449b163#diff-85c539d3d5feacb483cc18d614e7de347974dc61eceae017276d8f7dc24412af). After some discussion we believe it makes more sense for consuming apps to determine the right amount of padding.