### PR TITLE
display zus status

### DIFF
--- a/.changeset/beige-pears-wash.md
+++ b/.changeset/beige-pears-wash.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Display Zus status instead of clinical and verification status.

--- a/src/components/content/condition-history/condition-history-schema.tsx
+++ b/src/components/content/condition-history/condition-history-schema.tsx
@@ -66,11 +66,7 @@ export const conditionData = (condition: ConditionModel) => [
     label: "Provider Organization",
     value: condition.patient?.organization?.name,
   },
-  { label: "Clinical Status", value: capitalize(condition.clinicalStatus) },
-  {
-    label: "Verification Status",
-    value: capitalize(condition.verificationStatus),
-  },
+  { label: "Status", value: capitalize(condition.displayStatus) },
   { label: "Onset Date", value: condition.onset },
   { label: "Abatement Date", value: condition.abatement },
   {


### PR DESCRIPTION
Display Zus status instead of clinical and verification status in history drawer preview

CTW-697