### PR TITLE
Switch to better phone number regex

### DIFF
--- a/.changeset/tame-foxes-unite.md
+++ b/.changeset/tame-foxes-unite.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Allow phone numbers to have a leading 1 and country codes.

--- a/src/components/content/forms/schemas/validations.ts
+++ b/src/components/content/forms/schemas/validations.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 
 // Should match all valid formats.
-// See https://stackoverflow.com/a/16699507/1652396
+// See https://stackoverflow.com/a/56450924/1652396
 export const phoneNumberRegex =
-  /^(\+\d{1,2}\s)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/;
+  /^(\+\d{1,2}\s?)?1?-?\.?\s?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/;
 
 export const zipCodeRegex = /^\d{5}(-\d{4})?$/;
 


### PR DESCRIPTION
This regex should allow for more phone number patterns, including a leading 1 and +# for country-code's.

Before:
<img width="220" alt="Screenshot 2023-03-09 at 1 41 45 PM" src="https://user-images.githubusercontent.com/1568246/224123948-2a0c65f8-1f17-4312-80fe-ccc6dfc55748.png">

After:
<img width="181" alt="Screenshot 2023-03-09 at 1 41 21 PM" src="https://user-images.githubusercontent.com/1568246/224123960-c51c0570-2696-420d-b321-8cce79c9df3c.png">
