### PR TITLE
fix: don't hard fail if creation date is missing, instead don't show the document

### DIFF
--- a/.changeset/six-laws-explain.md
+++ b/.changeset/six-laws-explain.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix issue where no documents were rendered due to missing creation date

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "1.17.5",
+  "version": "1.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "1.17.5",
+      "version": "1.18.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,11 @@ const components: DemoComponent[] = [
     render: () => <PatientConditionsOutside />,
     title: "Patient Conditions Outside",
   },
-  { name: "documents", render: () => <PatientDocuments />, title: "Patient Documents" },
+  {
+    name: "documents",
+    render: () => <PatientDocuments enableFQS={true} />,
+    title: "Patient Documents",
+  },
   {
     name: "medications",
     render: () => <PatientMedications enableFQS={true} />,

--- a/src/components/content/document/helpers/filters.ts
+++ b/src/components/content/document/helpers/filters.ts
@@ -19,7 +19,7 @@ const isViewablePreRainbow = (doc: fhir4.DocumentReference) => {
   if (!creationDate) {
     return false;
   }
-  return creationDate > RAINBOW_CUTOVER_DATE;
+  return creationDate < RAINBOW_CUTOVER_DATE;
 };
 
 const isViewablePostRainbow = (docRef: fhir4.DocumentReference) => {

--- a/src/components/content/document/helpers/filters.ts
+++ b/src/components/content/document/helpers/filters.ts
@@ -8,14 +8,19 @@ const RAINBOW_CUTOVER_DATE = new Date("2023-03-08T05:00:00.000Z");
 const zusCreationDate = (doc: fhir4.DocumentReference) => {
   const createExtension = doc.meta?.extension?.filter((ext) => ext.url === ZUS_CREATION_DATE_URL);
   if (createExtension?.length !== 1 || !createExtension[0].valueInstant) {
-    throw Error("no creation date found for document reference");
+    return null;
   }
 
   return new Date(createExtension[0].valueInstant);
 };
 
-const isViewablePreRainbow = (doc: fhir4.DocumentReference) =>
-  zusCreationDate(doc) < RAINBOW_CUTOVER_DATE;
+const isViewablePreRainbow = (doc: fhir4.DocumentReference) => {
+  const creationDate = zusCreationDate(doc);
+  if (!creationDate) {
+    return false;
+  }
+  return creationDate > RAINBOW_CUTOVER_DATE;
+};
 
 const isViewablePostRainbow = (docRef: fhir4.DocumentReference) => {
   const document = new DocumentModel(docRef);


### PR DESCRIPTION
It is not guaranteed for a zus creation date to exist on a document reference; thus, we will default to not showing the document if the creation date is not present