### PR TITLE
Fix few style issues with filters

### DIFF
--- a/.changeset/modern-ghosts-jump.md
+++ b/.changeset/modern-ghosts-jump.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix a few more style issues for filters.

--- a/src/components/core/filter-bar/filter-bar-pills/checkbox-pill.tsx
+++ b/src/components/core/filter-bar/filter-bar-pills/checkbox-pill.tsx
@@ -72,7 +72,7 @@ export function FilterBarCheckboxPill({
       <div className="ctw-truncate ctw-font-medium ctw-text-content-black">
         {displayFilterItem(filter, { active: true })}
         {selectedItems.length > 0 && (
-          <span className="ctw-font-normal">: {selectedItems.join(",")}</span>
+          <span className="ctw-font-normal">: {selectedItems.join(", ")}</span>
         )}
       </div>
 

--- a/src/components/core/filter-bar/filter-bar.tsx
+++ b/src/components/core/filter-bar/filter-bar.tsx
@@ -207,27 +207,29 @@ export const FilterBar = ({
   }
 
   return (
-    <div className={cx(className, "ctw-flex ctw-items-center")}>
-      <div className="ctw-relative ctw-flex ctw-space-x-2">
-        {activeFilters.map((filter) => (
-          <FilterBarPill
-            isOpen={recentlyAdded === filter.key}
-            key={filter.key}
-            filter={filter}
-            filterValues={activeFilterValues}
-            handleAddOrRemoveFilter={addOrRemoveFilter}
-            handleClearFilter={clearFilter}
-            updateSelectedFilterValues={(
-              valueKey: string,
-              isSelected: boolean
-            ) => updateSelectedFilter(filter.key, valueKey, isSelected)}
-          />
-        ))}
-      </div>
+    <div
+      className={cx(
+        className,
+        "ctw-relative ctw-flex ctw-items-center ctw-space-x-2"
+      )}
+    >
+      {activeFilters.map((filter) => (
+        <FilterBarPill
+          isOpen={recentlyAdded === filter.key}
+          key={filter.key}
+          filter={filter}
+          filterValues={activeFilterValues}
+          handleAddOrRemoveFilter={addOrRemoveFilter}
+          handleClearFilter={clearFilter}
+          updateSelectedFilterValues={(valueKey: string, isSelected: boolean) =>
+            updateSelectedFilter(filter.key, valueKey, isSelected)
+          }
+        />
+      ))}
 
       <ListBox
         useBasicStyles
-        btnClassName="ctw-bg-transparent ctw-text-content-light ctw-flex ctw-items-center"
+        btnClassName="!ctw-text-content-light ctw-btn-clear ctw-space-x-1 !ctw-font-normal"
         items={inactiveFilterMenuItems}
         onChange={(_index, item) => {
           switch (item.key) {
@@ -240,7 +242,8 @@ export const FilterBar = ({
           }
         }}
       >
-        <FontAwesomeIcon icon={faPlus} className="ctw-w-4" /> Add Filters
+        <FontAwesomeIcon icon={faPlus} className="ctw-w-4" />
+        <span>Add Filters</span>
       </ListBox>
     </div>
   );

--- a/src/components/core/list-box/list-box.tsx
+++ b/src/components/core/list-box/list-box.tsx
@@ -68,7 +68,11 @@ export function ListBox<T extends MinListBoxItem>({
             "ctw-relative ctw-cursor-pointer ctw-justify-between ctw-space-x-2 ctw-border-0 ctw-border-transparent"
           )}
         >
-          {children || renderDisplay(selectedItem, { listView: false })}
+          {/* Wrap in div here so our horizontal spacing affects these two elements
+              and not any elements the children may have. */}
+          <div>
+            {children || renderDisplay(selectedItem, { listView: false })}
+          </div>
           {!useBasicStyles && (
             <FontAwesomeIcon icon={faChevronDown} className="ctw-w-2" />
           )}


### PR DESCRIPTION
**NOTE TO REVIEWER: May want to view diff ignoring whitepsace.**

CTW Standalone -- Issue where "Add Filter" has bad padding due to CTW standalone resetting all button styles.
<img width="562" alt="Screenshot 2023-03-13 at 1 21 09 PM" src="https://user-images.githubusercontent.com/1568246/224780555-7b372cb5-a26c-4fb5-ba18-2cd3813ff0fc.png">

Now, our button uses `ctw-btn-clear` to get a cleaned up button and we tweak our spacing to add back the spacing the default padding was giving us. Also added vertical padding to increase click area.
<img width="444" alt="Screenshot 2023-03-13 at 1 36 07 PM" src="https://user-images.githubusercontent.com/1568246/224782594-23519bfb-94a0-48b7-b1cd-825a582a3a8b.png">
