### PR TITLE
Fixing date formatting and sorting for patient history requests

### DIFF
--- a/.changeset/small-baboons-warn.md
+++ b/.changeset/small-baboons-warn.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix date formatting and sorting on patient history requests

--- a/src/components/content/patient-history/patient-history-table.tsx
+++ b/src/components/content/patient-history/patient-history-table.tsx
@@ -8,13 +8,13 @@ import { Pagination } from "@/components/core/pagination/pagination";
 import { Table } from "@/components/core/table/table";
 import { TableColumn } from "@/components/core/table/table-helpers";
 import { PatientModel } from "@/fhir/models";
-import { PatientHistorytModel } from "@/fhir/models/patient-history";
+import { PatientHistoryRequestModel } from "@/fhir/models/patient-history";
 import { CTWBox } from "@/index";
 import "./patient-history-table.scss";
 
 export type PatientsHistoryTableProps = {
   className?: cx.Argument;
-  handleRowClick?: (row: PatientHistorytModel) => void;
+  handleRowClick?: (row: PatientHistoryRequestModel) => void;
   pageSize?: number;
   title?: string;
 } & TableOptionProps<PatientModel>;
@@ -28,7 +28,7 @@ export const PatientHistoryTable = withErrorBoundary(
   }: PatientsHistoryTableProps) => {
     const [currentPage, setCurrentPage] = useState(1);
     const [total, setTotal] = useState(0);
-    const [patients, setPatients] = useState<PatientHistorytModel[]>([]);
+    const [patients, setPatients] = useState<PatientHistoryRequestModel[]>([]);
 
     const {
       data: { patients: responsePatients, total: responseTotal } = {},
@@ -95,7 +95,7 @@ export const PatientHistoryTable = withErrorBoundary(
   "PatientsHistoryTable"
 );
 
-const columns: TableColumn<PatientHistorytModel>[] = [
+const columns: TableColumn<PatientHistoryRequestModel>[] = [
   {
     title: "Name",
     render: (data) => <PatientNameColumn data={data} />,
@@ -120,7 +120,7 @@ const columns: TableColumn<PatientHistorytModel>[] = [
   },
 ];
 
-const PatientNameColumn = ({ data }: { data: PatientHistorytModel }) => (
+const PatientNameColumn = ({ data }: { data: PatientHistoryRequestModel }) => (
   <div className="ctw-flex ctw-items-center">
     <div className="ctw-ml-4">
       <div className="ctw-flex ctw-font-medium">

--- a/src/components/content/patient-history/use-builder-patient-history-list.ts
+++ b/src/components/content/patient-history/use-builder-patient-history-list.ts
@@ -39,7 +39,7 @@ export function useBuilderPatientHistoryList(pageSize: number, pageOffset: numbe
           patientsIds
         );
 
-        const patientHistoryPatients = compact(
+        const patientHistoryRequestsWithPatientData = compact(
           patientHistoryRequests.map((m) => {
             const matchingPatient = patientData.patients.find(
               (p) => p.id === m.initialData.patientId
@@ -50,7 +50,7 @@ export function useBuilderPatientHistoryList(pageSize: number, pageOffset: numbe
 
         return {
           total: response.data.length,
-          patients: patientHistoryPatients,
+          patients: patientHistoryRequestsWithPatientData,
         };
       } catch (e) {
         Telemetry.logError(e as Error, "Failed fetching patient history patients.");

--- a/src/fhir/models/patient-history.ts
+++ b/src/fhir/models/patient-history.ts
@@ -2,7 +2,7 @@ import { PatientModel } from "./patient";
 import { formatDate, formatISODateStringToDate } from "../formatters";
 import { PatientRefreshHistoryMessage } from "@/services/patient-history/patient-history-types";
 
-export class PatientHistorytModel {
+export class PatientHistoryRequestModel {
   kind = "PatientHistory" as const;
 
   historyInfo: PatientRefreshHistoryMessage | undefined = undefined;
@@ -33,7 +33,7 @@ export class PatientHistorytModel {
     return formatDate(
       // eslint-disable-next-line no-underscore-dangle
       this.historyInfo?._createdAt,
-      "MM/dd/yy HH:mm"
+      "M/d/yy h:mm a"
     );
   }
 


### PR DESCRIPTION
Fixed date formatting and made the table default to sorting by patient history request initiated date descending. Have been using this page to review recent patient history requests and the lack of logical sorting was making it somewhat difficult. Please merge on approval.

<img width="400" alt="Pasted Graphic 4" src="https://user-images.githubusercontent.com/97455910/234703770-f43ba16b-4ea2-4404-a1cd-a49e62739730.png">
