### PR TITLE
CTW-1069 Fixing queries that need to filter by users builder ID

### DIFF
--- a/.changeset/giant-waves-destroy.md
+++ b/.changeset/giant-waves-destroy.md
@@ -1,5 +1,5 @@
 ---
-"@zus-health/ctw-component-library": minor
+"@zus-health/ctw-component-library": patch
 ---
 
 Fixes issue with missing builder filter.

--- a/.changeset/giant-waves-destroy.md
+++ b/.changeset/giant-waves-destroy.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Fixes issue with missing builder filter.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,15 +65,15 @@ const demoComponents: DemoComponent[] = [
     render: () => (
       <ZusAggregatedProfile
         includePatientDemographicsForm={false}
-        resources={["timeline"]}
+        resources={["medications", "medications-outside"]}
         title="ZAP"
       />
     ),
   },
-  { render: () => <PatientSearch />, title: "Patient Search" },
-  { render: () => <PatientHistoryTable />, title: "Patient History Table" },
-  { render: () => <PatientConditionsOutside />, title: "Patient Conditions" },
-  { render: () => <PatientDocuments />, title: "Patient Documents" },
+  // { render: () => <PatientSearch />, title: "Patient Search" },
+  // { render: () => <PatientHistoryTable />, title: "Patient History Table" },
+  // { render: () => <PatientConditionsOutside />, title: "Patient Conditions" },
+  // { render: () => <PatientDocuments />, title: "Patient Documents" },
 ];
 
 const DemoApp = ({ accessToken = "" }) => (

--- a/src/components/core/providers/ctw-context.tsx
+++ b/src/components/core/providers/ctw-context.tsx
@@ -30,7 +30,9 @@ export type CTWState = {
 export type CTWRequestContext = {
   env: Env;
   authToken: string;
+  // The user's builder ID.
   builderId: string;
+  // The optional builder ID used in case the user is impersonating a builder.
   contextBuilderId: string | undefined;
   fhirClient: Client;
 };

--- a/src/fhir/patient-helper.ts
+++ b/src/fhir/patient-helper.ts
@@ -19,7 +19,6 @@ export async function getBuilderFhirPatient(
     const response = await searchBuilderRecords("Patient", requestContext, {
       ...searchParams,
       identifier: `${systemURL}|${patientID}`,
-      _count: 1,
       _include: "Patient:organization",
     });
 


### PR DESCRIPTION
We removed the logic that filters by the users builder ID because we believed that the firstparty search parameter would take care of that for us. But that search parameter doesn't filter out all other builders data, it just filters out third party data. So because of CPR our query still returns data from other builders.