### PR TITLE
CDEV-52: Fixing flag ready slowness

### DIFF
--- a/.changeset/gentle-pugs-pay.md
+++ b/.changeset/gentle-pugs-pay.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fixed issue where Unleash client was sometimes taking too long to load flags

--- a/src/hooks/use-feature-variant.ts
+++ b/src/hooks/use-feature-variant.ts
@@ -15,22 +15,12 @@ export function useFeatureVariant(name: string): FeatureVariant {
   const status = useFlagsStatus();
   const variant = useVariant(name);
   const [clientError, setClientError] = useState<boolean>();
-  const [clientRefetched, setClientRefetched] = useState<boolean>();
-  const { userId } = client.getContext();
 
   useEffect(() => {
     client.on("error", () => {
       setClientError(true);
     });
   }, [client]);
-
-  useEffect(() => {
-    if (userId) {
-      client.on("update", () => {
-        setClientRefetched(true);
-      });
-    }
-  }, [client, userId]);
 
   // return "ready" if unleash failed to bootstrap
   if (clientError) {
@@ -39,10 +29,6 @@ export function useFeatureVariant(name: string): FeatureVariant {
   // return "ready" if unleash failed to load flags
   if (status.flagsError) {
     return { ready: true };
-  }
-  // return "not ready" if unleash hasn't refetched flags after the context changed.
-  if (!clientRefetched) {
-    return { ready: false };
   }
   // return "not ready" if unleash is still fetching flags
   if (!status.flagsReady && !status.flagsError) {


### PR DESCRIPTION
https://zeushealth.atlassian.net/browse/CDEV-52

Removing the "on client update" listener that was originally put in so that `useFeatureVariant` would (presumably) wait until the Unleash client had been updated w/ the user context before returning flags. However, this should no longer be needed after the explicit client start/stop fix introduced [here](https://github.com/zeus-health/ctw-component-library/pull/833/files#diff-a98d6d28f3b21099b8ab57cd7e1478dd7e17b477159b55a3af61509509524572R50-R55).

The "on client update" hook is causing the standalone app to delay marking feature flags as ready, which then delays when Conditions data gets fetched.