### PR TITLE
Fix story decorators for scroll story

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "0.50.1",
+  "version": "0.50.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "0.50.1",
+      "version": "0.50.4",
       "dependencies": {
         "@datadog/browser-logs": "^4.30.1",
         "@datadog/browser-rum-slim": "^4.30.1",

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile.stories.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile.stories.tsx
@@ -40,27 +40,25 @@ export default {
   },
 } as Meta<Props>;
 
+const { decorators, parameters } = setupZusAggregatedProfileMocks({
+  allergyIntolerance,
+  otherConditions,
+  otherProviderMedications,
+  patientConditions,
+  providerMedications,
+});
+
 export const OutsideRecords: StoryObj<Props> = {
-  ...setupZusAggregatedProfileMocks({
-    allergyIntolerance,
-    otherConditions,
-    otherProviderMedications,
-    patientConditions,
-    providerMedications,
-  }),
+  decorators,
+  parameters,
   args: {
     resources: ["conditions-outside", "medications-outside"],
   },
 };
 
 export const ConditionsAndMedications: StoryObj<Props> = {
-  ...setupZusAggregatedProfileMocks({
-    allergyIntolerance,
-    otherConditions,
-    otherProviderMedications,
-    patientConditions,
-    providerMedications,
-  }),
+  decorators,
+  parameters,
   args: {
     resources: [
       "conditions",
@@ -72,26 +70,16 @@ export const ConditionsAndMedications: StoryObj<Props> = {
 };
 
 export const ProblemsAndDocuments: StoryObj<Props> = {
-  ...setupZusAggregatedProfileMocks({
-    allergyIntolerance,
-    otherConditions,
-    otherProviderMedications,
-    patientConditions,
-    providerMedications,
-  }),
+  decorators,
+  parameters,
   args: {
     resources: ["allergies", "conditions", "immunizations", "documents"],
   },
 };
 
 export const Everything: StoryObj<Props> = {
-  ...setupZusAggregatedProfileMocks({
-    allergyIntolerance,
-    otherConditions,
-    otherProviderMedications,
-    patientConditions,
-    providerMedications,
-  }),
+  decorators,
+  parameters,
   args: {
     resources: [
       "allergies",
@@ -108,13 +96,7 @@ export const Everything: StoryObj<Props> = {
 };
 
 export const ScrollbarsOnOverflowZap: StoryObj<Props> = {
-  ...setupZusAggregatedProfileMocks({
-    allergyIntolerance,
-    otherConditions,
-    otherProviderMedications,
-    patientConditions,
-    providerMedications,
-  }),
+  parameters,
   args: {
     resources: [
       "allergies",
@@ -131,6 +113,7 @@ export const ScrollbarsOnOverflowZap: StoryObj<Props> = {
     ],
   },
   decorators: [
+    ...decorators,
     (Story, { args }) => (
       <div className="ctw-border-solid ctw-border-divider-light ctw-p-2">
         <h3>Fixed height container</h3>


### PR DESCRIPTION
The issue was setupZusAggregatedProfileMocks is returning decorators but then we were overwriting it with our custom decorator. This caused a bug where on a fresh load certain resources would fail to fetch any data as the resource cache wasn't being initialized in the decorators as it should be.