### PR TITLE
Wait for meds refresh when dismissing meds

### DIFF
--- a/.changeset/yellow-ravens-burn.md
+++ b/.changeset/yellow-ravens-burn.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Dissmissing meds will now continue to show loading spinner until the meds data has been refreshed. This fixes a bug where we briefly show the stale, non-dismissed, state.

--- a/src/components/content/medications/patient-medications-outside.tsx
+++ b/src/components/content/medications/patient-medications-outside.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useAddMedicationForm } from "./helpers/add-new-med-drawer";
 import { medicationFilters } from "./helpers/filters";
 import { PatientMedicationsBase } from "./helpers/patient-medications-base";
@@ -24,13 +25,14 @@ const PatientMedicationsOutsideComponent = ({
   onOpenHistoryDrawer,
 }: PatientMedicationsOutsideProps) => {
   const { otherProviderMedications, isLoading } = useQueryAllPatientMedications();
+  const rowActions = useMemo(() => getRowActions({ onAddToRecord }), [onAddToRecord]);
 
   return (
     <PatientMedicationsBase
       className={className}
       query={{ data: otherProviderMedications, isLoading }}
       filters={medicationFilters(otherProviderMedications, true)}
-      rowActions={readOnly ? undefined : getRowActions({ onAddToRecord })}
+      rowActions={readOnly ? undefined : rowActions}
       onOpenHistoryDrawer={onOpenHistoryDrawer}
     />
   );


### PR DESCRIPTION
I believe this particular bug was introduced when I refactored the “2.0” code for conditions and medications. The bug here is that clicking “dismiss” shows the loading spinner (good) but then stops showing spinner BEFORE the state is updated where we’d know this med is now archived. So the UI bug is: user click “dismiss” -> sees loading spinner -> stops loading but record still shows up as is treated as if it was not yet dismissed -> after a moment it then disappears (state update, med is now dismissed).

I added some debug message to useToggleArchive and to the med query itself. Here we can see that the top level code of useToggleArchive is getting called again and its isLoading is false . This happens after we trigger meds refresh, but BEFORE the meds get refetched. What’s suppose to happen is isLoading stays false until meds are refetched and handleToggleArchive sets isLoading=false.

```
-- DISMISS CLICKED
useToggleArchive.handleToggleArchive  set isLoading=true
useToggleArchive (top level) isLoading=true
RowActions isLoading=true
-- REFETCH MEDS START
useToggleArchive (top level) isLoading=false
RowActions isLoading=false
-- REFETCH MEDS END
useToggleArchive.handleToggleArchive  set isLoading=false
```

The culprit?

Our use of getRowActions resulted in a new RowActions component getting created when the records changed. This meant the useToggleArchive would use a fresh new hook (the reason init was called again and isLoading was the default false).
```jsx
    <PatientMedicationsBase
      className={className}
      query={{ data: otherProviderMedications, isLoading }}
      filters={medicationFilters(otherProviderMedications, true)}
      rowActions={readOnly ? undefined : getRowActions({ onAddToRecord })}
      onOpenHistoryDrawer={onOpenHistoryDrawer}
    />
```

```jsx
const getRowActions =
  ({ onAddToRecord }: ExtraRowActionProps) =>
  (props: RowActionsProps<MedicationStatementModel>) =>
    <RowActions {...props} onAddToRecord={onAddToRecord} />;
```

The fix is to useMemo:
```
  const rowActions = useMemo(() => getRowActions({ onAddToRecord }), [onAddToRecord]);
```

**BEFORE**
![May-24-2023 12-39-36](https://github.com/zeus-health/ctw-component-library/assets/1568246/ca1bb28f-8799-43b7-9433-b2c8264a38fb)

**AFTER**
![May-24-2023 13-11-22](https://github.com/zeus-health/ctw-component-library/assets/1568246/90c0f385-30c1-48db-abb4-639a40437dbe)
