### PR TITLE
Fix sorting & display of patient history list

### DIFF
--- a/.changeset/itchy-tomatoes-teach.md
+++ b/.changeset/itchy-tomatoes-teach.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Add target date to patient history table.

--- a/src/components/content/patient-history/helpers/filters.tsx
+++ b/src/components/content/patient-history/helpers/filters.tsx
@@ -1,28 +1,44 @@
-import { faUser } from "@fortawesome/free-solid-svg-icons";
-import { FilterItem } from "@/components/core/filter-bar/filter-bar-types";
+import { faCalendarWeek, faHourglass } from "@fortawesome/free-solid-svg-icons";
+import { FilterChangeEvent, FilterItem } from "@/components/core/filter-bar/filter-bar-types";
 
 export function patientHistoryFilters(): FilterItem[] {
   const filters: FilterItem[] = [];
 
-  filters.push({
-    key: "status",
-    type: "select",
-    icon: faUser,
-    values: [
-      "initialize",
-      {
-        key: "in_progress",
-        name: "in progress",
-      },
-      "error",
-      "done",
-      {
-        key: "done_with_errors",
-        name: "done with errors ",
-      },
-    ],
-    display: "status",
-  });
+  filters.push(
+    {
+      key: "status",
+      type: "select",
+      icon: faHourglass,
+      values: [
+        "initialize",
+        {
+          key: "in_progress",
+          name: "in progress",
+        },
+        "error",
+        "done",
+        {
+          key: "done_with_errors",
+          name: "done with errors ",
+        },
+      ],
+      display: "status",
+    },
+    {
+      key: "future_jobs",
+      type: "tag",
+      icon: faCalendarWeek,
+      display: "Exclude Future Jobs",
+    }
+  );
 
   return filters;
 }
+
+export const defaultPatientHistoryFilters: FilterChangeEvent = {
+  future_jobs: {
+    key: "future_jobs",
+    selected: true,
+    type: "tag",
+  },
+};

