### PR TITLE
CDEV-52: slowness v2

### DIFF
--- a/.changeset/gentle-pugs-pay.md
+++ b/.changeset/gentle-pugs-pay.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fixed issue where Unleash client was sometimes taking too long to load flags

--- a/src/components/core/providers/feature-flag-provider.tsx
+++ b/src/components/core/providers/feature-flag-provider.tsx
@@ -1,14 +1,15 @@
-import {
-  FlagProvider,
-  UnleashClient,
-  useUnleashClient,
-  useUnleashContext,
-} from "@unleash/proxy-client-react";
+import { FlagProvider, UnleashClient, useUnleashContext } from "@unleash/proxy-client-react";
 import jwtDecode from "jwt-decode";
-import { ReactNode, useEffect, useMemo, useState } from "react";
+import { createContext, ReactNode, useEffect, useMemo, useState } from "react";
 import { useGetAuthToken } from "./authentication/use-get-auth-token";
 
-export type FeatureFlagProviderProps = { children: ReactNode };
+export const FeatureFlagContext = createContext({
+  unleashClientFailed: false,
+});
+
+export type FeatureFlagProviderProps = {
+  children: ReactNode;
+};
 
 export function FeatureFlagProvider({ children }: FeatureFlagProviderProps) {
   const unleashClient = useMemo(
@@ -25,39 +26,59 @@ export function FeatureFlagProvider({ children }: FeatureFlagProviderProps) {
 
   return (
     <FlagProvider unleashClient={unleashClient} startClient={false}>
-      <FeatureFlagProviderComponent>{children}</FeatureFlagProviderComponent>
+      <FeatureFlagProviderComponent unleashClient={unleashClient}>
+        {children}
+      </FeatureFlagProviderComponent>
     </FlagProvider>
   );
 }
 
+type FeatureFlagProviderComponentProps = {
+  children: ReactNode;
+  unleashClient: UnleashClient;
+};
+
 // Component responsible for fetching the auth token and updating the Unleash context once the auth token has been fetched.
 // This needs to be a child of `FlagProvider` in order to have access to the Unleash context.
-const FeatureFlagProviderComponent = ({ children }: FeatureFlagProviderProps) => {
-  const client = useUnleashClient();
+const FeatureFlagProviderComponent = ({
+  unleashClient,
+  children,
+}: FeatureFlagProviderComponentProps) => {
   const updateContext = useUnleashContext();
   const authTokenPromise = useGetAuthToken();
   const [authToken, setAuthToken] = useState<string>();
+  const [unleashClientStarted, setUnleashClientStarted] = useState<boolean>();
+  const [unleashClientFailed, setUnleashClientFailed] = useState<boolean>();
 
+  // fetch the auth token
   useEffect(() => {
     void (async function fetchData() {
       setAuthToken(await authTokenPromise());
     })();
   }, [authTokenPromise]);
 
+  // configure the unleash client
   useEffect(() => {
-    if (authToken) {
+    if (authToken && !unleashClientStarted) {
       void (async function run() {
-        // Explicitly stop/start the Unleash client when updating the context to avoid a race condition
-        // where existing "in flight" requests to the Unleash server (with incorrect context info) are returned
-        // just as the new (correct) Unleash context is set.
-        client.stop();
+        unleashClient.on("error", () => {
+          setUnleashClientFailed(true);
+        });
         await updateContext(getUnleashContext(authToken));
-        await client.start();
+        await unleashClient.start();
+        setUnleashClientStarted(true);
       })();
     }
-  }, [authToken, client, updateContext]);
+  }, [authToken, unleashClient, unleashClientStarted, updateContext]);
 
-  return <>{children}</>;
+  const context = useMemo(
+    () => ({
+      unleashClientFailed: !!unleashClientFailed,
+    }),
+    [unleashClientFailed]
+  );
+
+  return <FeatureFlagContext.Provider value={context}>{children}</FeatureFlagContext.Provider>;
 };
 
 function getUnleashContext(authToken: string) {

--- a/src/hooks/use-feature-variant.ts
+++ b/src/hooks/use-feature-variant.ts
@@ -15,22 +15,12 @@ export function useFeatureVariant(name: string): FeatureVariant {
   const status = useFlagsStatus();
   const variant = useVariant(name);
   const [clientError, setClientError] = useState<boolean>();
-  const [clientRefetched, setClientRefetched] = useState<boolean>();
-  const { userId } = client.getContext();
 
   useEffect(() => {
     client.on("error", () => {
       setClientError(true);
     });
   }, [client]);
-
-  useEffect(() => {
-    if (userId) {
-      client.on("update", () => {
-        setClientRefetched(true);
-      });
-    }
-  }, [client, userId]);
 
   // return "ready" if unleash failed to bootstrap
   if (clientError) {
@@ -39,10 +29,6 @@ export function useFeatureVariant(name: string): FeatureVariant {
   // return "ready" if unleash failed to load flags
   if (status.flagsError) {
     return { ready: true };
-  }
-  // return "not ready" if unleash hasn't refetched flags after the context changed.
-  if (!clientRefetched) {
-    return { ready: false };
   }
   // return "not ready" if unleash is still fetching flags
   if (!status.flagsReady && !status.flagsError) {


### PR DESCRIPTION
https://zeushealth.atlassian.net/browse/CDEV-52

This is another version of https://github.com/zeus-health/ctw-component-library/pull/836 w/ code simplification...

1. Simplified the `use-feature-variant` hook code 
2. `FeatureFlagProviderComponent` now only starts the unleash client once
3. Using a `FeatureFlagContext` to share state w/ `use-feature-variant` so that, when the unleash client errors, the hook [no longer has to wait for another error event to be emitted](https://github.com/zeus-health/ctw-component-library/pull/837/files#diff-3ef550bcba08c1508fe6c027cd24e131f59a90150b4f3025ccbc6c22af056d81L21-L25)

Tested:

- [x] Conditions **ctw-component-library** test App: 10 refreshes to make sure FQS is ENABLED when its supposed to be
- [x] Conditions **ctw-component-library** test App: 10 refreshes to make sure FQS is DISABLED when its supposed to be
- [x] Conditions **ctw-component-library** test App: 10 refreshes to make sure when the Unleash client fails to load, page loads immediately after w/ ODS
- [x] Conditions in standalone: 10 refreshes to make sure FQS is ENABLED when its supposed to be
- [x] Conditions in standalone: 10 refreshes to make sure FQS is DISABLED when its supposed to be
- [x] Conditions in standalone: 10 refreshes to make sure when the Unleash client fails to load, page loads immediately after w/ ODS
- [x] Conditions in standalone: 10 page navigations (not refreshes) to make sure FQS is ENABLED when its supposed to be
- [x] Conditions in standalone: 10 page navigations (not refreshes) to make sure FQS is DISABLED when its supposed to be
- [x] Conditions in standalone: 10 page navigations (not refreshes) to make sure when the Unleash client fails to load, page loads immediately after w/ ODS