### PR TITLE
CTW-691: Limiting FQS results to a single builder

### DIFF
--- a/src/services/common.ts
+++ b/src/services/common.ts
@@ -1,0 +1,16 @@
+import { DomainResource } from "fhir/r4";
+import { SYSTEM_ZUS_OWNER } from "@/fhir/system-urls";
+import { filter, some } from "@/utils/nodash";
+
+export const filterResourcesByBuilderId = <T extends DomainResource>(
+  resources: T[],
+  builderId: string
+) => {
+  const filteredResources = filter(resources, (record) =>
+    some(record.meta?.tag, {
+      system: SYSTEM_ZUS_OWNER,
+      code: `builder/${builderId}`,
+    })
+  );
+  return filteredResources;
+};


### PR DESCRIPTION
https://zeushealth.atlassian.net/browse/CTW-691

This is a fix for an issue spotted when looking at a supercluster in Sandbox: 

1. The current builder FQS query wasn't limiting the results to the only the builder in scope
2. Superclusters haven't necessarily been de-kludged in lower environments, which leads to weird results w/ the FQS query where it returns **all** data across the **all** pre-kludge builders. Updated the Outside Conditions query to limit the query to the lens builder, which will at least make these superclusters no longer return any Outside Conditions data.