--- a/src/components/content/patient-history/patient-history-table.tsx
+++ b/src/components/content/patient-history/patient-history-table.tsx
@@ -102,8 +102,12 @@ export const PatientHistoryTable = withErrorBoundary(
 
 const columns: TableColumn<PatientHistoryRequestModel>[] = [
   {
-    title: "Last Queried",
+    title: "Initiated",
     render: (data) => <div>{data.createdAt}</div>,
+  },
+  {
+    title: "Target Date",
+    render: (data) => <div>{data.targetDate}</div>,
   },
   {
     title: "Name",

--- a/src/components/content/patient-history/patient-history-table.tsx
+++ b/src/components/content/patient-history/patient-history-table.tsx
@@ -44,11 +44,7 @@ export const PatientHistoryTable = withErrorBoundary(
     } = useBuilderPatientHistoryList(pageSize, currentPage - 1, status, excludeFutureJobs);
 
     const onFilterChange = (e: FilterChangeEvent) => {
-      if (e.future_jobs?.selected && typeof e.future_jobs.selected === "boolean") {
-        setExcludeFutureJobs(e.future_jobs.selected);
-      } else {
-        setExcludeFutureJobs(false);
-      }
+      setExcludeFutureJobs(!!e.future_jobs?.selected)
       if (e.status?.selected && typeof e.status.selected === "string") {
         setStatus(e.status.selected.split(" ").join("_"));
       } else {

--- a/src/components/content/patient-history/patient-history-table.tsx
+++ b/src/components/content/patient-history/patient-history-table.tsx
@@ -102,11 +102,7 @@ export const PatientHistoryTable = withErrorBoundary(
 
 const columns: TableColumn<PatientHistoryRequestModel>[] = [
   {
-    title: "Initiated",
-    render: (data) => <div>{data.createdAt}</div>,
-  },
-  {
-    title: "Target Date",
+    title: "Last Queried",
     render: (data) => <div>{data.targetDate}</div>,
   },
   {

--- a/src/components/content/patient-history/patient-history-table.tsx
+++ b/src/components/content/patient-history/patient-history-table.tsx
@@ -2,7 +2,7 @@ import "./patient-history-table.scss";
 
 import cx from "classnames";
 import { useEffect, useState } from "react";
-import { patientHistoryFilters } from "./helpers/filters";
+import { defaultPatientHistoryFilters, patientHistoryFilters } from "./helpers/filters";
 import { useBuilderPatientHistoryList } from "./use-builder-patient-history-list";
 import { TableOptionProps } from "../patients/patients-table";
 import { ResourceTableActions } from "../resource/resource-table-actions";
@@ -35,14 +35,20 @@ export const PatientHistoryTable = withErrorBoundary(
     const [currentPage, setCurrentPage] = useState(1);
     const [patients, setPatients] = useState<PatientHistoryRequestModel[]>([]);
     const [status, setStatus] = useState<string>();
+    const [excludeFutureJobs, setExcludeFutureJobs] = useState<boolean>(true);
 
     const {
       data: { patients: responsePatients, total: responseTotal, hasNext } = {},
       isFetching,
       isError,
-    } = useBuilderPatientHistoryList(pageSize, currentPage - 1, status);
+    } = useBuilderPatientHistoryList(pageSize, currentPage - 1, status, excludeFutureJobs);
 
     const onFilterChange = (e: FilterChangeEvent) => {
+      if (e.future_jobs?.selected && typeof e.future_jobs.selected === "boolean") {
+        setExcludeFutureJobs(e.future_jobs.selected);
+      } else {
+        setExcludeFutureJobs(false);
+      }
       if (e.status?.selected && typeof e.status.selected === "string") {
         setStatus(e.status.selected.split(" ").join("_"));
       } else {
@@ -76,6 +82,7 @@ export const PatientHistoryTable = withErrorBoundary(
           filterOptions={{
             onChange: onFilterChange,
             filters: patientHistoryFilters(),
+            defaultState: defaultPatientHistoryFilters,
           }}
           className="ctw-ml-2"
         />
@@ -103,6 +110,10 @@ export const PatientHistoryTable = withErrorBoundary(
 const columns: TableColumn<PatientHistoryRequestModel>[] = [
   {
     title: "Last Queried",
+    render: (data) => <div>{data.lastUpdatedAt}</div>,
+  },
+  {
+    title: "Target Date",
     render: (data) => <div>{data.targetDate}</div>,
   },
   {

--- a/src/components/content/patient-history/patient-history-table.tsx
+++ b/src/components/content/patient-history/patient-history-table.tsx
@@ -44,7 +44,7 @@ export const PatientHistoryTable = withErrorBoundary(
     } = useBuilderPatientHistoryList(pageSize, currentPage - 1, status, excludeFutureJobs);
 
     const onFilterChange = (e: FilterChangeEvent) => {
-      setExcludeFutureJobs(!!e.future_jobs?.selected)
+      setExcludeFutureJobs(!!e.future_jobs?.selected);
       if (e.status?.selected && typeof e.status.selected === "string") {
         setStatus(e.status.selected.split(" ").join("_"));
       } else {

--- a/src/components/content/patient-history/use-builder-patient-history-list.ts
+++ b/src/components/content/patient-history/use-builder-patient-history-list.ts
@@ -10,11 +10,12 @@ import { Telemetry } from "@/utils/telemetry";
 export function useBuilderPatientHistoryList(
   pageSize: number,
   pageOffset: number,
-  status?: string
+  status?: string,
+  excludeFutureJobs?: boolean
 ) {
   return useQueryWithCTW(
     QUERY_KEY_PATIENT_HISTORY_LIST,
-    [pageSize, pageOffset, status],
+    [pageSize, pageOffset, status, excludeFutureJobs],
     async (requestContext) => {
       try {
         const response = (await getBuilderRefreshHistoryMessages({
@@ -22,6 +23,7 @@ export function useBuilderPatientHistoryList(
           count: pageSize,
           offset: pageOffset,
           status,
+          excludeFutureJobs,
         })) as PatientHistoryJobResponse;
 
         const patientsIds = uniq(

--- a/src/components/content/patient-history/use-patient-history.tsx
+++ b/src/components/content/patient-history/use-patient-history.tsx
@@ -1,4 +1,4 @@
-import format from "date-fns/format";
+import { format } from "date-fns";
 import { useEffect, useState } from "react";
 import { PatientHistoryStatus } from "./patient-history-message-status";
 import { PatientHistoryRequestDrawer } from "../patient-history-request-drawer";
@@ -91,6 +91,7 @@ export type GetBuilderRefreshHistoryMessagesParams = {
   offset?: number;
   patientId?: string;
   status?: string;
+  excludeFutureJobs?: boolean;
 };
 
 export async function getBuilderRefreshHistoryMessages({
@@ -99,6 +100,7 @@ export async function getBuilderRefreshHistoryMessages({
   offset = 0,
   patientId,
   status,
+  excludeFutureJobs,
 }: GetBuilderRefreshHistoryMessagesParams) {
   const baseUrl = new URL(`${getZusApiBaseUrl(requestContext.env)}/patient-history/jobs?`);
 
@@ -111,7 +113,7 @@ export async function getBuilderRefreshHistoryMessages({
         : "",
       "filter[patient-id]": patientId ? `${patientId}` : "",
       "filter[status]": status ? `${status}` : "",
-      "filter[targetDate][until]": format(Date.now(), "yyyy-MM-dd"),
+      ...(!!excludeFutureJobs && { "filter[targetDate][until]": format(Date.now(), "yyyy-MM-dd") }),
     },
     (value) => !value
   );

--- a/src/components/content/patient-history/use-patient-history.tsx
+++ b/src/components/content/patient-history/use-patient-history.tsx
@@ -1,3 +1,4 @@
+import format from "date-fns/format";
 import { useEffect, useState } from "react";
 import { PatientHistoryStatus } from "./patient-history-message-status";
 import { PatientHistoryRequestDrawer } from "../patient-history-request-drawer";
@@ -110,6 +111,7 @@ export async function getBuilderRefreshHistoryMessages({
         : "",
       "filter[patient-id]": patientId ? `${patientId}` : "",
       "filter[status]": status ? `${status}` : "",
+      "filter[targetDate][until]": format(Date.now(), "yyyy-MM-dd"),
     },
     (value) => !value
   );

--- a/src/fhir/models/patient-history.ts
+++ b/src/fhir/models/patient-history.ts
@@ -1,7 +1,7 @@
+import { format } from "date-fns";
 import { PatientModel } from "./patient";
 import { formatISODateStringToDate } from "../formatters";
 import { PatientHistoryJobResponseJobData } from "@/services/patient-history/patient-history-types";
-import { format } from "date-fns";
 
 export class PatientHistoryRequestModel {
   kind = "PatientHistory" as const;

--- a/src/fhir/models/patient-history.ts
+++ b/src/fhir/models/patient-history.ts
@@ -19,6 +19,13 @@ export class PatientHistoryRequestModel {
     return this.historyInfo?.attributes.providers;
   }
 
+  get lastUpdatedAt() {
+    return format(
+      new Date(Number(this.historyInfo?.attributes.lastUpdatedAt) * 1000),
+      "M/d/yy h:mm a"
+    );
+  }
+
   get key() {
     return this.historyInfo?.id || "";
   }

--- a/src/fhir/models/patient-history.ts
+++ b/src/fhir/models/patient-history.ts
@@ -1,7 +1,7 @@
-import { format } from "date-fns";
 import { PatientModel } from "./patient";
 import { formatISODateStringToDate } from "../formatters";
 import { PatientHistoryJobResponseJobData } from "@/services/patient-history/patient-history-types";
+import { format } from "date-fns";
 
 export class PatientHistoryRequestModel {
   kind = "PatientHistory" as const;
@@ -23,8 +23,8 @@ export class PatientHistoryRequestModel {
     return this.historyInfo?.id || "";
   }
 
-  get lastRetrievedAt() {
-    return formatISODateStringToDate(this.historyInfo?.attributes.createdAt);
+  get targetDate() {
+    return formatISODateStringToDate(this.historyInfo?.attributes.targetDate);
   }
 
   get createdAt() {

--- a/src/services/patient-history/patient-history-types.ts
+++ b/src/services/patient-history/patient-history-types.ts
@@ -16,6 +16,7 @@ export type PatientHistoryJobResponseJobData = {
   attributes: {
     createdAt: string;
     requestConsent: boolean;
+    lastUpdatedAt: string;
     practitioner: {
       npi: string;
       name: string;


### PR DESCRIPTION
CTW-1088

The patient history API returns data sorted by targetDate descending and has no sorting options. We display the createdAt field. This causes confusion as to why the table is ordered the way it is - for a customer that uses appointment-based patient history automation we are setting a target date based on upcoming appointments, so we're showing a bunch of unresolved/upcoming patient history requests on the first page, and they have very disparate create timestamps, so the data looks kind of nonsensical. We can alleviate this for the time being by displaying the target date for the "Last Queried" date and filtering the search to only return patient history requests that have a target date up until the current date (ie. don't show those that are set to happen in the future).

<img width="984" alt="image" src="https://github.com/zeus-health/ctw-component-library/assets/16874444/7e8acaaa-c455-416a-b943-d5f59d5627d2">

