### PR TITLE
Storybook Preperation for ZusAggregatedProfile

### DIFF
--- a/.changeset/tender-cows-repair.md
+++ b/.changeset/tender-cows-repair.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Storybook mocked requests cleanup after themselves.

--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -9,7 +9,7 @@ import {
   Subtitle,
   Title,
 } from "@storybook/addon-docs";
-import { initialize, mswDecorator } from "msw-storybook-addon";
+import { initialize, getWorker, mswDecorator } from "msw-storybook-addon";
 import "./preview.scss";
 
 // Disable caching in react query. This way mock data responses
@@ -70,4 +70,12 @@ export const parameters = {
 };
 
 // Provide the MSW addon decorator globally
-export const decorators = [mswDecorator];
+export const decorators = [
+  mswDecorator,
+  (Story) => {
+    // This solves some of our storybook test issues as it resets
+    // handlers in between stories now.
+    getWorker().resetHandlers();
+    return Story();
+  },
+];

--- a/src/components/content/allergies/patient-allergies.stories.tsx
+++ b/src/components/content/allergies/patient-allergies.stories.tsx
@@ -26,5 +26,5 @@ export default {
 } as Meta<Props>;
 
 export const Basic: StoryObj<Props> = {
-  ...setupAllergiesMocks({ allergies: allergyIntolerance }),
+  ...setupAllergiesMocks({ allergyIntolerance }),
 };

--- a/src/components/content/allergies/patient-allergies.tsx
+++ b/src/components/content/allergies/patient-allergies.tsx
@@ -1,4 +1,3 @@
-import cx from "classnames";
 import { useRef } from "react";
 import { patientAllergiesColumns } from "@/components/content/allergies/patient-allergies-column";
 import { Table } from "@/components/core/table/table";
