### PR TITLE
Allow programatic detection of package license

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@zus-health/ctw-component-library",
   "version": "1.7.8",
+  "license" : "MIT",
   "type": "module",
   "engines": {
     "node": ">=16 <19"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zus-health/ctw-component-library",
   "version": "1.7.8",
-  "license" : "MIT",
+  "license": "MIT",
   "type": "module",
   "engines": {
     "node": ">=16 <19"


### PR DESCRIPTION
Currently this library doesn't appear with a license on [NPM](https://www.npmjs.com/package/@zus-health/ctw-component-library) or in security scans.