### PR TITLE
CTW-919: Fixing the word break on beta tag

### DIFF
--- a/src/components/core/beta-label.tsx
+++ b/src/components/core/beta-label.tsx
@@ -8,7 +8,7 @@ export const BetaLabel = ({ className }: BetaLabelProps) => (
   <span
     className={cx(
       className,
-      "ctw-relative ctw-bottom-1 ctw-text-[10px] ctw-uppercase ctw-text-content-light"
+      "ctw-relative ctw-bottom-1 ctw-break-keep ctw-text-[10px] ctw-uppercase ctw-text-content-light"
     )}
   >
     beta


### PR DESCRIPTION
https://zeushealth.atlassian.net/browse/CTW-919

Tai noticed that BETA was breaking weird at smaller resolutions; making it so there's no word break on the label.

BEFORE:
<img width="216" alt="Screenshot 2023-04-27 at 10 33 25 AM" src="https://user-images.githubusercontent.com/5325813/234895910-038a00b8-e63a-4ac0-8fb3-a10199619ad4.png">

AFTER:
<img width="107" alt="Screenshot 2023-04-27 at 10 33 17 AM" src="https://user-images.githubusercontent.com/5325813/234895951-540e07ae-00d1-4de0-9fd8-6cc429acb6ca.png">
