### PR TITLE
Add managingOrg to conditionHistory

### DIFF
--- a/.changeset/slimy-scissors-prove.md
+++ b/.changeset/slimy-scissors-prove.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Update conditionHistory entries to contain ManagingOrganization.

--- a/src/services/fqs/queries/fragments/condition.ts
+++ b/src/services/fqs/queries/fragments/condition.ts
@@ -5,11 +5,20 @@ export function fragmentCondition(isConditionHistory: boolean) {
   const subjectFragment = isConditionHistory
     ? ""
     : `subject {
-    reference
-    resource {
-      ...Patient
-    }
-  }`;
+      reference
+      resource {
+        ... on Patient {
+          ...Patient
+          managingOrganization {
+            resource {
+              ... on Organization {
+                name
+              }
+            }
+          }
+        }
+      }
+    }`;
   return `
     ${fragmentCoding}
     ${patientFragment}


### PR DESCRIPTION
This PR adds managingOrganization to conditionHistory. 

<img width="562" alt="Screenshot 2023-06-26 at 8 28 57 PM" src="https://github.com/zeus-health/ctw-component-library/assets/98342697/7686cd7e-27c9-4ca7-85ed-c5a9094edc8a">
