### PR TITLE
CTW-1021/Remove RUM

### DIFF
--- a/.changeset/tricky-tigers-impress.md
+++ b/.changeset/tricky-tigers-impress.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Removed RUM. No longer tracking interactions when someone focuses a form field

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "1.2.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "1.2.1",
+      "version": "1.4.2",
       "hasInstallScript": true,
       "dependencies": {
         "@datadog/browser-logs": "^4.30.1",
-        "@datadog/browser-rum-slim": "^4.30.1",
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
         "@fortawesome/free-regular-svg-icons": "^6.4.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
@@ -2463,31 +2462,6 @@
       },
       "peerDependenciesMeta": {
         "@datadog/browser-rum": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@datadog/browser-rum-core": {
-      "version": "4.38.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.38.0.tgz",
-      "integrity": "sha512-rp1FxQuGb6g06/a0OT6gTCNEUcjmXC4yXFdd6OnsEbf+h1PAMHiMDGmt5Y2THDpN0x2xzLXG1NBpk291E4eZRw==",
-      "dependencies": {
-        "@datadog/browser-core": "4.38.0"
-      }
-    },
-    "node_modules/@datadog/browser-rum-slim": {
-      "version": "4.38.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-slim/-/browser-rum-slim-4.38.0.tgz",
-      "integrity": "sha512-/ldb9sg2/vZhKzdyb5LBDNlK/moy2E8x3AM04DaDQdFPlN57/IwmPVsntFjBfDakKUCXgz7wK5dp82C8DAGJYw==",
-      "dependencies": {
-        "@datadog/browser-core": "4.38.0",
-        "@datadog/browser-rum-core": "4.38.0"
-      },
-      "peerDependencies": {
-        "@datadog/browser-logs": "4.38.0"
-      },
-      "peerDependenciesMeta": {
-        "@datadog/browser-logs": {
           "optional": true
         }
       }
@@ -30123,23 +30097,6 @@
         "@datadog/browser-core": "4.38.0"
       }
     },
