### PR TITLE
CDEV-224/Refactor FQS / ODS query code and remove "drawer" variants

### DIFF
--- a/.changeset/metal-chairs-sit.md
+++ b/.changeset/metal-chairs-sit.md
@@ -2,4 +2,4 @@
 "@zus-health/ctw-component-library": patch
 ---
 
-Documents drawer requests use a separate toggle variant than the documents table requests
+Refactored FQS vs ODS query logic and removed all "drawer" specific feature variants. We'll instead use resource specific variants, regardless of which components do the data fetching.

--- a/.changeset/metal-chairs-sit.md
+++ b/.changeset/metal-chairs-sit.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Documents drawer requests use a separate toggle variant than the documents table requests

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ const components: DemoComponent[] = [
   },
   {
     name: "documents",
-    render: () => <PatientDocuments enableFQS={true} />,
+    render: () => <PatientDocuments />,
     title: "Patient Documents",
   },
   {
@@ -120,7 +120,6 @@ const components: DemoComponent[] = [
         title="ZAP"
         timelineProps={{ enableFQS: true }}
         observationsProps={{ enableFQS: true }}
-        documentsProps={{ enableFQS: true }}
       />
     ),
   },

--- a/src/components/content/allergies/patient-allergies.tsx
+++ b/src/components/content/allergies/patient-allergies.tsx
@@ -22,7 +22,7 @@ export type PatientAllergiesProps = {
 function PatientAllergiesComponent({ className }: PatientAllergiesProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { featureFlags } = useCTW();
-  const { enabled } = useFQSFeatureToggle("allergiesDrawer");
+  const { enabled } = useFQSFeatureToggle("allergies");
   const patientAllergiesQuery = usePatientAllergies();
   const { data, setFilters, setSort } = useFilteredSortedData({
     defaultFilters: defaultAllergyFilters,

--- a/src/components/content/conditions/helpers/details.tsx
+++ b/src/components/content/conditions/helpers/details.tsx
@@ -12,7 +12,7 @@ export const useConditionDetailsDrawer = ({
   canEdit: boolean;
   canRemove: boolean;
 }) => {
-  const { enabled } = useFQSFeatureToggle("conditionsDrawer");
+  const { enabled } = useFQSFeatureToggle("conditions");
   const showEditConditionForm = useEditConditionForm();
   const confirmDelete = useConfirmDeleteCondition();
 

--- a/src/components/content/document/patient-document.stories.tsx
+++ b/src/components/content/document/patient-document.stories.tsx
@@ -41,8 +41,6 @@ export const Basic: StoryObj<Props> = {
 };
 
 export const BasicFQS: StoryObj<Props> = {
-  args: {
-    enableFQS: true,
-  },
+  args: {},
   ...setupDocumentMocks(),
 };

--- a/src/components/content/document/patient-documents.tsx
+++ b/src/components/content/document/patient-documents.tsx
@@ -19,7 +19,7 @@ export type PatientDocumentProps = {
 function PatientDocumentsComponent({ className }: PatientDocumentProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { featureFlags } = useCTW();
-  const { enabled } = useFQSFeatureToggle("documentsDrawer");
+  const { enabled } = useFQSFeatureToggle("documents");
 
   const patientDocumentQuery = usePatientDocument();
   const { viewOptions, defaultView } = getDateRangeView<DocumentModel>("dateCreated");

--- a/src/components/content/document/patient-documents.tsx
+++ b/src/components/content/document/patient-documents.tsx
@@ -10,15 +10,16 @@ import { useCTW } from "@/components/core/providers/use-ctw";
 import { usePatientDocument } from "@/fhir/document";
 import { DocumentModel } from "@/fhir/models/document";
 import { useFilteredSortedData } from "@/hooks/use-filtered-sorted-data";
+import { useFQSFeatureToggle } from "@/hooks/use-fqs-feature-toggle";
 
 export type PatientDocumentProps = {
   className?: string;
-  enableFQS?: boolean;
 };
 
-function PatientDocumentsComponent({ className, enableFQS = false }: PatientDocumentProps) {
+function PatientDocumentsComponent({ className }: PatientDocumentProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { featureFlags } = useCTW();
+  const { enabled } = useFQSFeatureToggle("documentsDrawer");
 
   const patientDocumentQuery = usePatientDocument();
   const { viewOptions, defaultView } = getDateRangeView<DocumentModel>("dateCreated");
@@ -30,7 +31,7 @@ function PatientDocumentsComponent({ className, enableFQS = false }: PatientDocu
   const openDetails = useResourceDetailsDrawer({
     header: (m) => `${m.dateCreated} - ${m.title}`,
     details: documentData,
-    enableFQS,
+    enableFQS: enabled,
   });
 
   return (

--- a/src/components/content/immunizations/patient-immunizations.tsx
+++ b/src/components/content/immunizations/patient-immunizations.tsx
@@ -24,7 +24,7 @@ function PatientImmunizationsComponent({ className }: PatientImmunizationsProps)
   const containerRef = useRef<HTMLDivElement>(null);
   const breakpoints = useBreakpoints(containerRef);
   const { featureFlags } = useCTW();
-  const { enabled } = useFQSFeatureToggle("immunizationsDrawer");
+  const { enabled } = useFQSFeatureToggle("immunizations");
   const patientImmunizationsQuery = usePatientImmunizations();
   const openDetails = useResourceDetailsDrawer({
     header: (m) => m.description,

--- a/src/components/content/resource/history.ts
+++ b/src/components/content/resource/history.ts
@@ -47,7 +47,7 @@ export function useHistory<T extends ResourceTypeString, M extends FHIRModel<Res
 }: UseHistoryProps<T, M>) {
   return useQueryWithPatient(
     queryKey,
-    [model],
+    [model, enableFQS],
     enableFQS
       ? withTimerMetric(
           async (requestContext, patient) =>

--- a/src/fhir/basic.ts
+++ b/src/fhir/basic.ts
@@ -61,7 +61,7 @@ export async function recordProfileAction<T extends fhir4.Resource>(
 export function useBasic(fqs: FQSFeatureToggle) {
   return useQueryWithPatient(
     QUERY_KEY_BASIC,
-    [fqs.ready],
+    [fqs.ready, fqs.enabled],
     (() => {
       if (!fqs.ready) {
         return async () =>

--- a/src/fhir/document.ts
+++ b/src/fhir/document.ts
@@ -1,34 +1,21 @@
 import { searchCommonRecords } from "./search-helpers";
-import { PatientModel, useQueryWithPatient } from "..";
+import { PatientModel, useFeatureFlaggedQueryWithPatient } from "..";
 import { applyDocumentFilters } from "@/components/content/document/helpers/filters";
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
-import { useFQSFeatureToggle } from "@/hooks/use-fqs-feature-toggle";
 import { createGraphqlClient } from "@/services/fqs/client";
 import { DocumentReferenceGraphqlResponse, documentsQuery } from "@/services/fqs/queries/documents";
 import { orderBy } from "@/utils/nodash";
 import { QUERY_KEY_PATIENT_DOCUMENTS } from "@/utils/query-keys";
-import { Telemetry, withTimerMetric } from "@/utils/telemetry";
+import { Telemetry } from "@/utils/telemetry";
 
 export function usePatientDocument() {
-  const fqs = useFQSFeatureToggle("documents");
-  return useQueryWithPatient(
+  return useFeatureFlaggedQueryWithPatient(
     QUERY_KEY_PATIENT_DOCUMENTS,
-    [fqs.ready],
-    (() => {
-      if (!fqs.ready) {
-        return async () => [];
-      }
-      return fqs.enabled
-        ? withTimerMetric(
-            async (requestContext, patient) => getDocumentFromFQS(requestContext, patient),
-            "req.timing.documents",
-            ["fqs"]
-          )
-        : withTimerMetric(
-            async (requestContext, patient) => getDocumentFromODS(requestContext, patient),
-            "req.timing.documents"
-          );
-    })()
+    [],
+    "documents",
+    "req.timing.documents",
+    getDocumentFromFQS,
+    getDocumentFromODS
   );
 }
 

--- a/src/services/conditions.ts
+++ b/src/services/conditions.ts
@@ -11,7 +11,7 @@ import {
 } from "../fhir/system-urls";
 import { getLensBuilderId } from "@/api/urls";
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
-import { useQueryWithPatient } from "@/components/core/providers/patient-provider";
+import { useFeatureFlaggedQueryWithPatient } from "@/components/core/providers/patient-provider";
 import { useBasic } from "@/fhir/basic";
 import { getIncludedBasics } from "@/fhir/bundle";
 import { ConditionModel } from "@/fhir/models/condition";
@@ -25,41 +25,27 @@ import {
   QUERY_KEY_PATIENT_CONDITIONS,
 } from "@/utils/query-keys";
 import { queryClient } from "@/utils/request";
-import { Telemetry, withTimerMetric } from "@/utils/telemetry";
+import { Telemetry } from "@/utils/telemetry";
 
 export function usePatientBuilderConditions() {
-  const fqs = useFQSFeatureToggle("conditions");
-  return useQueryWithPatient(
+  return useFeatureFlaggedQueryWithPatient(
     QUERY_KEY_PATIENT_CONDITIONS,
-    [fqs.ready],
-    (() => {
-      if (!fqs.ready) {
-        return async () => [];
-      }
-      return fqs.enabled
-        ? withTimerMetric(fetchPatientBuilderConditionsFQS, "req.timing.builder_conditions", [
-            "fqs",
-          ])
-        : withTimerMetric(fetchPatientBuilderConditionsODS, "req.timing.builder_conditions");
-    })()
+    [],
+    "conditions",
+    "req.timing.builder_conditions",
+    fetchPatientBuilderConditionsFQS,
+    fetchPatientBuilderConditionsODS
   );
 }
 
 function usePatientSummaryConditions() {
-  const fqs = useFQSFeatureToggle("conditions");
-  return useQueryWithPatient(
+  return useFeatureFlaggedQueryWithPatient(
     QUERY_KEY_OTHER_PROVIDER_CONDITIONS,
-    [fqs.ready],
-    (() => {
-      if (!fqs.ready) {
-        return async () => [];
-      }
-      return fqs.enabled
-        ? withTimerMetric(fetchPatientSummaryConditionsFQS, "req.timing.summary_conditions", [
-            "fqs",
-          ])
-        : withTimerMetric(fetchPatientSummaryConditionsODS, "req.timing.summary_conditions");
-    })()
+    [],
+    "conditions",
+    "req.timing.summary_conditions",
+    fetchPatientSummaryConditionsFQS,
+    fetchPatientSummaryConditionsODS
   );
 }
 


### PR DESCRIPTION
CDEV-224

* Switch allergies, conditions, documents, immunizations, & medications to use base variant and not *Drawer variant.
* Refactored a bunch of FQS | ODS queries to use new `useFeatureFlaggedQueryWithPatient` helper.
* Removed a few use-medication hooks that were no longer used.
* Changed `req.medication_history` metric to `req.timing.medication_history` to align with other metrics.