### PR TITLE
Add logging when form errors our validation

### DIFF
--- a/.changeset/tender-grapes-rule.md
+++ b/.changeset/tender-grapes-rule.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Add logging when our form fails our validation, so that consumers of library can debug better.

--- a/src/components/core/form/drawer-form.tsx
+++ b/src/components/core/form/drawer-form.tsx
@@ -69,6 +69,11 @@ export const DrawerForm = <T,>({
     // Validation that occurs before the request.
     const formResult = await getFormData(data, schema);
     if (!formResult.success) {
+      // eslint-disable-next-line no-console
+      console.error(
+        "There was an error processing form data. formResult:",
+        formResult
+      );
       setErrors({
         formErrors: formResult.errors,
         requestErrors: undefined,


### PR DESCRIPTION
It is very hard to debug as a consumer of the drawerFormWithFields when it fails our validation as we can see the error or dont have access to the object. This just adds a log to help when debugging. 