### PR TITLE
fix: allergies sort and dedupe are now done case insensitive

### DIFF
--- a/.changeset/curly-balloons-travel.md
+++ b/.changeset/curly-balloons-travel.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix issue where allergies were not sorted correctly

--- a/src/components/content/allergies/allergies-filter.tsx
+++ b/src/components/content/allergies/allergies-filter.tsx
@@ -16,4 +16,4 @@ export const applyAllergyFilters = (
   return allergyData;
 };
 
-const valuesToDedupeOn = (allergy: AllergyModel) => [allergy.display];
+const valuesToDedupeOn = (allergy: AllergyModel) => [allergy.lowercaseDisplay];

--- a/src/components/content/allergies/helpers/sort.ts
+++ b/src/components/content/allergies/helpers/sort.ts
@@ -14,10 +14,10 @@ export const allergySortOptions: SortOption<AllergyModel>[] = [
   },
   {
     display: "Name (A-Z)",
-    sorts: [{ key: "display", dir: "asc" }],
+    sorts: [{ key: "lowercaseDisplay", dir: "asc" }],
   },
   {
     display: "Name (Z-A)",
-    sorts: [{ key: "display", dir: "desc" }],
+    sorts: [{ key: "lowercaseDisplay", dir: "desc" }],
   },
 ];

--- a/src/fhir/models/allergies.ts
+++ b/src/fhir/models/allergies.ts
@@ -24,6 +24,10 @@ export class AllergyModel extends FHIRModel<fhir4.AllergyIntolerance> {
   get display(): string | undefined {
     return codeableConceptLabel(this.resource.code);
   }
+  
+  get lowercaseDisplay(): string | undefined {
+    return this.display ? this.display.toLowerCase() : this.display;
+  }
 
   get manifestations(): string {
     const manifestations: string[] = [];

--- a/src/fhir/models/allergies.ts
+++ b/src/fhir/models/allergies.ts
@@ -24,7 +24,7 @@ export class AllergyModel extends FHIRModel<fhir4.AllergyIntolerance> {
   get display(): string | undefined {
     return codeableConceptLabel(this.resource.code);
   }
-  
+
   get lowercaseDisplay(): string | undefined {
     return this.display ? this.display.toLowerCase() : this.display;
   }


### PR DESCRIPTION
When deduplicating allergies and sorting allergies, we were using the display value as is, which unsurprisingly in healthcare is inconsistent. This change enforces lowercase on all operations that depend on case sensitivity like sort and filter