### PR TITLE
Revert tag filter

### DIFF
--- a/.changeset/rotten-ads-sip.md
+++ b/.changeset/rotten-ads-sip.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Re-add builder \_tag to filters.
+Re-add builder `_tag` to filters.

--- a/.changeset/rotten-ads-sip.md
+++ b/.changeset/rotten-ads-sip.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Re-add builder `_tag` to filters.
+Re-add builder `_tag` to filters to fix issue with CPR records being duplicated.

--- a/.changeset/rotten-ads-sip.md
+++ b/.changeset/rotten-ads-sip.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Re-add builder \_tag to filters.

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -3,6 +3,7 @@ import { getResources } from "./bundle";
 import {
   SYSTEM_SUMMARY,
   SYSTEM_ZUS_LENS,
+  SYSTEM_ZUS_OWNER,
   SYSTEM_ZUS_THIRD_PARTY,
   SYSTEM_ZUS_UNIVERSAL_ID,
   SYSTEM_ZUS_UPI_RECORD_TYPE,
@@ -88,12 +89,15 @@ export async function searchBuilderRecords<T extends ResourceTypeString>(
     ...SUMMARY_TAGS,
     ...UPI_TAGS,
   ];
+  const builderTag = `${SYSTEM_ZUS_OWNER}|builder/${requestContext.builderId}`;
   type FirstPartyParams = {
     _tag?: string[];
     firstparty?: boolean;
     "_tag:not"?: string[];
   };
-  const firstPartyParams: FirstPartyParams = {};
+  const firstPartyParams: FirstPartyParams = {
+    _tag: [builderTag],
+  };
 
   if (FIRST_PARTY_TAG_SUPPORTED_RESOURCES.includes(resourceType)) {
     firstPartyParams.firstparty = true;
@@ -114,7 +118,10 @@ export async function searchLensRecords<T extends ResourceTypeString>(
   lensTag: LensTag,
   searchParams?: SearchParams
 ): Promise<SearchReturn<T>> {
-  const tagFilter = [`${SYSTEM_ZUS_LENS}|${lensTag}`];
+  const tagFilter = [
+    `${SYSTEM_ZUS_LENS}|${lensTag}`,
+    `${SYSTEM_ZUS_OWNER}|builder/${requestContext.builderId}`,
+  ];
   const params = mergeParams(searchParams, {
     _tag: tagFilter,
   });
@@ -127,7 +134,10 @@ export async function searchSummaryRecords<T extends ResourceTypeString>(
   requestContext: CTWRequestContext,
   searchParams?: SearchParams
 ): Promise<SearchReturn<T>> {
-  const tagFilter = [...SUMMARY_TAGS];
+  const tagFilter = [
+    ...SUMMARY_TAGS,
+    `${SYSTEM_ZUS_OWNER}|builder/${requestContext.builderId}`,
+  ];
   const params = mergeParams(searchParams, {
     _tag: tagFilter,
   });


### PR DESCRIPTION
Re-add builder `_tag` to filters to fix issue with CPR records being duplicated.


Original pr: https://github.com/zeus-health/ctw-component-library/pull/542