### PR TITLE
Uniform tables and telemetry

### DIFF
--- a/.changeset/large-geckos-smile.md
+++ b/.changeset/large-geckos-smile.md
@@ -1,0 +1,8 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Telemetry wrapper on Allergies, Immunizations and Documents.
+Remove heading titles from Immunizations and Documents.
+Remove inner padding on PatientsTable.
+

--- a/.changeset/large-geckos-smile.md
+++ b/.changeset/large-geckos-smile.md
@@ -5,4 +5,3 @@
 Telemetry wrapper on Allergies, Immunizations and Documents.
 Remove heading titles from Immunizations and Documents.
 Remove inner padding on PatientsTable.
-

--- a/src/components/content/allergies/patient-allergies.tsx
+++ b/src/components/content/allergies/patient-allergies.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { patientAllergiesColumns } from "@/components/content/allergies/patient-allergies-column";
+import { withErrorBoundary } from "@/components/core/error-boundary";
 import { Table } from "@/components/core/table/table";
 import { usePatientAllergies } from "@/fhir/allergies";
 import { useBreakpoints } from "@/hooks/use-breakpoints";
@@ -9,7 +10,7 @@ export type PatientAllergiesProps = {
   enableFqs?: boolean;
 };
 
-export function PatientAllergies({
+function PatientAllergiesComponent({
   className,
   enableFqs,
 }: PatientAllergiesProps) {
@@ -27,14 +28,21 @@ export function PatientAllergies({
       ref={containerRef}
       data-zus-telemetry-namespace="Allergies"
     >
-      <Table
-        stacked={breakpoints.sm}
-        className="-ctw-mx-px !ctw-rounded-none"
-        removeLeftAndRightBorders
-        isLoading={isLoading}
-        records={allergies}
-        columns={patientAllergiesColumns}
-      />
+      <div className="ctw-overflow-hidden">
+        <Table
+          stacked={breakpoints.sm}
+          className="-ctw-mx-px !ctw-rounded-none"
+          removeLeftAndRightBorders
+          isLoading={isLoading}
+          records={allergies}
+          columns={patientAllergiesColumns}
+        />
+      </div>
     </div>
   );
 }
+
+export const PatientAllergies = withErrorBoundary(
+  PatientAllergiesComponent,
+  "PatientAllergies"
+);

--- a/src/components/content/conditions/patient-conditions.tsx
+++ b/src/components/content/conditions/patient-conditions.tsx
@@ -78,13 +78,9 @@ export const PatientConditions = withErrorBoundary(
     return (
       <div
         ref={containerRef}
-        className={cx(
-          "ctw-patient-conditions ctw-items-center ctw-justify-between ctw-bg-white",
-          className,
-          {
-            "ctw-patient-conditions-stacked": breakpoints.sm,
-          }
-        )}
+        className={cx("ctw-patient-conditions ctw-bg-white", className, {
+          "ctw-patient-conditions-stacked": breakpoints.sm,
+        })}
       >
         {!(hideBuilderOwnedRecords || hideOutsideOwnedRecords) && (
           <PatientConditionsTabs
@@ -107,23 +103,25 @@ export const PatientConditions = withErrorBoundary(
           filters={filters[collection]}
         />
 
-        <Table
-          stacked={breakpoints.sm}
-          removeLeftAndRightBorders
-          className="-ctw-mx-px !ctw-rounded-none"
-          showTableHead={false}
-          emptyMessage="There are no condition records available."
-          isLoading={isLoading()}
-          records={conditions}
-          RowActions={readOnly ? undefined : RowActions}
-          columns={patientConditionsColumns}
-          handleRowClick={(condition) =>
-            showConditionHistory({
-              condition,
-              readOnly: readOnly || condition.isSummaryResource,
-            })
-          }
-        />
+        <div className="ctw-overflow-hidden">
+          <Table
+            stacked={breakpoints.sm}
+            removeLeftAndRightBorders
+            className="-ctw-mx-px !ctw-rounded-none"
+            showTableHead={false}
+            emptyMessage="There are no condition records available."
+            isLoading={isLoading()}
+            records={conditions}
+            RowActions={readOnly ? undefined : RowActions}
+            columns={patientConditionsColumns}
+            handleRowClick={(condition) =>
+              showConditionHistory({
+                condition,
+                readOnly: readOnly || condition.isSummaryResource,
+              })
+            }
+          />
+        </div>
       </div>
     );
   },

--- a/src/components/content/document/patient-documents.tsx
+++ b/src/components/content/document/patient-documents.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 import { useRef } from "react";
 import { useDocumentDetailsDrawer } from "./document-details-drawer";
 import { patientDocumentColumns } from "./patient-document-columns";
-import { Heading } from "@/components/core/ctw-box";
+import { withErrorBoundary } from "@/components/core/error-boundary";
 import { Table } from "@/components/core/table/table";
 import { usePatientDocument } from "@/fhir/document";
 import { DocumentModel } from "@/fhir/models/document";
@@ -13,7 +13,7 @@ export type PatientDocumentProps = {
   includeViewFhirResource?: boolean;
 };
 
-export function PatientDocuments({
+function PatientDocumentsComponent({
   className,
   includeViewFhirResource,
 }: PatientDocumentProps) {
@@ -32,23 +32,27 @@ export function PatientDocuments({
   return (
     <div
       ref={containerRef}
-      className={cx(
-        "ctw-border ctw-border-solid ctw-border-divider-light ctw-bg-white",
-        className,
-        {
-          "ctw-stacked": breakpoints.sm,
-        }
-      )}
+      data-zus-telemetry-namespace="Documents"
+      className={cx("ctw-patient-documents ctw-bg-white", className, {
+        "ctw-stacked": breakpoints.sm,
+      })}
     >
-      <Heading title="Documents" />
-      <Table
-        stacked={breakpoints.sm}
-        className="-ctw-mx-px !ctw-rounded-none"
-        isLoading={isLoading}
-        records={document}
-        columns={patientDocumentColumns(includeViewFhirResource)}
-        handleRowClick={handleRowClick}
-      />
+      <div className="ctw-overflow-hidden">
+        <Table
+          stacked={breakpoints.sm}
+          removeLeftAndRightBorders
+          className="-ctw-mx-px !ctw-rounded-none"
+          isLoading={isLoading}
+          records={document}
+          columns={patientDocumentColumns(includeViewFhirResource)}
+          handleRowClick={handleRowClick}
+        />
+      </div>
     </div>
   );
 }
+
+export const PatientDocuments = withErrorBoundary(
+  PatientDocumentsComponent,
+  "PatientDocuments"
+);

--- a/src/components/content/immunizations/patient-immunizations.tsx
+++ b/src/components/content/immunizations/patient-immunizations.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 import { useRef } from "react";
 import { useImmunizationDetailsDrawer } from "./immunizations-details-drawer";
 import { patientImmunizationsColumns } from "./patient-immunizations-columns";
-import { Heading } from "@/components/core/ctw-box";
+import { withErrorBoundary } from "@/components/core/error-boundary";
 import { Table } from "@/components/core/table/table";
 import { ViewFHIR } from "@/components/core/view-fhir";
 import { usePatientImmunizations } from "@/fhir/immunizations";
@@ -17,7 +17,9 @@ const viewRecordFHIR = ({ record }: { record: ImmunizationModel }) => (
   <ViewFHIR name="Immunization Resource" resource={record.resource} />
 );
 
-export function PatientImmunizations({ className }: PatientImmunizationsProps) {
+function PatientImmunizationsComponent({
+  className,
+}: PatientImmunizationsProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const breakpoints = useBreakpoints(containerRef);
   const patientImmunizationsQuery = usePatientImmunizations();
@@ -30,24 +32,28 @@ export function PatientImmunizations({ className }: PatientImmunizationsProps) {
   return (
     <div
       ref={containerRef}
-      className={cx(
-        "ctw-patient-immunizations ctw-border ctw-border-solid ctw-border-divider-light ctw-bg-white",
-        className,
-        {
-          "ctw-stacked": breakpoints.sm,
-        }
-      )}
+      data-zus-telemetry-namespace="Immunizations"
+      className={cx("ctw-patient-immunizations ctw-bg-white", className, {
+        "ctw-stacked": breakpoints.sm,
+      })}
     >
-      <Heading title="Immunizations" />
-      <Table
-        RowActions={viewRecordFHIR}
-        stacked={breakpoints.sm}
-        className="-ctw-mx-px !ctw-rounded-none"
-        isLoading={patientImmunizationsQuery.isLoading}
-        records={patientImmunizationsQuery.data ?? []}
-        columns={patientImmunizationsColumns}
-        handleRowClick={handleRowClick}
-      />
+      <div className="ctw-overflow-hidden">
+        <Table
+          removeLeftAndRightBorders
+          RowActions={viewRecordFHIR}
+          stacked={breakpoints.sm}
+          className="-ctw-mx-px !ctw-rounded-none"
+          isLoading={patientImmunizationsQuery.isLoading}
+          records={patientImmunizationsQuery.data ?? []}
+          columns={patientImmunizationsColumns}
+          handleRowClick={handleRowClick}
+        />
+      </div>
     </div>
   );
 }
+
+export const PatientImmunizations = withErrorBoundary(
+  PatientImmunizationsComponent,
+  "PatientImmunizations"
+);

--- a/src/components/content/medications-table-base.tsx
+++ b/src/components/content/medications-table-base.tsx
@@ -109,17 +109,19 @@ export const MedicationsTableBase = ({
       ref={containerRef}
       data-zus-telemetry-namespace={telemetryNamespace}
     >
-      <Table
-        removeLeftAndRightBorders
-        className="-ctw-mx-px !ctw-rounded-none"
-        sort={sort}
-        onSort={setSort}
-        stacked={breakpoints.sm}
-        records={medicationStatements}
-        columns={breakpoints.sm ? columnsStacked : columns}
-        emptyMessage={emptyMessage}
-        {...tableProps}
-      />
+      <div className="ctw-overflow-hidden">
+        <Table
+          removeLeftAndRightBorders
+          className="-ctw-mx-px !ctw-rounded-none"
+          sort={sort}
+          onSort={setSort}
+          stacked={breakpoints.sm}
+          records={medicationStatements}
+          columns={breakpoints.sm ? columnsStacked : columns}
+          emptyMessage={emptyMessage}
+          {...tableProps}
+        />
+      </div>
       {children}
     </div>
   );

--- a/src/components/content/patients/patients-table.tsx
+++ b/src/components/content/patients/patients-table.tsx
@@ -116,8 +116,10 @@ export const PatientsTable = withErrorBoundary(
             />
           </div>
         </CTWBox.Heading>
-        <CTWBox.Body>
+        <div className="ctw-overflow-hidden">
           <Table
+            removeLeftAndRightBorders
+            className="-ctw-mx-px !ctw-rounded-none"
             records={patients}
             columns={columns}
             handleRowClick={handleRowClick}
@@ -131,7 +133,7 @@ export const PatientsTable = withErrorBoundary(
               isLoading={isFetching}
             />
           </Table>
-        </CTWBox.Body>
+        </div>
       </CTWBox.StackedWrapper>
     );
   },


### PR DESCRIPTION
Wraps tables in `.ctw-overflow-hidden` because the -1px x margin on tables will cause a bold lefthand border if the table touches the sides of its container (and the container has a border). This happened even if the left and right borders of the table were off.

Telemetry and error boundary wrapper on Allergies, Immunizations and Documents.

Removed these two class names `ctw-items-center ctw-justify-between` from component containers (besides old meds and old conditions) as the classes don't affect the layout at all. Must have been a relic of when more content was in the body of components.

Removed the title bar from Documents and Immunizations as the V2 components don't need titles. It's becoming more of a CTW pattern than a CTW Component Library pattern.

Removed the padding on Patients Table along with its tables left and right borders. See the image below, it is CTW, the nested borders are different styles and don't look like the rest of the site:
![Screen Shot 2023-02-23 at 2 15 57 PM](https://user-images.githubusercontent.com/6380075/221007909-2af7d2c6-e529-4cd9-bf31-00c2a8f4bd36.png)
So now they will look like this:
![Screen Shot 2023-02-23 at 2 18 33 PM](https://user-images.githubusercontent.com/6380075/221008421-a98c4578-b0b6-459d-9f76-d765f7d9a874.png)

For completeness, here are how the other components that were changed look:

https://www.loom.com/share/5044ddd4c0fa4fffb7e499da506cdc29