-    "@datadog/browser-rum-core": {
-      "version": "4.38.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.38.0.tgz",
-      "integrity": "sha512-rp1FxQuGb6g06/a0OT6gTCNEUcjmXC4yXFdd6OnsEbf+h1PAMHiMDGmt5Y2THDpN0x2xzLXG1NBpk291E4eZRw==",
-      "requires": {
-        "@datadog/browser-core": "4.38.0"
-      }
-    },
-    "@datadog/browser-rum-slim": {
-      "version": "4.38.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-slim/-/browser-rum-slim-4.38.0.tgz",
-      "integrity": "sha512-/ldb9sg2/vZhKzdyb5LBDNlK/moy2E8x3AM04DaDQdFPlN57/IwmPVsntFjBfDakKUCXgz7wK5dp82C8DAGJYw==",
-      "requires": {
-        "@datadog/browser-core": "4.38.0",
-        "@datadog/browser-rum-core": "4.38.0"
-      }
-    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -34510,7 +34467,7 @@
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "form-data": "^3.0.0"
+        "form-data": "4.0.0"
       }
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
   },
   "dependencies": {
     "@datadog/browser-logs": "^4.30.1",
-    "@datadog/browser-rum-slim": "^4.30.1",
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-regular-svg-icons": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",

--- a/src/components/content/forms/form-field.tsx
+++ b/src/components/content/forms/form-field.tsx
@@ -75,7 +75,6 @@ export const FormField = ({
           readOnly={readonly}
           name={inputProps.name}
           id={inputProps.name}
-          data-zus-telemetry-focus={inputProps.name}
         />
       );
     }
@@ -92,7 +91,6 @@ export const FormField = ({
         // would get reset when saving and showing errors as the defaultValue could
         // be undefined and the input gets reset to that (empty).
         {...(value ? { defaultValue: value } : {})}
-        data-zus-telemetry-focus={inputProps.name}
       />
     );
   };

--- a/src/components/core/form/combobox-field.tsx
+++ b/src/components/core/form/combobox-field.tsx
@@ -145,7 +145,7 @@ const ComboboxOptions = ({
   }
 
   if (query.length < 2) {
-    return <ComboboxOption option={{ value: "", label: "Pleae type at least two characters" }} />;
+    return <ComboboxOption option={{ value: "", label: "Please type at least two characters" }} />;
   }
 
   if (options.length === 0) {

--- a/src/utils/telemetry.test.ts
+++ b/src/utils/telemetry.test.ts
@@ -1,5 +1,4 @@
 import { datadogLogs } from "@datadog/browser-logs";
-import { datadogRum } from "@datadog/browser-rum-slim";
 import { vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
 import { Telemetry, withTimerMetric } from "@/utils/telemetry";
@@ -52,23 +51,20 @@ describe("telemetry", () => {
     expect(await fetches[0].json()).toEqual({
       name: "am_i.or_am_i_not",
       type: "timing",
-      tags: ["service:ctw-component-library", "env:test", "practitioner_id:none", "is_super:false"],
+      tags: ["service:ctw-component-library", "env:test", "is_super:false"],
       value: 0,
     });
   });
 
   test("Default datadog clients and event listeners", async () => {
     const datadogLogsInitSpy = vi.spyOn(datadogLogs, "init");
-    const datadogRumInitSpy = vi.spyOn(datadogRum, "init");
     const addEventListenerSpy = vi.spyOn(document.body, "addEventListener");
 
     datadogLogsInitSpy.mockImplementation(() => undefined);
-    datadogRumInitSpy.mockImplementation(() => undefined);
     addEventListenerSpy.mockImplementation(() => undefined);
 
     Telemetry.init("test");
     expect(datadogLogsInitSpy).not.toHaveBeenCalled();
-    expect(datadogRumInitSpy).not.toHaveBeenCalled();
     expect(addEventListenerSpy).toHaveBeenCalled();
   });
 });

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -1,5 +1,4 @@
 import { datadogLogs } from "@datadog/browser-logs";
-import { datadogRum } from "@datadog/browser-rum-slim";
 import jwtDecode from "jwt-decode";
 import packageJson from "../../package.json";
 import { getMetricsBaseUrl } from "@/api/urls";
@@ -67,7 +66,7 @@ export class Telemetry {
     return isInitialized;
   }
 
-  private static rumLoggingIsEnabled = false;
+  private static datadogLoggingEnabled = false;
 
   static logger = datadogLogs.logger;
 
@@ -88,31 +87,17 @@ export class Telemetry {
     }
   }
 
-  static init(environment: string, allowDataDogRumAndLogging = false) {
-    this.rumLoggingIsEnabled = allowDataDogRumAndLogging;
+  static init(environment: string, allowDataDogLogging = false) {
+    this.datadogLoggingEnabled = allowDataDogLogging;
     this.setEnv(environment);
 
     if (this.telemetryIsAvailable) {
       return;
     }
 
-    // Turning on RUM and Logging is conditional. However, the event handlers
+    // Turning on Datadog Logging is conditional. However, the event handlers
     // that explicitly send internal /report/metrics to ctw are not optional.
-    if (allowDataDogRumAndLogging) {
-      datadogRum.init({
-        ...(isLocalDevelopment ? devDatadogConfig : prodDatadogConfig),
-        allowedTracingUrls: [], // No allowed tracing urls
-        defaultPrivacyLevel: "mask",
-        env: this.environment,
-        sessionReplaySampleRate: 20,
-        sessionSampleRate: 100,
-        site: "datadoghq.com",
-        trackLongTasks: true,
-        trackResources: false,
-        trackUserInteractions: false,
-        trackViewsManually: true, // url path names are useless to cwl-cl
-        version: packageJson.version,
-      });
+    if (allowDataDogLogging) {
       datadogLogs.init({
         ...(isLocalDevelopment ? devDatadogConfig : prodDatadogConfig),
         env: this.environment,
@@ -156,9 +141,8 @@ export class Telemetry {
   }
 
   static setBuilder(builderId?: string) {
-    if (this.rumLoggingIsEnabled) {
+    if (this.datadogLoggingEnabled) {
       datadogLogs.setGlobalContextProperty("builderId", builderId);
-      datadogRum.setGlobalContextProperty("builderId", builderId);
     }
   }
 
@@ -176,20 +160,18 @@ export class Telemetry {
         patientId: user[AUTH_PATIENT_ID],
         isSuperOrg: user[AUTH_IS_SUPER_ORG],
       };
-      if (this.rumLoggingIsEnabled) {
+      if (this.datadogLoggingEnabled) {
         datadogLogs.setUser(decodedUser);
-        datadogRum.setUser(decodedUser);
       }
     }
   }
 
   static clearUser() {
     datadogLogs.setUser({});
-    datadogRum.setUser({});
   }
 
   static trackView(viewName: string) {
-    datadogRum.startView(viewName);
+    this.countMetric(`component.${viewName}.loaded`);
   }
 
   static logError(error: Error, overrideMessage?: string): Error {
@@ -209,7 +191,7 @@ export class Telemetry {
 
   static trackInteraction(eventType: string, namespace: string, action: string) {
     // We log this event with namespace breadcrumbs if allowed
-    if (this.telemetryIsAvailable && this.rumLoggingIsEnabled) {
+    if (this.telemetryIsAvailable && this.datadogLoggingEnabled) {
       this.logger.log(`${eventType} event: ${namespace} > ${action}`, {
         eventType,
         action,
@@ -328,7 +310,6 @@ export class Telemetry {
       "service:ctw-component-library",
       `env:${this.environment}`,
       user[AUTH_BUILDER_NAME] ? `builder_name:${user[AUTH_BUILDER_NAME]}` : undefined,
-      `practitioner_id:${user[AUTH_PRACTITIONER_ID] || "none"}`,
       `is_super:${user[AUTH_IS_SUPER_ORG] || "false"}`,
       ...additionalTags,
     ]);


### PR DESCRIPTION
Removed RUM. The logging is still on (if telemetry enabled) and custom metrics are still sent through the proxy.

Additionally to lower noise, removed custom interaction metrics being sent each time someone focuses on an input field.