### PR TITLE
fix: use document date first before using binary creation date

### DIFF
--- a/.changeset/nice-years-appear.md
+++ b/.changeset/nice-years-appear.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Use document date before binary creation date when defining document's creation date

--- a/src/fhir/models/document.ts
+++ b/src/fhir/models/document.ts
@@ -36,7 +36,9 @@ export class DocumentModel extends FHIRModel<fhir4.DocumentReference> {
   }
 
   get dateCreated(): string | undefined {
-    return formatISODateStringToDate(this.resource.content[0].attachment.creation);
+    return formatISODateStringToDate(
+      this.resource.date || this.resource.content[0].attachment.creation
+    );
   }
 
   get custodian(): string | undefined {


### PR DESCRIPTION
Currently we use the first attachment's creation date to define the document's "Date Created"; however, this is not guaranteed to be populated. This change leverages the Document Reference Date first, then fall back to the binary creation date if the document reference date is not present