### PR TITLE
CTW-1079 Leave total returned by FHIR server

### DIFF
--- a/.changeset/hip-kings-share.md
+++ b/.changeset/hip-kings-share.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Preserving server side total in response from searchBuilderRecords

--- a/src/fhir/search-helpers.ts
+++ b/src/fhir/search-helpers.ts
@@ -141,8 +141,6 @@ export async function searchBuilderRecords<T extends ResourceTypeString>(
 
   records.resources = resources;
   records.bundle.entry = entry;
-  records.bundle.total = entry.length;
-  records.total = resources.length;
 
   return records;
 }


### PR DESCRIPTION
As part of some recent performance tweaks we started doing more client-side filtering of data. For example, we are filtering by the builder tag to distinguish data owned by the user's builder. In a recent PR we added some logic to filter data returned by `searchBuilderRecords` to only data belonging to the current user's builder. This code set the `total` property of the response to the number of records returned, which broke any functionality that used `_count` and `_offset` for server side pagination because the returned result set never included a `total` representing all the data available, it just represented the data returned by that specific, paginated, request.

The short term fix here is to leave that `total` property untouched so it represents all the data available on the server. However, that number is actually going to be too high, as it represents all the data available on the server, regardless of the client side filtering logic.

One option is to go back to using the `_tag` search parameter and just do the builder filtering on the server side, though that will likely have performance implications.

Another option is to paginate without exposing a total count, so it would not be clear to the user how many pages there are. Though we may still have challenges there with each page potentially having a different number of records.

All that said, this currently only impacts the patient list, so it may not be that much of a concern.