### PR TITLE
Ctw 903/open multiple drawers

### DIFF
--- a/.changeset/gorgeous-walls-scream.md
+++ b/.changeset/gorgeous-walls-scream.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix bug where opening successive drawers outside of zap component causes apps to crash.

--- a/src/components/core/providers/drawer-provider.tsx
+++ b/src/components/core/providers/drawer-provider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useContext, useMemo, useState } from "react";
+import { ReactNode, useContext, useEffect, useMemo, useState } from "react";
 import { DrawerContext, DrawerState, OpenDrawerProps } from "./drawer-context";
 
 interface ProviderProps {
@@ -30,8 +30,18 @@ export function DrawerProvider({ children }: ProviderProps) {
         });
       },
     }),
+
     []
   );
+
+  useEffect(() => {
+    if (!isOpen) {
+      // Reset the props when the drawer is closed.
+      setProps({
+        component: dummyChild,
+      });
+    }
+  }, [isOpen]);
 
   return (
     <DrawerContext.Provider value={state}>


### PR DESCRIPTION
Fix bug where opening successive drawers outside of zap component causes apps to crash.