### PR TITLE
CTW-802/show hide dismiss

### DIFF
--- a/.changeset/grumpy-chicken-move.md
+++ b/.changeset/grumpy-chicken-move.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Tweak "Show Dismissed Records" filter to be below divider and to then show up as "Hide Dismissed Records" when it has been applied.

--- a/src/components/content/conditions/helpers/filters.ts
+++ b/src/components/content/conditions/helpers/filters.ts
@@ -24,6 +24,7 @@ export function conditionFilters(
     filters.push({
       key: "isArchived",
       type: "tag",
+      belowTheFold: true,
       icon: faEye,
       display: ({ listView }) =>
         listView ? "show dismissed records" : "dismissed records",

--- a/src/components/content/conditions/helpers/filters.ts
+++ b/src/components/content/conditions/helpers/filters.ts
@@ -1,8 +1,8 @@
 import {
   faClipboardCheck,
   faClipboardList,
-  faEye,
 } from "@fortawesome/free-solid-svg-icons";
+import { dismissFilter } from "../../resource/filters";
 import {
   FilterChangeEvent,
   FilterItem,
@@ -21,14 +21,7 @@ export function conditionFilters(
   const filters: FilterItem[] = [];
 
   if (outside) {
-    filters.push({
-      key: "isArchived",
-      type: "tag",
-      belowTheFold: true,
-      icon: faEye,
-      display: ({ listView }) =>
-        listView ? "show dismissed records" : "dismissed records",
-    });
+    filters.push(dismissFilter);
   }
 
   filters.push(

--- a/src/components/content/medications/helpers/filters.ts
+++ b/src/components/content/medications/helpers/filters.ts
@@ -1,4 +1,5 @@
-import { faEye, faUser } from "@fortawesome/free-solid-svg-icons";
+import { faUser } from "@fortawesome/free-solid-svg-icons";
+import { dismissFilter } from "../../resource/filters";
 import {
   FilterChangeEvent,
   FilterItem,
@@ -14,14 +15,7 @@ export function medicationFilters(
   const filters: FilterItem[] = [];
 
   if (outside) {
-    filters.push({
-      key: "isArchived",
-      type: "tag",
-      belowTheFold: true,
-      icon: faEye,
-      display: ({ listView }) =>
-        listView ? "show dismissed records" : "dismissed records",
-    });
+    filters.push(dismissFilter);
   }
 
   if (prescriberNames.length > 1) {

--- a/src/components/content/medications/helpers/filters.ts
+++ b/src/components/content/medications/helpers/filters.ts
@@ -17,6 +17,7 @@ export function medicationFilters(
     filters.push({
       key: "isArchived",
       type: "tag",
+      belowTheFold: true,
       icon: faEye,
       display: ({ listView }) =>
         listView ? "show dismissed records" : "dismissed records",

--- a/src/components/content/resource/filters.ts
+++ b/src/components/content/resource/filters.ts
@@ -1,0 +1,13 @@
+import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+import { FilterItem } from "@/components/core/filter-bar/filter-bar-types";
+
+export const dismissFilter: FilterItem = {
+  key: "isArchived",
+  type: "tag",
+  belowTheFold: true,
+  display: ({ listView }) =>
+    listView ? "show dismissed records" : "dismissed records",
+  icon: faEye,
+  toggleDisplay: "hide dismissed records",
+  toggleIcon: faEyeSlash,
+};

--- a/src/components/content/resource/filters.ts
+++ b/src/components/content/resource/filters.ts
@@ -4,7 +4,7 @@ import { FilterItem } from "@/components/core/filter-bar/filter-bar-types";
 export const dismissFilter: FilterItem = {
   key: "isArchived",
   type: "tag",
-  belowTheFold: true,
+  belowDivider: true,
   display: ({ listView }) =>
     listView ? "show dismissed records" : "dismissed records",
   icon: faEye,

--- a/src/components/core/filter-bar/filter-bar-pills.tsx
+++ b/src/components/core/filter-bar/filter-bar-pills.tsx
@@ -4,7 +4,7 @@ import { FilterBarSelectPill } from "./filter-bar-pills/select-pill";
 import { FilterBarTagPill } from "./filter-bar-pills/tag-pill";
 
 type FilterBarPillProps = {
-  handleAddOrRemoveFilter: (key: string, remove: boolean) => void;
+  onRemove: (key: string) => void;
   filter: FilterItem;
   filterValues: FilterValuesRecord;
   isOpen: boolean;
@@ -17,13 +17,13 @@ type FilterBarPillProps = {
  * will only be used by the FilterBar component.
  */
 export function FilterBarPill({
-  handleAddOrRemoveFilter,
+  onRemove,
   filter,
   filterValues,
   isOpen,
   updateSelectedFilterValues,
 }: FilterBarPillProps) {
-  const handleRemove = () => handleAddOrRemoveFilter(filter.key, true);
+  const handleRemove = () => onRemove(filter.key);
   switch (filter.type) {
     case "tag":
       return <FilterBarTagPill filter={filter} onRemove={handleRemove} />;

--- a/src/components/core/filter-bar/filter-bar-types.ts
+++ b/src/components/core/filter-bar/filter-bar-types.ts
@@ -11,7 +11,7 @@ export type FilterBarProps = {
 };
 
 type MinFilterItem = {
-  belowTheFold?: boolean; // should the filter be below divider in main menu?
+  belowDivider?: boolean; // Should the filter be below divider in main menu?
   className?: cx.Argument;
   display: string | ((status: ListBoxOptionStatus) => ReactNode | string);
   icon?: IconDefinition;

--- a/src/components/core/filter-bar/filter-bar-types.ts
+++ b/src/components/core/filter-bar/filter-bar-types.ts
@@ -16,6 +16,10 @@ type MinFilterItem = {
   display: string | ((status: ListBoxOptionStatus) => ReactNode | string);
   icon?: IconDefinition;
   key: string;
+  // These allow the filter to still show up in the main filter menu
+  // but with a different display and or icon.
+  toggleDisplay?: string;
+  toggleIcon?: IconDefinition;
 };
 
 export type FilterOptionSelect = {

--- a/src/components/core/filter-bar/filter-bar-types.ts
+++ b/src/components/core/filter-bar/filter-bar-types.ts
@@ -10,31 +10,34 @@ export type FilterBarProps = {
   defaultState?: FilterChangeEvent;
 };
 
-export type MinFilterItem = {
+type MinFilterItem = {
   belowTheFold?: boolean; // should the filter be below divider in main menu?
   className?: cx.Argument;
   display: string | ((status: ListBoxOptionStatus) => ReactNode | string);
   icon?: IconDefinition;
   key: string;
-  type: "tag";
 };
 
 export type FilterOptionSelect = {
   type: "select";
   // Using strings in `values` will set both key and display automatically
   values: (string | { key: string; display: string })[];
-} & Omit<MinFilterItem, "type">;
+} & MinFilterItem;
 
 export type FilterOptionCheckbox = {
   type: "checkbox";
   // Using strings in `values` will set both key and display automatically
   values: (string | { key: string; display: string })[];
-} & Omit<MinFilterItem, "type">;
+} & MinFilterItem;
+
+export type FilterOptionTag = {
+  type: "tag";
+} & MinFilterItem;
 
 export type FilterItem =
-  | MinFilterItem
   | FilterOptionSelect
-  | FilterOptionCheckbox;
+  | FilterOptionCheckbox
+  | FilterOptionTag;
 
 export type FilterValuesRecord = Record<string, string | string[]>;
 

--- a/src/components/core/filter-bar/filter-bar.tsx
+++ b/src/components/core/filter-bar/filter-bar.tsx
@@ -168,30 +168,35 @@ export const FilterBar = ({
 
   const activeFiltersWithToggle = activeFilters.filter((f) => f.toggleDisplay);
 
-  const [aboveTheFold, belowTheFold] = partition(
-    (filter) => !filter.belowTheFold,
+  const [aboveDivider, belowDivider] = partition(
+    (filter) => !filter.belowDivider,
     [...inactiveFilters, ...activeFiltersWithToggle]
   );
 
   if (!isEmptyValue(initialState)) {
-    belowTheFold.push({
+    belowDivider.push({
       display: "reset filters",
       icon: faRefresh,
       key: "_reset",
       type: "tag",
     });
   }
-  belowTheFold.push({
+  belowDivider.push({
     display: "remove all filters",
     icon: faTrash,
     key: "_remove",
     type: "tag",
   });
 
+  // Add a divider only if there are both items above
+  // and below the divider.
+  const maybeDivider: { divider: true }[] =
+    aboveDivider.length && belowDivider.length ? [{ divider: true }] : [];
+
   const menuItems: MinListBoxItem[] = [
-    ...aboveTheFold.map(toFilterMenuItem),
-    { divider: true },
-    ...belowTheFold.map(toFilterMenuItem),
+    ...aboveDivider.map(toFilterMenuItem),
+    ...maybeDivider,
+    ...belowDivider.map(toFilterMenuItem),
   ];
 
   return (

--- a/src/components/core/filter-bar/filter-bar.tsx
+++ b/src/components/core/filter-bar/filter-bar.tsx
@@ -14,6 +14,7 @@ import {
 import { FilterBarPill } from "@/components/core/filter-bar/filter-bar-pills";
 import { ListBox, MinListBoxItem } from "@/components/core/list-box/list-box";
 import { omit, partition, uniq } from "@/utils/nodash/fp";
+import { isEmptyValue } from "@/utils/types";
 
 const INTERNAL_KEYS = ["_remove", "_reset"];
 const removeInternalKeys = (keys: string[]) =>
@@ -161,43 +162,27 @@ export const FilterBar = ({
     (filter) => !filter.belowTheFold,
     inactiveFilters
   );
-  const hasBelowTheFoldItems = belowTheFold.length > 0;
-  if (hasBelowTheFoldItems) {
-    // We need to add the ccs border top divider to first item under fold
-    belowTheFold[0] = {
-      ...belowTheFold[0],
-      className: cx(
-        belowTheFold[0].className,
-        "ctw-border-solid ctw-border-divider-light ctw-border-b-0"
-      ),
-    };
-  }
-  // Creates the main filter list dropdown
-  const inactiveFilterMenuItems: MinListBoxItem[] = [
-    ...aboveTheFold.map(toFilterMenuItem),
-    // Need to add class for the first menu item under the fold
-    ...belowTheFold.slice(0, 1).map(toFilterMenuItem),
-    ...belowTheFold.slice(1).map(toFilterMenuItem),
 
-    {
-      display: "remove all filters",
-      icon: faTrash,
-      key: "_remove",
-      className: "ctw-capitalize",
-    },
-  ];
-
-  if ([initialState].filter((filter) => filter.type !== "tag").length > 0) {
-    inactiveFilterMenuItems.splice(-1, 0, {
+  if (!isEmptyValue(initialState)) {
+    belowTheFold.push({
       display: "reset filters",
       icon: faRefresh,
       key: "_reset",
-      className: cx("ctw-capitalize", {
-        // This adds divider to this item if needed
-        "ctw-border-top first-of-type:ctw-border-none": !hasBelowTheFoldItems,
-      }),
+      type: "tag",
     });
   }
+  belowTheFold.push({
+    display: "remove all filters",
+    icon: faTrash,
+    key: "_remove",
+    type: "tag",
+  });
+
+  const menuItems: MinListBoxItem[] = [
+    ...aboveTheFold.map(toFilterMenuItem),
+    { divider: true },
+    ...belowTheFold.map(toFilterMenuItem),
+  ];
 
   return (
     <div
@@ -222,7 +207,7 @@ export const FilterBar = ({
       <ListBox
         useBasicStyles
         btnClassName="!ctw-text-content-light ctw-btn-clear !ctw-font-normal !ctw-py-2"
-        items={inactiveFilterMenuItems}
+        items={menuItems}
         onChange={(_index, item) => {
           switch (item.key) {
             case "_remove":

--- a/src/components/core/list-box/list-box.tsx
+++ b/src/components/core/list-box/list-box.tsx
@@ -13,19 +13,22 @@ import { FilterOptionSelect } from "@/components/core/filter-bar/filter-bar-type
 import { isFunction } from "@/utils/nodash";
 import "./list-box.scss";
 
-export type MinListBoxItem = {
+type ListBoxItem = {
   className?: cx.Argument;
+  divider?: false;
   display: string | ((status: ListBoxOptionStatus) => ReactNode);
   icon?: IconDefinition;
   key: string;
 };
 
-export type ListBoxProps<T> = {
+export type MinListBoxItem = ListBoxItem | { divider: true };
+
+export type ListBoxProps = {
   btnClassName?: cx.Argument;
   children?: ReactNode;
   defaultIndex?: number;
-  items: T[];
-  onChange: (index: number, item: T) => void;
+  items: MinListBoxItem[];
+  onChange: (index: number, item: ListBoxItem) => void;
   optionsClassName?: cx.Argument;
   useBasicStyles?: boolean;
 };
@@ -37,7 +40,7 @@ export type ListBoxOptionStatus = {
   selected?: boolean;
 };
 
-export function ListBox<T extends MinListBoxItem>({
+export function ListBox({
   useBasicStyles = false,
   btnClassName,
   children,
@@ -45,7 +48,7 @@ export function ListBox<T extends MinListBoxItem>({
   items,
   defaultIndex = 0,
   onChange,
-}: ListBoxProps<T>) {
+}: ListBoxProps) {
   const [selectedTabIndex, setSelectedTabIndex] = useState(defaultIndex);
   const selectedItem = items[selectedTabIndex] ?? {
     display: "Choose a selection",
@@ -56,7 +59,9 @@ export function ListBox<T extends MinListBoxItem>({
       <Listbox
         value={selectedTabIndex}
         onChange={(index: number) => {
-          onChange(index, items[index]);
+          const item = items[index];
+          if (item.divider) return;
+          onChange(index, item);
           setSelectedTabIndex(index);
         }}
       >
@@ -74,52 +79,64 @@ export function ListBox<T extends MinListBoxItem>({
           )}
         </Listbox.Button>
         <Listbox.Options className={cx(optionsClassName, "ctw-list-box")}>
-          {items.map((item, index) => (
-            <Listbox.Option key={item.key} value={index} as={Fragment}>
-              {({ active, selected }) => (
-                <li
-                  className={cx(
-                    "ctw-flex ctw-cursor-pointer ctw-justify-between ctw-px-3 ctw-py-2",
-                    "hover:ctw-bg-bg-lighter",
-                    item.className,
-                    {
-                      "ctw-text-medium": active || selected,
-                      "ctw-text-content-black": !(active || selected),
-                      "ctw-bg-bg-lighter": active,
-                    }
-                  )}
-                >
-                  <span
-                    className={cx("ctw-inline-flex ctw-align-middle", {
-                      "ctw-font-semibold": selected && !useBasicStyles,
-                    })}
+          {items.map((item, index) => {
+            if (item.divider) {
+              return <div key="divider" className="ctw-border-top" />;
+            }
+
+            return (
+              <Listbox.Option key={item.key} value={index} as={Fragment}>
+                {({ active, selected }) => (
+                  <li
+                    className={cx(
+                      "ctw-flex ctw-cursor-pointer ctw-justify-between ctw-px-3 ctw-py-2",
+                      "hover:ctw-bg-bg-lighter",
+                      item.className,
+                      {
+                        "ctw-text-medium": active || selected,
+                        "ctw-text-content-black": !(active || selected),
+                        "ctw-bg-bg-lighter": active,
+                      }
+                    )}
                   >
-                    {renderDisplay(item, { active, selected, listView: true })}
-                  </span>
-                  {!useBasicStyles && selected && !item.key.startsWith("_") && (
-                    <span className="ctw-inline-flex ctw-pb-0.5">
-                      <FontAwesomeIcon
-                        icon={faCheck}
-                        className="ctw-inline-block ctw-h-4 ctw-stroke-0 ctw-align-middle ctw-text-primary-dark"
-                      />
+                    <span
+                      className={cx("ctw-inline-flex ctw-align-middle", {
+                        "ctw-font-semibold": selected && !useBasicStyles,
+                      })}
+                    >
+                      {renderDisplay(item, {
+                        active,
+                        selected,
+                        listView: true,
+                      })}
                     </span>
-                  )}
-                </li>
-              )}
-            </Listbox.Option>
-          ))}
+                    {!useBasicStyles &&
+                      selected &&
+                      !item.key.startsWith("_") && (
+                        <span className="ctw-inline-flex ctw-pb-0.5">
+                          <FontAwesomeIcon
+                            icon={faCheck}
+                            className="ctw-inline-block ctw-h-4 ctw-stroke-0 ctw-align-middle ctw-text-primary-dark"
+                          />
+                        </span>
+                      )}
+                  </li>
+                )}
+              </Listbox.Option>
+            );
+          })}
         </Listbox.Options>
       </Listbox>
     </div>
   );
 }
 
-// TODO pull this out?
 // A helper function to render items for both the ListBox button and options.
-export function renderDisplay<T extends MinListBoxItem>(
+function renderDisplay<T extends MinListBoxItem>(
   item: T,
   status: ListBoxOptionStatus
 ) {
+  if (item.divider) return null;
   return (
     <MenuItem icon={item.icon}>
       {isFunction(item.display) ? item.display(status) : item.display}


### PR DESCRIPTION
CTW-802

1. Get "Show Dismissed Records" showing up below the divider.
2. Get "Hide Dismissed Records" showing up when show is active.

Steps to get this working:
1. Simplified how divider is added, now `ListBox` can take a `{divider: true}` item and put a divider in that spot.
2. Renamed `belowTheFold` to `belowDivider` and added that to the newly refactored `dismissFilter`.
3. Added new `toggleDisplay` and `toggleIcon` options which will be displayed for active filters.
4. Changed `addOrRemoveFilter` to `toggleFilter` so now it knows whether this filter should be added or removed based on the current status.

<img width="731" alt="Screenshot 2023-03-22 at 11 56 21 AM" src="https://user-images.githubusercontent.com/1568246/226967973-d7d73ad2-2eb2-40e1-b915-d92a3a2e6531.png">

<img width="902" alt="Screenshot 2023-03-22 at 11 57 03 AM" src="https://user-images.githubusercontent.com/1568246/226967990-a2740e4c-f7ba-4b4b-bf82-d9283b2e9758.png">