### PR TITLE
Ctw 772/fix dot style

### DIFF
--- a/.changeset/itchy-cows-complain.md
+++ b/.changeset/itchy-cows-complain.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix alignment and size of status dots. Add underline on display when hovering on items in medication table.

--- a/src/components/content/allergies/patient-allergies-column.tsx
+++ b/src/components/content/allergies/patient-allergies-column.tsx
@@ -4,7 +4,9 @@ import { AllergyModel } from "@/fhir/models/allergies";
 export const patientAllergiesColumns: TableColumn<AllergyModel>[] = [
   {
     title: "Onset",
-    dataIndex: "onset",
+    render: (allergy) => (
+      <div className="group-hover:ctw-underline">{allergy.onset}</div>
+    ),
   },
   {
     title: "Description",

--- a/src/components/content/conditions/helpers/columns.tsx
+++ b/src/components/content/conditions/helpers/columns.tsx
@@ -21,9 +21,7 @@ export const patientConditionsColumns: TableColumn<ConditionModel>[] = [
     minWidth: 320,
     render: (condition) => (
       <div>
-        <div className="ctw-pc-title group-hover:ctw-underline">
-          {condition.display}
-        </div>
+        <div className="group-hover:ctw-underline">{condition.display}</div>
         <div className="ctw-pc-chapter">{condition.ccsChapter}</div>
       </div>
     ),
@@ -40,9 +38,9 @@ export const patientConditionsColumns: TableColumn<ConditionModel>[] = [
         >
           &bull;
         </div>
-        <div className="ctw-pc-status-and-extra">
-          <div className="ctw-pc-status">{condition.displayStatus}</div>
+        <div className="ctw-pc-status">{condition.displayStatus}</div>
 
+        <div className="ctw-pc-status-and-extra">
           {condition.isSummaryResource ? (
             <div>
               {compact([

--- a/src/components/content/conditions/helpers/patient-conditions.scss
+++ b/src/components/content/conditions/helpers/patient-conditions.scss
@@ -5,7 +5,11 @@
     }
 
     .ctw-pc-status-and-extra {
-      margin-left: 0 !important;
+      grid-area: 2 / 2;
+    }
+
+    .ctw-pc-status-container {
+      display: initial;
     }
 
     .ctw-pc-status-dot {
@@ -16,6 +20,10 @@
       @apply ctw-text-content-black;
     }
   }
+
+  .ctw-pc-status-and-extra {
+    grid-area: 2 / 2;
+  }
 }
 
 .ctw-patient-conditions {
@@ -24,11 +32,13 @@
   }
 
   .ctw-pc-status-container {
-    @apply ctw-flex ctw-space-x-2;
+    @apply ctw-grid ctw-items-center;
+    grid-template-columns: 1rem auto;
+    grid-template-rows: 2;
   }
 
   .ctw-pc-status-dot {
-    @apply ctw-text-base;
+    @apply ctw-text-xl;
   }
 
   .ctw-pc-status {

--- a/src/components/content/document/patient-document-columns.tsx
+++ b/src/components/content/document/patient-document-columns.tsx
@@ -8,7 +8,9 @@ export const patientDocumentColumns = (includeViewFhirResource = true) => {
       widthPercent: 20,
       minWidth: 100,
       title: "Date Created",
-      render: (document) => <div>{document.dateCreated}</div>,
+      render: (document) => (
+        <div className="group-hover:ctw-underline">{document.dateCreated}</div>
+      ),
     },
     {
       widthPercent: 30,

--- a/src/components/content/immunizations/patient-immunizations-columns.tsx
+++ b/src/components/content/immunizations/patient-immunizations-columns.tsx
@@ -4,7 +4,9 @@ import { ImmunizationModel } from "@/fhir/models/immunization";
 export const patientImmunizationsColumns: TableColumn<ImmunizationModel>[] = [
   {
     title: "Date",
-    dataIndex: "occurrence",
+    render: (immunization) => (
+      <div className="group-hover:ctw-underline">{immunization.occurrence}</div>
+    ),
   },
   {
     title: "Description",

--- a/src/components/content/medications-table-base.tsx
+++ b/src/components/content/medications-table-base.tsx
@@ -38,7 +38,9 @@ export const MedicationsTableBase = ({
       title: "Medication Name",
       render: (medication) => (
         <>
-          <div className="ctw-font-medium">{medication.display}</div>
+          <div className="ctw-font-medium group-hover:ctw-underline">
+            {medication.display}
+          </div>
           <div className="ctw-font-light">{medication.dosage}</div>
         </>
       ),

--- a/src/components/content/timeline/patient-timeline-columns.tsx
+++ b/src/components/content/timeline/patient-timeline-columns.tsx
@@ -9,7 +9,9 @@ export const patientTimelineColumns = (includeViewFhirResource = true) => {
       title: "Date",
       widthPercent: 10,
       minWidth: 120,
-      dataIndex: "periodStart",
+      render: (encounter) => (
+        <div className="group-hover:ctw-underline">{encounter.periodStart}</div>
+      ),
     },
     {
       title: "Type",


### PR DESCRIPTION
Fix alignment and size of status dots. Add underline on display when hovering on items in medication table.

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/16874444/223830688-2f06baed-b678-476b-a230-548d2eab2cb2.png">


<img width="1129" alt="image" src="https://user-images.githubusercontent.com/16874444/223830533-8f94bcd5-9873-457e-b502-3338c89c091f.png">
