### PR TITLE
CTW-782 Adjust columns for conditions component

### DIFF
--- a/.changeset/sixty-cherries-rest.md
+++ b/.changeset/sixty-cherries-rest.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Adjust display values for columns in conditions component.

--- a/src/components/content/conditions/patient-conditions-columns.tsx
+++ b/src/components/content/conditions/patient-conditions-columns.tsx
@@ -40,19 +40,13 @@ export const patientConditionsColumns: TableColumn<ConditionModel>[] = [
         </div>
         <div className="ctw-pc-status-and-extra">
           <div className="ctw-pc-status">{condition.displayStatus}</div>
-
-          {condition.isSummaryResource ? (
-            <div>
-              {compact([
-                condition.patient?.organization?.name,
-                condition.recordedDate,
-              ]).join(" ")}
-            </div>
-          ) : (
-            <div>
-              {compact([condition.recorder, condition.recordedDate]).join(" ")}
-            </div>
-          )}
+          <div>
+            Last Updated:{" "}
+            {compact([
+              condition.recordedDate,
+              condition.recorder ? `(${condition.recorder})` : "",
+            ]).join(" ")}
+          </div>
         </div>
       </div>
     ),

--- a/src/components/content/conditions/patient-conditions.scss
+++ b/src/components/content/conditions/patient-conditions.scss
@@ -31,10 +31,6 @@
     @apply ctw-text-base;
   }
 
-  .ctw-pc-status {
-    @apply ctw-text-sm ctw-font-medium ctw-capitalize ctw-text-content-black;
-  }
-
   .ctw-pc-notes {
     overflow: hidden;
     display: -webkit-box;


### PR DESCRIPTION
- Making display status not bold (so only the diagnosis string is bold)
- Added "Last Updated:" before the recorded date (which I verified is the latest recorded date for other provider records, so I think "Last Updated" is reasonable here).
- Added recorder name in parentheses, if available
- Removed Managing Org display from Other Provider Records tab. I don't think this makes sense to display at this level because we won't have a managing org on a summary resource like this, since the diagnosis could've been summarized from any number of outside records from different managing orgs that information makes more sense in the history (where it's already displayed).

[Verifying with UX in this Slack thread](https://zushealth.slack.com/archives/C03M2KKTXPZ/p1678200670412839?thread_ts=1678125980.304119&cid=C03M2KKTXPZ).

*Before*:
<img width="610" alt="Pasted Graphic 3" src="https://user-images.githubusercontent.com/97455910/223459318-5fe90f1a-b65c-44e6-b4fd-afebedd759b1.png">
<img width="610" alt="Pasted Graphic 4" src="https://user-images.githubusercontent.com/97455910/223459340-4de9e8ad-91ec-4855-b4e8-28296780bdce.png">

*After*:
<img width="610" alt="Pasted Graphic 5" src="https://user-images.githubusercontent.com/97455910/223459360-042e5fde-74da-47c6-b6f9-9fce2ae3dfef.png"
<img width="610" alt="Pasted Graphic 6" src="https://user-images.githubusercontent.com/97455910/223459375-c1c4cc8a-640d-444a-b81d-bb8649d1176c.png">
>


