### PR TITLE
CTW-681/fine scoped metrics for dashboard II

### DIFF
--- a/.changeset/green-mails-walk.md
+++ b/.changeset/green-mails-walk.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Paginate metric is not unique by page

--- a/src/components/core/pagination/pagination.tsx
+++ b/src/components/core/pagination/pagination.tsx
@@ -137,7 +137,7 @@ const Page = ({
       disabled={disabled}
       onClick={() => setCurrentPage(page)}
       className={cx(className, "ctw-pagination-page-btn", { active, disabled })}
-      data-zus-telemetry-click={`paginate(${page})`}
+      data-zus-telemetry-click="paginate"
     >
       {children || page}
     </button>


### PR DESCRIPTION
We no longer create a unique metric per page on "paginate" metrics.

Why: The `paginate_{number}` metric is now `paginate` because each unique metric here equals a handful of metrics which means `paginate_0` to `paginate_20` created ~100 custom metrics in our Datadog account.
