### PR TITLE
Fix issue where when there are no messages results were still shown.

### DIFF
--- a/.changeset/gentle-sloths-rush.md
+++ b/.changeset/gentle-sloths-rush.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix issue where when there are no messages results were still shown.

--- a/src/components/content/patient-history/use-builder-patient-history-list.ts
+++ b/src/components/content/patient-history/use-builder-patient-history-list.ts
@@ -29,6 +29,11 @@ export function useBuilderPatientHistoryList(
             subsetMessages.map((message) => message.initialData.patientId)
           )
         );
+
+        if (!patientsIds.length) {
+          return { total: 0, patients: [] };
+        }
+
         const patientData = await getBuilderPatientsListByIdentifier(
           requestContext,
           undefined,


### PR DESCRIPTION
fix-patient-empty-messagesFix issue where when there are no messages results were still shown.
