### PR TITLE
fix: show only renderable binaries (at this time, only CW and CQ docs)

### DIFF
--- a/.changeset/clever-experts-switch.md
+++ b/.changeset/clever-experts-switch.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+List only renderable documents in document component

--- a/src/components/content/document/helpers/filters.test.ts
+++ b/src/components/content/document/helpers/filters.test.ts
@@ -103,9 +103,24 @@ describe("document filters tests", () => {
     postRainbowCategories: false,
   });
 
+  const carequalityDoc = createSyntheticDocRef({
+    id: "1",
+    docRefDate: "2023-04-17T12:34:56.000Z",
+    zusCreationDate: "2023-04-17T12:34:56.000Z",
+    thirdPartyOwner: "carequality",
+    postRainbowCategories: true,
+  });
+
   test("verify only commonwell docs are rendered", () => {
-    const input = [commonwellDoc, commonwelPreRainbowDoc, surescriptsDoc, questDoc, firstPartyDoc];
-    const expectedOutput = [commonwellDoc, commonwelPreRainbowDoc].map(
+    const input = [
+      commonwellDoc,
+      commonwelPreRainbowDoc,
+      surescriptsDoc,
+      questDoc,
+      firstPartyDoc,
+      carequalityDoc,
+    ];
+    const expectedOutput = [commonwellDoc, commonwelPreRainbowDoc, carequalityDoc].map(
       (docRef) => new DocumentModel(docRef)
     );
     const actualOutput = applyDocumentFilters(input);

--- a/src/components/content/document/helpers/filters.test.ts
+++ b/src/components/content/document/helpers/filters.test.ts
@@ -1,0 +1,115 @@
+import { applyDocumentFilters, THIRD_PARTY_SOURCE_SYSTEM, ZUS_CREATION_DATE_URL } from "./filters";
+import { DocumentModel } from "@/fhir/models/document";
+
+interface SyntheticDocRefProps {
+  id: string;
+  postRainbowCategories: boolean;
+  zusCreationDate: string;
+  thirdPartyOwner?: string;
+  docRefDate?: string;
+  binaryCreationDate?: string;
+}
+
+const createSyntheticDocRef = (props: SyntheticDocRefProps): fhir4.DocumentReference => ({
+  id: props.id,
+  resourceType: "DocumentReference",
+  status: "current",
+  content: [
+    {
+      attachment: {
+        creation: props.binaryCreationDate,
+        data: "blah",
+      },
+    },
+  ],
+  date: props.docRefDate,
+  meta: {
+    extension: [
+      {
+        url: ZUS_CREATION_DATE_URL,
+        valueInstant: props.zusCreationDate,
+      },
+    ],
+    tag: props.thirdPartyOwner
+      ? [
+          {
+            system: THIRD_PARTY_SOURCE_SYSTEM,
+            code: props.thirdPartyOwner,
+          },
+        ]
+      : undefined,
+  },
+  category: props.postRainbowCategories
+    ? [
+        {
+          coding: [
+            {
+              code: "abc",
+            },
+          ],
+          text: "abc",
+        },
+        {
+          coding: [
+            {
+              code: "xyz",
+            },
+          ],
+          text: "xyz",
+        },
+      ]
+    : undefined,
+});
+
+describe("document filters tests", () => {
+  const commonwellDoc = createSyntheticDocRef({
+    id: "1",
+    docRefDate: "2023-04-17T12:34:56.000Z",
+    zusCreationDate: "2023-04-17T12:34:56.000Z",
+    thirdPartyOwner: "commonwell",
+    postRainbowCategories: true,
+  });
+
+  const commonwelPreRainbowDoc = createSyntheticDocRef({
+    id: "1a",
+    docRefDate: "2022-04-17T12:34:56.000Z",
+    zusCreationDate: "2022-04-17T12:34:56.000Z",
+    thirdPartyOwner: "commonwell",
+    postRainbowCategories: false,
+  });
+
+  const surescriptsDoc = createSyntheticDocRef({
+    id: "2",
+    docRefDate: "2023-04-17T12:34:56.000Z",
+    zusCreationDate: "2023-04-17T12:34:56.000Z",
+
+    thirdPartyOwner: "surescripts",
+    postRainbowCategories: true,
+  });
+
+  const questDoc = createSyntheticDocRef({
+    id: "3",
+    docRefDate: "2023-04-17T12:34:56.000Z",
+    zusCreationDate: "2023-04-17T12:34:56.000Z",
+
+    thirdPartyOwner: "quest",
+    postRainbowCategories: true,
+  });
+
+  const firstPartyDoc = createSyntheticDocRef({
+    id: "4",
+    docRefDate: "2023-04-17T12:34:56.000Z",
+    zusCreationDate: "2023-04-17T12:34:56.000Z",
+    postRainbowCategories: false,
+  });
+
+  test("verify only commonwell docs are rendered", () => {
+    const input = [commonwellDoc, commonwelPreRainbowDoc, surescriptsDoc, questDoc, firstPartyDoc];
+    const expectedOutput = [commonwellDoc, commonwelPreRainbowDoc].map(
+      (docRef) => new DocumentModel(docRef)
+    );
+    const actualOutput = applyDocumentFilters(input);
+
+    expect(actualOutput).toStrictEqual(expectedOutput);
+  });
+});

--- a/src/components/content/document/helpers/filters.test.ts
+++ b/src/components/content/document/helpers/filters.test.ts
@@ -3,6 +3,7 @@ import { DocumentModel } from "@/fhir/models/document";
 
 interface SyntheticDocRefProps {
   id: string;
+  title: string;
   postRainbowCategories: boolean;
   zusCreationDate: string;
   thirdPartyOwner?: string;
@@ -17,6 +18,7 @@ const createSyntheticDocRef = (props: SyntheticDocRefProps): fhir4.DocumentRefer
   content: [
     {
       attachment: {
+        title: props.title,
         creation: props.binaryCreationDate,
         data: "blah",
       },
@@ -64,6 +66,7 @@ const createSyntheticDocRef = (props: SyntheticDocRefProps): fhir4.DocumentRefer
 describe("document filters tests", () => {
   const commonwellDoc = createSyntheticDocRef({
     id: "1",
+    title: "post rainbow commonwell",
     docRefDate: "2023-04-17T12:34:56.000Z",
     zusCreationDate: "2023-04-17T12:34:56.000Z",
     thirdPartyOwner: "commonwell",
@@ -72,6 +75,7 @@ describe("document filters tests", () => {
 
   const commonwelPreRainbowDoc = createSyntheticDocRef({
     id: "1a",
+    title: "pre rainbow commonwell",
     docRefDate: "2022-04-17T12:34:56.000Z",
     zusCreationDate: "2022-04-17T12:34:56.000Z",
     thirdPartyOwner: "commonwell",
@@ -80,24 +84,25 @@ describe("document filters tests", () => {
 
   const surescriptsDoc = createSyntheticDocRef({
     id: "2",
+    title: "post rainbow surescript",
     docRefDate: "2023-04-17T12:34:56.000Z",
     zusCreationDate: "2023-04-17T12:34:56.000Z",
-
     thirdPartyOwner: "surescripts",
     postRainbowCategories: true,
   });
 
   const questDoc = createSyntheticDocRef({
     id: "3",
+    title: "post rainbow quest",
     docRefDate: "2023-04-17T12:34:56.000Z",
     zusCreationDate: "2023-04-17T12:34:56.000Z",
-
     thirdPartyOwner: "quest",
     postRainbowCategories: true,
   });
 
   const firstPartyDoc = createSyntheticDocRef({
     id: "4",
+    title: "first party",
     docRefDate: "2023-04-17T12:34:56.000Z",
     zusCreationDate: "2023-04-17T12:34:56.000Z",
     postRainbowCategories: false,
@@ -105,6 +110,7 @@ describe("document filters tests", () => {
 
   const carequalityDoc = createSyntheticDocRef({
     id: "1",
+    title: "post rainbow carequality",
     docRefDate: "2023-04-17T12:34:56.000Z",
     zusCreationDate: "2023-04-17T12:34:56.000Z",
     thirdPartyOwner: "carequality",

--- a/src/components/content/document/helpers/filters.ts
+++ b/src/components/content/document/helpers/filters.ts
@@ -1,12 +1,12 @@
 import { DocumentModel } from "@/fhir/models/document";
 import { isEqual, uniqWith } from "@/utils/nodash";
 
+export const THIRD_PARTY_SOURCE_SYSTEM = "https://zusapi.com/thirdparty/source";
+export const ZUS_CREATION_DATE_URL = "https://zusapi.com/created-at";
 const RAINBOW_CUTOVER_DATE = new Date("2023-03-08T05:00:00.000Z");
 
 const zusCreationDate = (doc: fhir4.DocumentReference) => {
-  const createExtension = doc.meta?.extension?.filter(
-    (ext) => ext.url === "https://zusapi.com/created-at"
-  );
+  const createExtension = doc.meta?.extension?.filter((ext) => ext.url === ZUS_CREATION_DATE_URL);
   if (createExtension?.length !== 1 || !createExtension[0].valueInstant) {
     throw Error("no creation date found for document reference");
   }
@@ -27,9 +27,17 @@ const isViewablePostRainbow = (docRef: fhir4.DocumentReference) => {
   );
 };
 
+const isRenderableBinary = (doc: fhir4.DocumentReference): boolean => {
+  const thirdPartyTag = doc.meta?.tag?.find((tag) => tag.system === THIRD_PARTY_SOURCE_SYSTEM);
+  const isSupportedThirdParty = ["commonwell"].includes(thirdPartyTag?.code || "");
+  return isSupportedThirdParty;
+};
+
 export const applyDocumentFilters = (data: fhir4.DocumentReference[]) => {
   const documentModels = data
-    .filter((doc) => isViewablePreRainbow(doc) || isViewablePostRainbow(doc))
+    .filter(
+      (doc) => (isViewablePreRainbow(doc) || isViewablePostRainbow(doc)) && isRenderableBinary(doc)
+    )
     .map((document) => new DocumentModel(document));
 
   const documentData = uniqWith(documentModels, (a, b) =>

--- a/src/components/content/document/helpers/filters.ts
+++ b/src/components/content/document/helpers/filters.ts
@@ -29,7 +29,7 @@ const isViewablePostRainbow = (docRef: fhir4.DocumentReference) => {
 
 const isRenderableBinary = (doc: fhir4.DocumentReference): boolean => {
   const thirdPartyTag = doc.meta?.tag?.find((tag) => tag.system === THIRD_PARTY_SOURCE_SYSTEM);
-  const isSupportedThirdParty = ["commonwell"].includes(thirdPartyTag?.code || "");
+  const isSupportedThirdParty = ["commonwell", "carequality"].includes(thirdPartyTag?.code || "");
   return isSupportedThirdParty;
 };
 


### PR DESCRIPTION
Currently the library can only render CCDA documents; hence, we filter out documents we cannot render to reduce confusion