### PR TITLE
CTW-667/condition unknown status

### DIFF
--- a/.changeset/smooth-stingrays-rest.md
+++ b/.changeset/smooth-stingrays-rest.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Add all condition statuses as filter options and ensure we can filter on "Unknown" status for both patient records and outside records.

--- a/src/components/content/conditions/helpers/filters.ts
+++ b/src/components/content/conditions/helpers/filters.ts
@@ -7,6 +7,10 @@ import {
   FilterItem,
 } from "@/components/core/filter-bar/filter-bar-types";
 import { ConditionModel } from "@/fhir/models";
+import {
+  conditionStatuses,
+  outsideConditionStatuses,
+} from "@/fhir/models/condition";
 import { uniqueValues } from "@/utils/filters";
 
 export function conditionFilters(
@@ -19,16 +23,8 @@ export function conditionFilters(
       type: "checkbox",
       icon: faClipboardCheck,
       display: "Status",
-      values: outside
-        ? ["Active", "Inactive", "Dismissed", "Unknown"]
-        : [
-            "Active",
-            "Inactive",
-            "Entered in Error",
-            "Pending",
-            "Refuted",
-            "Unknown",
-          ],
+      // Create new array as these other ones are readonly.
+      values: [...(outside ? outsideConditionStatuses : conditionStatuses)],
     },
     {
       key: "ccsChapter",

--- a/src/components/content/conditions/helpers/filters.ts
+++ b/src/components/content/conditions/helpers/filters.ts
@@ -20,7 +20,7 @@ export function conditionFilters(
       icon: faClipboardCheck,
       display: "Status",
       values: outside
-        ? ["Active", "Inactive", "Unknown"]
+        ? ["Active", "Inactive", "Dismissed", "Unknown"]
         : [
             "Active",
             "Inactive",

--- a/src/components/content/conditions/helpers/filters.ts
+++ b/src/components/content/conditions/helpers/filters.ts
@@ -9,14 +9,26 @@ import {
 import { ConditionModel } from "@/fhir/models";
 import { uniqueValues } from "@/utils/filters";
 
-export function conditionFilters(conditions: ConditionModel[]): FilterItem[] {
+export function conditionFilters(
+  conditions: ConditionModel[],
+  outside: boolean
+): FilterItem[] {
   return [
     {
       key: "displayStatus",
       type: "checkbox",
       icon: faClipboardCheck,
       display: "Status",
-      values: uniqueValues(conditions, "displayStatus"),
+      values: outside
+        ? ["Active", "Inactive", "Unknown"]
+        : [
+            "Active",
+            "Inactive",
+            "Entered in Error",
+            "Pending",
+            "Refuted",
+            "Unknown",
+          ],
     },
     {
       key: "ccsChapter",

--- a/src/components/content/conditions/helpers/patient-conditions-base.tsx
+++ b/src/components/content/conditions/helpers/patient-conditions-base.tsx
@@ -18,6 +18,7 @@ export type PatientConditionsTableProps = {
   action?: ResourceTableActionsProps<ConditionModel>["action"];
   className?: string;
   query: { data?: ConditionModel[]; isLoading: boolean };
+  outside?: boolean;
   readOnly?: boolean;
   rowActions?: ResourceTableProps<ConditionModel>["rowActions"];
 };
@@ -26,6 +27,7 @@ export const PatientConditionsBase = ({
   action,
   className,
   query,
+  outside = false,
   readOnly = false,
   rowActions,
 }: PatientConditionsTableProps) => {
@@ -42,7 +44,7 @@ export const PatientConditionsBase = ({
         filterOptions={{
           onChange: setFilters,
           defaultState: defaultConditionFilters,
-          filters: conditionFilters(query.data ?? []),
+          filters: conditionFilters(query.data ?? [], outside),
         }}
         sortOptions={{
           defaultSort: defaultConditionSort,

--- a/src/components/content/conditions/patient-conditions-outside.tsx
+++ b/src/components/content/conditions/patient-conditions-outside.tsx
@@ -26,6 +26,7 @@ const PatientConditionsOutsideComponent = ({
 
   return (
     <PatientConditionsBase
+      outside
       action={action}
       className={className}
       query={query}

--- a/src/components/core/filter-bar/filter-bar-pills.tsx
+++ b/src/components/core/filter-bar/filter-bar-pills.tsx
@@ -7,7 +7,6 @@ type FilterBarPillProps = {
   handleAddOrRemoveFilter: (key: string, remove: boolean) => void;
   filter: FilterItem;
   filterValues: FilterValuesRecord;
-  handleClearFilter: (key: string) => void;
   isOpen: boolean;
   updateSelectedFilterValues: (valueKey: string, isSelected: boolean) => void;
 };
@@ -19,7 +18,6 @@ type FilterBarPillProps = {
  */
 export function FilterBarPill({
   handleAddOrRemoveFilter,
-  handleClearFilter,
   filter,
   filterValues,
   isOpen,
@@ -45,7 +43,6 @@ export function FilterBarPill({
           filterValues={filterValues}
           onRemove={handleRemove}
           onChange={updateSelectedFilterValues}
-          onReset={() => handleClearFilter(filter.key)}
         />
       );
     default:

--- a/src/components/core/filter-bar/filter-bar-pills/checkbox-pill.tsx
+++ b/src/components/core/filter-bar/filter-bar-pills/checkbox-pill.tsx
@@ -1,8 +1,4 @@
-import {
-  faChevronDown,
-  faRefresh,
-  faTrash,
-} from "@fortawesome/free-solid-svg-icons";
+import { faChevronDown, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import cx from "classnames";
 import { DropdownMenuAction } from "@/components/core/dropdown-action-menu";
@@ -20,7 +16,6 @@ type FilterBarCheckboxPillProps = {
   isOpen: boolean;
   onChange: (key: string, isSelected: boolean) => void;
   onRemove?: () => void;
-  onReset?: () => void;
 };
 
 const buttonClassName =
@@ -32,7 +27,6 @@ export function FilterBarCheckboxPill({
   isOpen,
   onRemove,
   onChange,
-  onReset,
 }: FilterBarCheckboxPillProps) {
   const selected = filter.key in filterValues ? filterValues[filter.key] : [];
   const items = filter.values.map((item) => ({
@@ -51,13 +45,6 @@ export function FilterBarCheckboxPill({
       items={items}
       type="checkbox"
       pinnedActions={compact([
-        onReset
-          ? {
-              icon: faRefresh,
-              name: "Reset Filter",
-              action: onReset,
-            }
-          : null,
         onRemove
           ? {
               icon: faTrash,

--- a/src/components/core/filter-bar/filter-bar-pills/select-pill.tsx
+++ b/src/components/core/filter-bar/filter-bar-pills/select-pill.tsx
@@ -1,8 +1,4 @@
-import {
-  faRefresh,
-  faTrash,
-  IconDefinition,
-} from "@fortawesome/free-solid-svg-icons";
+import { faTrash, IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
 import { ReactNode } from "react";
 import { MenuItem } from "../../menu/menu-item";
@@ -34,7 +30,6 @@ const builtInButton = (name: string, key: string, icon: IconDefinition) => ({
       filter && renderDisplay(filter.display)
     ),
 });
-const resetButton = builtInButton("reset filter", "_reset", faRefresh);
 const removeButton = builtInButton("remove filter", "_remove", faTrash);
 
 export function FilterBarSelectPill({
@@ -45,7 +40,7 @@ export function FilterBarSelectPill({
   const filterNames = filter.values.map((value) =>
     isString(value) ? value : value.display
   );
-  const items = [...filterNames, resetButton, removeButton];
+  const items = [...filterNames, removeButton];
   return (
     <ListBox
       defaultIndex={items.length - 1} // clear index
@@ -54,7 +49,7 @@ export function FilterBarSelectPill({
       items={items.map((item) => ({
         // eslint-disable-next-line react/no-unstable-nested-components
         display: ({ listView }: ListBoxOptionStatus) => {
-          if (item === resetButton || item === removeButton) {
+          if (item === removeButton) {
             return item.display({ listView, filter });
           }
           return listView ? (
@@ -69,7 +64,7 @@ export function FilterBarSelectPill({
         key: isString(item) ? item : item.key,
         className: cx("ctw-capitalize", {
           "ctw-border ctw-capitalize ctw-border-solid ctw-border-divider-light ctw-border-0 ctw-border-t":
-            item === resetButton,
+            item === removeButton,
         }),
       }))}
       onChange={(index, item) => {

--- a/src/components/core/filter-bar/filter-bar.tsx
+++ b/src/components/core/filter-bar/filter-bar.tsx
@@ -6,7 +6,7 @@ import type {
 import { faPlus, faRefresh, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import cx from "classnames";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   filterChangeEvent,
   filterChangeEventToValuesRecord,
@@ -91,13 +91,6 @@ export const FilterBar = ({
       filterChangeEvent(filters, Object.keys(initialState), initialState)
     );
   };
-
-  const clearFilter = useCallback(
-    (key: string) => {
-      setActiveFilterValues({ ...activeFilterValues, [key]: [] });
-    },
-    [activeFilterValues]
-  );
 
   // Add or remove a filter from the activated filters list
   const addOrRemoveFilter = (key: string, remove = false) => {
@@ -220,7 +213,6 @@ export const FilterBar = ({
           filter={filter}
           filterValues={activeFilterValues}
           handleAddOrRemoveFilter={addOrRemoveFilter}
-          handleClearFilter={clearFilter}
           updateSelectedFilterValues={(valueKey: string, isSelected: boolean) =>
             updateSelectedFilter(filter.key, valueKey, isSelected)
           }

--- a/src/components/core/filter-bar/filter-bar.tsx
+++ b/src/components/core/filter-bar/filter-bar.tsx
@@ -229,7 +229,7 @@ export const FilterBar = ({
 
       <ListBox
         useBasicStyles
-        btnClassName="!ctw-text-content-light ctw-btn-clear ctw-space-x-1 !ctw-font-normal"
+        btnClassName="!ctw-text-content-light ctw-btn-clear !ctw-font-normal !ctw-py-2"
         items={inactiveFilterMenuItems}
         onChange={(_index, item) => {
           switch (item.key) {
@@ -242,8 +242,10 @@ export const FilterBar = ({
           }
         }}
       >
-        <FontAwesomeIcon icon={faPlus} className="ctw-w-4" />
-        <span>Add Filters</span>
+        <div className="ctw-space-x-1">
+          <FontAwesomeIcon icon={faPlus} className="ctw-w-4" />
+          <span>Add Filters</span>
+        </div>
       </ListBox>
     </div>
   );

--- a/src/components/core/list-box/list-box.tsx
+++ b/src/components/core/list-box/list-box.tsx
@@ -80,7 +80,6 @@ export function ListBox<T extends MinListBoxItem>({
                 <li
                   className={cx(
                     "ctw-flex ctw-cursor-pointer ctw-justify-between ctw-px-3 ctw-py-2",
-                    "first:ctw-pt-3 last:ctw-pb-3",
                     "hover:ctw-bg-bg-lighter",
                     item.className,
                     {

--- a/src/components/core/list-box/list-box.tsx
+++ b/src/components/core/list-box/list-box.tsx
@@ -68,11 +68,7 @@ export function ListBox<T extends MinListBoxItem>({
             "ctw-relative ctw-cursor-pointer ctw-justify-between ctw-space-x-2 ctw-border-0 ctw-border-transparent"
           )}
         >
-          {/* Wrap in div here so our horizontal spacing affects these two elements
-              and not any elements the children may have. */}
-          <div>
-            {children || renderDisplay(selectedItem, { listView: false })}
-          </div>
+          {children || renderDisplay(selectedItem, { listView: false })}
           {!useBasicStyles && (
             <FontAwesomeIcon icon={faChevronDown} className="ctw-w-2" />
           )}

--- a/src/fhir/models/condition.ts
+++ b/src/fhir/models/condition.ts
@@ -311,10 +311,6 @@ export class ConditionModel extends FHIRModel<fhir4.Condition> {
       }
     }
 
-    const concatenation =
-      verificationStatusMap(this.verificationStatusCode) +
-      clinicalStatusMap(this.clinicalStatusCode).toLowerCase();
-
     // What to show if lens or summary resource.
     if (this.isSummaryResource) {
       if (this.isArchived) {
@@ -323,6 +319,10 @@ export class ConditionModel extends FHIRModel<fhir4.Condition> {
 
       return clinicalStatusMap(this.clinicalStatusCode) || "Unknown";
     }
+
+    const concatenation =
+      verificationStatusMap(this.verificationStatusCode) +
+      clinicalStatusMap(this.clinicalStatusCode).toLowerCase();
 
     // What to show if patient record resource.
     switch (concatenation) {

--- a/src/fhir/models/condition.ts
+++ b/src/fhir/models/condition.ts
@@ -278,7 +278,7 @@ export class ConditionModel extends FHIRModel<fhir4.Condition> {
     );
   }
 
-  get displayStatus(): string {
+  get displayStatus(): ConditionStatuses {
     function clinicalStatusMap(code: ClinicalStatus | undefined) {
       switch (code) {
         case "active":
@@ -359,3 +359,23 @@ export class ConditionModel extends FHIRModel<fhir4.Condition> {
     })?.code as VerificationStatus | undefined;
   }
 }
+
+export const conditionStatuses = [
+  "Active",
+  "Inactive",
+  "Entered in Error",
+  "Pending",
+  "Refuted",
+  "Unknown",
+] as const;
+
+export const outsideConditionStatuses = [
+  "Active",
+  "Inactive",
+  "Dismissed",
+  "Unknown",
+] as const;
+
+export type ConditionStatuses =
+  | typeof conditionStatuses[number]
+  | typeof outsideConditionStatuses[number];

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -7,18 +7,27 @@ export const applyFilters = <T extends object>(
 ) =>
   data.filter((entry) =>
     Object.entries(filters).every(([_, filterItem]) => {
-      if (filterItem?.type === "checkbox" && isArray(filterItem.selected)) {
-        const filteredList = filterItem.selected.filter((item) =>
-          compact(uniq(data.map((c) => c[filterItem.key as keyof T]))).includes(
-            item as T[keyof T]
-          )
-        );
+      if (!filterItem) return true;
 
-        const targetFilter = entry[filterItem.key as keyof T];
+      const targetFilter = String(entry[filterItem.key as keyof T]);
 
-        return filteredList.includes(String(targetFilter));
+      switch (filterItem.type) {
+        case "checkbox":
+          if (isArray(filterItem.selected)) {
+            const filteredList = filterItem.selected.filter((item) =>
+              compact(
+                uniq(data.map((c) => c[filterItem.key as keyof T]))
+              ).includes(item as T[keyof T])
+            );
+
+            return filteredList.includes(targetFilter);
+          }
+          break;
+        case "select":
+          return targetFilter === filterItem.selected;
+        case "tag":
+        default:
       }
-
       return true;
     })
   );

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -16,9 +16,7 @@ export const applyFilters = <T extends object>(
 
         const targetFilter = entry[filterItem.key as keyof T];
 
-        return (
-          filteredList.length < 1 || filteredList.includes(String(targetFilter))
-        );
+        return filteredList.includes(String(targetFilter));
       }
 
       return true;


### PR DESCRIPTION
Fixed up status filtering for conditions.

1. Show all status options independent of data.
2. Include "Unknown" in list of status options, with ability to filter unknown statuses.
3. Remove "Reset Filter" button from individual filters.
4. Apply filters that have 0 things checked. Luckily when you first add a filter, we don't applyFilters yet, giving users a chance to make some selections. This will also get reworked in the near future to default new checkbox filters to have an "All" selected.

Not implemented, just showing future "All" functionality.
![Screenshot 2023-03-14 at 12 28 04 PM](https://user-images.githubusercontent.com/1568246/225072727-0adc3d63-fd5e-489f-ae04-7413551cdd43.png)

New status filters (implemented here!)
![Screenshot 2023-03-14 at 12 11 29 PM](https://user-images.githubusercontent.com/1568246/225072836-1e4035e4-957b-4918-90f0-0634f797eb77.png)

