### PR TITLE
Ignore dismissed outside resources for badge count

### DIFF
--- a/.changeset/tricky-clouds-smile.md
+++ b/.changeset/tricky-clouds-smile.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Don't count dismissed outside resources in badges

--- a/src/components/content/conditions/patient-conditions-outside-badge.tsx
+++ b/src/components/content/conditions/patient-conditions-outside-badge.tsx
@@ -4,7 +4,7 @@ import { usePatientConditionsOutside } from "@/fhir/conditions";
 export const PatientConditionsOutsideBadge = () => {
   const otherConditionsQuery = usePatientConditionsOutside();
   const activeUnarchivedConditions = otherConditionsQuery.data.filter(
-    (condition) => condition.displayStatus === "Active"
+    (condition) => condition.active && !condition.isArchived
   );
 
   if (activeUnarchivedConditions.length > 0) {

--- a/src/components/content/observations/patient-observations-outside-badge.tsx
+++ b/src/components/content/observations/patient-observations-outside-badge.tsx
@@ -3,8 +3,13 @@ import { usePatientAllDiagnosticReports } from "@/fhir/diagnostic-report";
 
 export const PatientObservationsOutsideBadge = () => {
   const { data = [] } = usePatientAllDiagnosticReports();
+  const unarchivedObservations = data.filter((observation) => !observation.isArchived);
 
-  return data.length ? (
-    <Badge color="notification" text={data.length.toString()} className="ctw-h-5" />
+  return unarchivedObservations.length ? (
+    <Badge
+      color="notification"
+      text={unarchivedObservations.length.toString()}
+      className="ctw-h-5"
+    />
   ) : null;
 };


### PR DESCRIPTION
<img width="882" alt="Screenshot 2023-05-19 at 10 40 23 AM" src="https://github.com/zeus-health/ctw-component-library/assets/1568246/edf6af7e-51dc-4187-a409-f4ac7681995b">

Can't actually dismiss observations a.t.m but good to have the badge aligned with filtering out dismissed observations if/when we can dismiss them.