### PR TITLE
CTW-1224/medications date sorting direction

### DIFF
--- a/.changeset/wet-tips-study.md
+++ b/.changeset/wet-tips-study.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fixed medication sort directions for date based sorts.

--- a/src/components/content/medications/helpers/sorts.ts
+++ b/src/components/content/medications/helpers/sorts.ts
@@ -12,23 +12,23 @@ export const medicationSortOptions: SortOption<MedicationStatementModel>[] = [
   },
   {
     display: "Last Fill Date (Oldest to Newest)",
-    sorts: [{ key: "lastFillDate", dir: "desc", isDate: true }],
+    sorts: [{ key: "lastFillDate", dir: "asc", isDate: true }],
   },
   {
     display: "Last Fill Date (Newest to Oldest)",
-    sorts: [{ key: "lastFillDate", dir: "asc", isDate: true }],
+    sorts: [{ key: "lastFillDate", dir: "desc", isDate: true }],
   },
   {
     display: "Last Prescribed (Old to New)",
     sorts: [
-      { key: "lastPrescribedDate", isDate: true, dir: "desc" },
+      { key: "lastPrescribedDate", isDate: true, dir: "asc" },
       { key: "lastPrescriber", dir: "asc" },
     ],
   },
   {
     display: "Last Prescribed (New to Old)",
     sorts: [
-      { key: "lastPrescribedDate", isDate: true, dir: "asc" },
+      { key: "lastPrescribedDate", isDate: true, dir: "desc" },
       { key: "lastPrescriber", dir: "asc" },
     ],
   },


### PR DESCRIPTION
Fixed a bug where the medications component was sorting dates in the wrong direction.