### PR TITLE
Dedupe logic condition history

### DIFF
--- a/.changeset/flat-dots-end.md
+++ b/.changeset/flat-dots-end.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Remove condition display from dedupe logic in condition history.

--- a/src/components/content/condition-history/condition-history-filters.tsx
+++ b/src/components/content/condition-history/condition-history-filters.tsx
@@ -35,9 +35,5 @@ const valuesToDedupeOn = (condition: ConditionModel) => [
   condition.onset,
   condition.abatement,
   condition.encounter,
-  condition.knownCodings.map((coding) => [
-    coding.display,
-    coding.system,
-    coding.code,
-  ]),
+  condition.knownCodings.map((coding) => [coding.system, coding.code]),
 ];

--- a/src/components/content/condition-history/condition-history-filters.tsx
+++ b/src/components/content/condition-history/condition-history-filters.tsx
@@ -15,7 +15,7 @@ export const applyConditionHistoryFilters = (
   // We sort by hasEnrichment as well because we want enriched records to be preferred in uniqWith function.
   const sortedConditions = orderBy(
     conditionModels,
-    [(c) => c.resource.recordedDate ?? "", (c) => c.hasEnrichment],
+    ["resource.recordedDate", "hasEnrichment"],
     "desc"
   );
 

--- a/src/components/content/condition-history/condition-history-filters.tsx
+++ b/src/components/content/condition-history/condition-history-filters.tsx
@@ -12,6 +12,7 @@ export const applyConditionHistoryFilters = (
     (c) => new ConditionModel(c, includedResources)
   );
 
+  // We sort by hasEnrichment as well because we want enriched records to be preferred in uniqWith function.
   const sortedConditions = orderBy(
     conditionModels,
     [(c) => c.resource.recordedDate ?? "", (c) => c.hasEnrichment],
@@ -22,6 +23,7 @@ export const applyConditionHistoryFilters = (
     isEqual(valuesToDedupeOn(a), valuesToDedupeOn(b))
   );
 
+  // Sort by recordedDate and then version id because recorded date is can be a flat date.
   return orderBy(
     conditionsDataDeduped,
     [(c) => c.resource.recordedDate ?? "", (c) => c.resource.meta?.versionId],

--- a/src/components/content/condition-history/condition-history-filters.tsx
+++ b/src/components/content/condition-history/condition-history-filters.tsx
@@ -14,7 +14,7 @@ export const applyConditionHistoryFilters = (
 
   const sortedConditions = orderBy(
     conditionModels,
-    (c) => c.resource.recordedDate ?? "",
+    [(c) => c.resource.recordedDate ?? "", (c) => c.hasEnrichment],
     "desc"
   );
 
@@ -22,7 +22,11 @@ export const applyConditionHistoryFilters = (
     isEqual(valuesToDedupeOn(a), valuesToDedupeOn(b))
   );
 
-  return conditionsDataDeduped;
+  return orderBy(
+    conditionsDataDeduped,
+    [(c) => c.resource.recordedDate ?? "", (c) => c.resource.meta?.versionId],
+    ["desc", "desc"]
+  );
 };
 
 const valuesToDedupeOn = (condition: ConditionModel) => [

--- a/src/fhir/models/condition.ts
+++ b/src/fhir/models/condition.ts
@@ -145,6 +145,19 @@ export class ConditionModel extends FHIRModel<fhir4.Condition> {
     return this.verificationStatusCode === "entered-in-error";
   }
 
+  get hasEnrichment(): boolean {
+    const enrichmentCodes = CONDITION_CODE_PREFERENCE_ORDER.filter(
+      (codePreference) => codePreference.checkForEnrichment === true
+    );
+    const codings = compact(
+      enrichmentCodes.map((code) =>
+        findCodingWithEnrichment(code.system, this.resource.code)
+      )
+    );
+
+    return codings.length > 0;
+  }
+
   get knownCodings(): fhir4.Coding[] {
     const codings = compact(
       CONDITION_CODE_PREFERENCE_ORDER.map((code) => {


### PR DESCRIPTION
Couple of decisions that had to be made:

- We sort by hasEnrichment as well because we want enriched records to be preferred in uniqWith function.
- Sort by recordedDate and then version id because recorded date is can be a flat date and it was not sorting by the most recent record if it was on the same date. Not sure maybe instead of versionId maybe lastUpdated time from the meta tag?

<img width="543" alt="Screenshot 2023-03-08 at 11 16 09 PM" src="https://user-images.githubusercontent.com/16874444/223915539-660950a8-35ee-4990-bbcc-e656b7db4f88.png">
