### PR TITLE
Fix bug updating resources fetched from FQS

### DIFF
--- a/.changeset/hot-needles-talk.md
+++ b/.changeset/hot-needles-talk.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix bug when trying to save or update resources fetched from FQS.

--- a/src/fhir/action-helper.ts
+++ b/src/fhir/action-helper.ts
@@ -1,6 +1,6 @@
 import { FhirResource, Resource } from "fhir/r4";
 import { v4 as uuidv4 } from "uuid";
-import { omitEmptyArrays } from "./client";
+import { fixupFHIR } from "./client";
 import { isFhirError } from "./errors";
 import { ASSEMBLER_CODING, CREATE_CODING, createProvenance } from "./provenance";
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
@@ -24,7 +24,7 @@ export async function createOrEditFhirResource(
       response = await fhirClient.update({
         resourceType: resource.resourceType,
         id: resource.id,
-        body: omitEmptyArrays(resource),
+        body: fixupFHIR(resource),
       });
       if (!isFhirError(response)) {
         await createProvenance("UPDATE", response, requestContext);
@@ -33,7 +33,7 @@ export async function createOrEditFhirResource(
       // Utilize the FHIR write-back client for creating resources
       response = await fhirWriteBackClient.create({
         resourceType: resource.resourceType,
-        body: omitEmptyArrays(resource),
+        body: fixupFHIR(resource),
       });
       if (!isFhirError(response)) {
         resourceModified.id = response.id;
@@ -103,7 +103,7 @@ export async function createFhirResourceWithProvenance(
   };
 
   return fhirClient.transaction({
-    body: omitEmptyArrays({
+    body: fixupFHIR({
       ...bundle,
       type: "transaction",
     }),

--- a/src/fhir/client.ts
+++ b/src/fhir/client.ts
@@ -28,25 +28,41 @@ export function getFhirClients(env: Env, accessToken: string, builderId?: string
   };
 }
 
-// Returns a new value with all empty arrays replaced with "undefined".
-// This fixes an issue where ODS will complain with:
-// "Array cannot be empty - the property should not be present if it has no values"
-export const omitEmptyArrays = <T>(value: T): T =>
+// Takes a fhir resource and returns a new one that has numerous fixes
+// to help get saves working with ODS.
+// 1. Remoes all empty arrays.
+//    This fixes an issue where ODS will complain with:
+//    "Array cannot be empty - the property should not be present if it has no values"
+// 2. Removes all null and undefined values.
+// 3. Removes "resource" from references which are added by FQS.
+export const fixupFHIR = <T>(value: T): T =>
   // Cast because the function that finds and omits arrays produces an unknown.
-  omitEmptyArraysHelper(value) as T;
+  fixupFHIRHelper(value) as T;
 
-const omitEmptyArraysHelper = (value: unknown): unknown => {
+const fixupFHIRHelper = (value: unknown): unknown => {
   if (Array.isArray(value)) {
     if (value.length === 0) {
       return undefined;
     }
-    return value.map(omitEmptyArrays);
+    return value.map(fixupFHIR);
   }
 
   if (value !== null && typeof value === "object") {
     const newValue = value as { [key: string]: unknown };
     Object.entries(newValue).forEach(([key, v]) => {
-      newValue[key] = omitEmptyArrays(v);
+      if (v === undefined || v === null) {
+        delete newValue[key];
+      } else {
+        newValue[key] = fixupFHIR(v);
+      }
+      // FQS allows fetching nested "resource" objects from references.
+      // We cannot pass these back when saving to ODS,
+      // so we delete them from the object here.
+      // Our simple test is if the current object has a "reference"
+      // and a "resource" object.
+      if (newValue.reference && typeof newValue.resource === "object") {
+        delete newValue.resource;
+      }
     });
     return newValue;
   }


### PR DESCRIPTION
FQS returns some non FHIR compliant data (nulls and reference resources). We now filter those out before saving to ODS.