@@ -24,27 +23,18 @@ export function PatientAllergies({
 
   return (
     <div
+      className={className}
       ref={containerRef}
-      className={cx(
-        "ctw-border ctw-border-solid ctw-border-divider-light ctw-bg-white",
-        className,
-        {
-          "ctw-stacked": breakpoints.sm,
-        }
-      )}
+      data-zus-telemetry-namespace="Allergies"
     >
-      <div className="ctw-items-center ctw-justify-between ctw-py-5 ctw-px-4">
-        <div className="ctw-ml-3 ctw-text-xl ctw-font-medium ctw-text-content-black">
-          Allergies
-        </div>
-        <Table
-          stacked={breakpoints.sm}
-          className="-ctw-mx-px !ctw-rounded-none"
-          isLoading={isLoading}
-          records={allergies}
-          columns={patientAllergiesColumns}
-        />
-      </div>
+      <Table
+        stacked={breakpoints.sm}
+        className="-ctw-mx-px !ctw-rounded-none"
+        removeLeftAndRightBorders
+        isLoading={isLoading}
+        records={allergies}
+        columns={patientAllergiesColumns}
+      />
     </div>
   );
 }

--- a/src/components/content/allergies/story-helpers/mocks/requests.ts
+++ b/src/components/content/allergies/story-helpers/mocks/requests.ts
@@ -6,28 +6,33 @@ import { cloneDeep } from "@/utils/nodash/fp";
 let patientAllergiesCache: fhir4.Bundle;
 
 export function setupAllergiesMocks({
-  allergies,
+  allergyIntolerance,
 }: Record<string, fhir4.Bundle>) {
   return {
     decorators: [
       (Story: ComponentType) => {
-        patientAllergiesCache = cloneDeep(allergies);
+        patientAllergiesCache = cloneDeep(allergyIntolerance);
         return createElement(Story);
       },
     ],
     parameters: {
-      msw: [mockPatientGet, mockAllergiesIntolleranceGet],
+      msw: mockRequests(),
     },
   };
 }
 
-const mockPatientGet = rest.get(
-  "https://api.dev.zusapi.com/fhir/Patient",
-  // Add ctx.delay(750), delay to show loading, we set this to 750ms
-  (req, res, ctx) => res(ctx.delay(750), ctx.status(200), ctx.json(patient))
-);
+function mockRequests() {
+  const mockPatientGet = rest.get(
+    "https://api.dev.zusapi.com/fhir/Patient",
+    // Add ctx.delay(750), delay to show loading, we set this to 750ms
+    (req, res, ctx) => res(ctx.delay(750), ctx.status(200), ctx.json(patient))
+  );
 
-const mockAllergiesIntolleranceGet = rest.get(
-  "https://api.dev.zusapi.com/fhir/AllergyIntolerance",
-  (req, res, ctx) => res(ctx.status(200), ctx.json(patientAllergiesCache))
-);
+  const mockAllergyIntolleranceGet = rest.get(
+    "https://api.dev.zusapi.com/fhir/AllergyIntolerance",
+    (req, res, ctx) =>
+      res(ctx.delay(750), ctx.status(200), ctx.json(patientAllergiesCache))
+  );
+
+  return [mockPatientGet, mockAllergyIntolleranceGet];
+}

--- a/src/components/content/conditions/patient-conditions-actions.tsx
+++ b/src/components/content/conditions/patient-conditions-actions.tsx
@@ -37,7 +37,7 @@ export function PatientConditionsActions({
   const patientHistory = usePatientHistory();
 
   return (
-    <div className="ctw-flex ctw-flex-wrap ctw-items-center ctw-justify-between ctw-py-3 sm:ctw-pt-1.5">
+    <div className="ctw-flex ctw-flex-wrap ctw-items-center ctw-justify-between ctw-py-2 sm:ctw-pt-1.5">
       <div className="ctw-flex ctw-flex-wrap ctw-gap-x-2">
         <SortButton
           options={sortOptions}

--- a/src/components/content/conditions/patient-conditions-tabs.tsx
+++ b/src/components/content/conditions/patient-conditions-tabs.tsx
@@ -3,14 +3,13 @@ import { usePatientHistory } from "../patient-history/use-patient-history";
 import { FilterCollection } from "./patient-conditions-filters";
 import { Badge } from "@/components/core/badge";
 import { TabGroup, TabGroupItem } from "@/components/core/tab-group/tab-group";
-import { useOtherProviderConditions } from "@/fhir/conditions";
+import { useOtherProviderConditionsDeduped } from "@/fhir/conditions";
 import { ConditionModel } from "@/fhir/models";
 
 export type PatientConditionsTabsProps = {
   collection: FilterCollection;
   forceHorizontalTabs?: boolean;
   onCollectionChange: (collection: FilterCollection) => void;
-  otherConditions: ConditionModel[];
 };
 
 const tabbedContent: TabGroupItem<ConditionModel>[] = [
@@ -60,10 +59,7 @@ export function PatientConditionsTabs({
 }
 
 export const BadgeOtherProviderConditionsCount = () => {
-  const otherConditionsQuery = useOtherProviderConditions();
-  if (!otherConditionsQuery.data) {
-    return null;
-  }
+  const otherConditionsQuery = useOtherProviderConditionsDeduped();
   const activeUnarchivedConditions = otherConditionsQuery.data.filter(
     (condition) => condition.displayStatus === "Active"
   );

--- a/src/components/content/immunizations/patient-immunizations.stories.tsx
+++ b/src/components/content/immunizations/patient-immunizations.stories.tsx
@@ -3,10 +3,7 @@ import {
   PatientImmunizations,
   PatientImmunizationsProps,
 } from "./patient-immunizations";
-import {
-  mockImmunizationGet,
-  mockPatientGet,
-} from "./story-helpers/mocks/requests";
+import { setupImmunizationMocks } from "./story-helpers/mocks/requests";
 import { CTWProvider } from "@/components/core/providers/ctw-provider";
 import { PatientProvider } from "@/components/core/providers/patient-provider";
 import { SYSTEM_ZUS_UNIVERSAL_ID } from "@/fhir/system-urls";
@@ -42,7 +39,5 @@ export default {
 } as Meta<Props>;
 
 export const Basic: StoryObj<Props> = {
-  parameters: {
-    msw: [mockPatientGet, mockImmunizationGet],
-  },
+  ...setupImmunizationMocks(),
 };

--- a/src/components/content/immunizations/story-helpers/mocks/requests.ts
+++ b/src/components/content/immunizations/story-helpers/mocks/requests.ts
@@ -2,14 +2,26 @@ import { rest } from "msw";
 import { immunizations } from "./immunizations";
 import { patient } from "./patient";
 
-export const mockPatientGet = rest.get(
-  "https://api.dev.zusapi.com/fhir/Patient",
-  // Add ctx.delay(750), delay to show loading, we set this to 750ms to be
-  // less than the default testing-library timeout of 1000ms.
-  (req, res, ctx) => res(ctx.delay(750), ctx.status(200), ctx.json(patient))
-);
+export function setupImmunizationMocks() {
+  return {
+    parameters: {
+      msw: mockRequests(),
+    },
+  };
+}
 
-export const mockImmunizationGet = rest.get(
-  "https://api.dev.zusapi.com/fhir/Immunization",
-  (req, res, ctx) => res(ctx.status(200), ctx.json(immunizations))
-);
+function mockRequests() {
+  const mockPatientGet = rest.get(
+    "https://api.dev.zusapi.com/fhir/Patient",
+    // Add ctx.delay(750), delay to show loading, we set this to 750ms to be
+    // less than the default testing-library timeout of 1000ms.
+    (req, res, ctx) => res(ctx.delay(750), ctx.status(200), ctx.json(patient))
+  );
+
+  const mockImmunizationGet = rest.get(
+    "https://api.dev.zusapi.com/fhir/Immunization",
+    (req, res, ctx) => res(ctx.status(200), ctx.json(immunizations))
+  );
+
+  return [mockPatientGet, mockImmunizationGet];
+}

--- a/src/components/content/medications-table-base.tsx
+++ b/src/components/content/medications-table-base.tsx
@@ -110,6 +110,8 @@ export const MedicationsTableBase = ({
       data-zus-telemetry-namespace={telemetryNamespace}
     >
       <Table
+        removeLeftAndRightBorders
+        className="-ctw-mx-px !ctw-rounded-none"
         sort={sort}
         onSort={setSort}
         stacked={breakpoints.sm}

--- a/src/components/content/medications/patient-medications-tabbed.tsx
+++ b/src/components/content/medications/patient-medications-tabbed.tsx
@@ -86,8 +86,13 @@ export function OtherProviderMedsTableTab({
   useEffect(() => {
     if (!isLoading && otherProviderMedications) {
       const filteredRecords = otherProviderMedications.filter((medication) => {
-        if (filters.providers?.selected) {
-          return filters.providers.selected === medication.lastPrescriber;
+        if (
+          Array.isArray(filters.providers?.selected) &&
+          filters.providers?.selected.length
+        ) {
+          return filters.providers.selected.includes(
+            medication.lastPrescriber as string
+          );
         }
         return true;
       });
@@ -161,7 +166,7 @@ export function PatientMedicationsTabbed({
   return (
     <CTWBox.StackedWrapper
       className={cx(
-        "ctw-patient-resource-component ctw-patient-medications ctw-space-y-3",
+        "ctw-patient-medications ctw-space-y-3 ctw-bg-white",
         className
       )}
     >

--- a/src/components/content/medications/patient-medications.tsx
+++ b/src/components/content/medications/patient-medications.tsx
@@ -40,7 +40,7 @@ export const PatientMedications = withErrorBoundary(
 
     return (
       <CTWBox.StackedWrapper
-        className={cx(" ctw-patient-medications", className)}
+        className={cx("ctw-patient-medications", className)}
         data-zus-telemetry-namespace="PatientMedications"
       >
         <CTWBox.Heading title="Medications">

--- a/src/components/content/medications/provider-meds-table.tsx
+++ b/src/components/content/medications/provider-meds-table.tsx
@@ -12,10 +12,9 @@ import { sort, SortDir } from "@/utils/sort";
 
 export type ProviderMedsTableProps = {
   className?: string;
+  showInactive?: boolean;
   sortColumn?: keyof MedicationStatementModel;
   sortOrder?: SortDir;
-  // should inactive meds be shown?
-  showInactive?: boolean;
 } & MedsHistoryTempProps;
 
 /**

--- a/src/components/content/medications/story-helpers/mocks/requests.ts
+++ b/src/components/content/medications/story-helpers/mocks/requests.ts
@@ -26,109 +26,117 @@ export function setupMedicationMocks({
       },
     ],
     parameters: {
-      msw: [
-        mockPatientGet,
-        mockTerminologyDosageGet,
-        mockMedicationStatementGet,
-        mockMedicationStatementPost,
-        mockMedicationRequestGet,
-        mockMedicationDispenseGet,
-        mockMedicationAdministrationGet,
-        mockBasicPost,
-      ],
+      msw: mockRequests(),
     },
   };
 }
 
-const mockPatientGet = rest.get(
-  "https://api.dev.zusapi.com/fhir/Patient",
-  // Add ctx.delay(750), delay to show loading, we set this to 750ms to be
-  // less than the default testing-library timeout of 1000ms.
-  (req, res, ctx) => res(ctx.delay(750), ctx.status(200), ctx.json(patient))
-);
+function mockRequests() {
+  const mockPatientGet = rest.get(
+    "https://api.dev.zusapi.com/fhir/Patient",
+    // Add ctx.delay(750), delay to show loading, we set this to 750ms to be
+    // less than the default testing-library timeout of 1000ms.
+    (req, res, ctx) => res(ctx.delay(750), ctx.status(200), ctx.json(patient))
+  );
 
-const mockMedicationStatementGet = rest.get(
-  "https://api.dev.zusapi.com/fhir/MedicationStatement",
-  (req, res, ctx) => {
-    if (req.url.searchParams.get("firstparty")) {
-      return res(ctx.status(200), ctx.json(patientProviderMedsCache));
+  const mockMedicationStatementGet = rest.get(
+    "https://api.dev.zusapi.com/fhir/MedicationStatement",
+    (req, res, ctx) => {
+      if (req.url.searchParams.get("firstparty")) {
+        return res(ctx.status(200), ctx.json(patientProviderMedsCache));
+      }
+      return res(ctx.status(200), ctx.json(patientOtherProviderMedsCache));
     }
-    return res(ctx.status(200), ctx.json(patientOtherProviderMedsCache));
-  }
-);
+  );
 
-// Mocked post will add the new medication to patientProviderMedsCache
-const mockMedicationStatementPost = rest.post(
-  "https://api.dev.zusapi.com/fhir",
-  async (req, res, ctx) => {
-    const findMedStatementInBundleFn = find({
-      resource: { resourceType: "MedicationStatement" },
-    });
-    const bundle = await req.json();
-    const newMedication = findMedStatementInBundleFn(bundle.entry)?.resource as
-      | MedicationStatement
-      | undefined;
-    if (!newMedication) {
-      return res(ctx.status(400));
+  // Mocked post will add the new medication to patientProviderMedsCache
+  const mockMedicationStatementPost = rest.post(
+    "https://api.dev.zusapi.com/fhir",
+    async (req, res, ctx) => {
+      const findMedStatementInBundleFn = find({
+        resource: { resourceType: "MedicationStatement" },
+      });
+      const bundle = await req.json();
+      const newMedication = findMedStatementInBundleFn(bundle.entry)
+        ?.resource as MedicationStatement | undefined;
+      if (!newMedication) {
+        return res(ctx.status(400));
+      }
+
+      newMedication.id = uuidv4();
+      patientProviderMedsCache.entry?.push({
+        resource: newMedication,
+        search: { mode: "match" },
+      });
+      patientProviderMedsCache.total = patientProviderMedsCache.entry?.length;
+
+      return res(ctx.delay(500), ctx.status(200), ctx.json(newMedication));
     }
+  );
 
-    newMedication.id = uuidv4();
-    patientProviderMedsCache.entry?.push({
-      resource: newMedication,
-      search: { mode: "match" },
-    });
-    patientProviderMedsCache.total = patientProviderMedsCache.entry?.length;
+  const mockMedicationRequestGet = rest.get(
+    "https://api.dev.zusapi.com/fhir/MedicationRequest",
+    (req, res, ctx) => res(ctx.status(200), ctx.json(medicationRequest))
+  );
 
-    return res(ctx.delay(500), ctx.status(200), ctx.json(newMedication));
-  }
-);
+  const mockMedicationDispenseGet = rest.get(
+    "https://api.dev.zusapi.com/fhir/MedicationDispense",
+    (req, res, ctx) => res(ctx.status(200), ctx.json(medicationDispense))
+  );
 
-const mockMedicationRequestGet = rest.get(
-  "https://api.dev.zusapi.com/fhir/MedicationRequest",
-  (req, res, ctx) => res(ctx.status(200), ctx.json(medicationRequest))
-);
+  const mockMedicationAdministrationGet = rest.get(
+    "https://api.dev.zusapi.com/fhir/MedicationAdministration",
+    (req, res, ctx) => res(ctx.status(200), ctx.json(medicationAdministration))
+  );
 
-const mockMedicationDispenseGet = rest.get(
-  "https://api.dev.zusapi.com/fhir/MedicationDispense",
-  (req, res, ctx) => res(ctx.status(200), ctx.json(medicationDispense))
-);
+  const mockTerminologyDosageGet = rest.get(
+    "https://api.dev.zusapi.com/forms-data/terminology/dosages",
+    (req, res, ctx) => {
+      const search = req.url.searchParams.get("display") ?? "";
+      const results = searchDosagesALB.filter(
+        (item) => item.display.indexOf(search) !== -1
+      );
+      return res(
+        ctx.status(200),
+        ctx.json({
+          total: results.length,
+          data: results,
+        })
+      );
+    }
+  );
 
-const mockMedicationAdministrationGet = rest.get(
-  "https://api.dev.zusapi.com/fhir/MedicationAdministration",
-  (req, res, ctx) => res(ctx.status(200), ctx.json(medicationAdministration))
-);
+  // Mock the creation of a Basic resource for a dismissed med and add to cache.
+  const mockBasicPost = rest.post(
+    "https://api.dev.zusapi.com/fhir/Basic",
+    async (req, res, ctx) => {
+      const newBasicResource = await req.json();
+      if (newBasicResource.subject.type !== "MedicationStatement") {
+        // The ZusAggregatedProfile component has multiple tabs mocking fhir
+        // Basic resources. We only want to handle medications here.
+        return undefined;
+      }
+      newBasicResource.search = { mode: "include" };
+      newBasicResource.id = uuidv4();
+      patientOtherProviderMedsCache.entry?.push({
+        resource: newBasicResource,
+        search: { mode: "include" },
+      });
 
-const mockTerminologyDosageGet = rest.get(
-  "https://api.dev.zusapi.com/forms-data/terminology/dosages",
-  (req, res, ctx) => {
-    const search = req.url.searchParams.get("display") ?? "";
-    const results = searchDosagesALB.filter(
-      (item) => item.display.indexOf(search) !== -1
-    );
-    return res(
-      ctx.status(200),
-      ctx.json({
-        total: results.length,
-        data: results,
-      })
-    );
-  }
-);
+      patientOtherProviderMedsCache.total =
+        patientOtherProviderMedsCache.entry?.length || 0;
+      return res(ctx.status(200), ctx.json(newBasicResource));
+    }
+  );
 
-// Mock the creation of a Basic resource for a dismissed med and add to cache.
-const mockBasicPost = rest.post(
-  "https://api.dev.zusapi.com/fhir/Basic",
-  async (req, res, ctx) => {
-    const newBasicResource = await req.json();
-    newBasicResource.search = { mode: "include" };
-    newBasicResource.id = uuidv4();
-    patientOtherProviderMedsCache.entry?.push({
-      resource: newBasicResource,
-      search: { mode: "include" },
-    });
-
-    patientOtherProviderMedsCache.total =
-      patientOtherProviderMedsCache.entry?.length || 0;
-    return res(ctx.status(200), ctx.json(newBasicResource));
-  }
-);
+  return [
+    mockPatientGet,
+    mockTerminologyDosageGet,
+    mockMedicationStatementGet,
+    mockMedicationStatementPost,
+    mockMedicationRequestGet,
+    mockMedicationDispenseGet,
+    mockMedicationAdministrationGet,
+    mockBasicPost,
+  ];
+}

--- a/src/components/core/main.scss
+++ b/src/components/core/main.scss
@@ -110,10 +110,6 @@
     hyphens: auto;
   }
 
-  .ctw-patient-resource-component {
-    @apply ctw-bg-white ctw-p-5;
-  }
-
   select.ctw-error,
   input.ctw-error {
     @apply ctw-border-error-main ctw-pr-10 focus:ctw-border-error-main focus:ctw-outline-none focus:ctw-ring-1 focus:ctw-ring-error-main;


### PR DESCRIPTION
As I started the ZusAggregatedProfile I realized storybook would need refactoring. That snowballed into a good place, but also lots of files touched. So this PR I removed the ZusAggregatedProfile component and left in storybook and component changes to support the mega component.

- MSW mocks now cleanup appropriately when changing to different components and reset completely before a new story begins.
- Medications and Conditions both mock `Basic` resource, which is fine, now it's double fine as both mocks can exist at same time (as they will need to in ZusAggregatedProfile story). Having multiple mocks for the same URL is fine, returning undefined from a handler allows other handlers to run. So the conditions mock of "Basic" now returns undefined if the resource sent in the request isn't a condition (and vice-versa for medications component mocks)
- Removed header from allergies component.
- Made padding in conditions actions even on top and bottom (so meds and conditions will look the same in ZAP component and match figma).


There will be more style changes when the second ZAP component PR comes in. For now I wanted to get the storybook changes in as they are legion.