### PR TITLE
Don't filter out resources without dates

### DIFF
--- a/.changeset/friendly-sheep-bow.md
+++ b/.changeset/friendly-sheep-bow.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Don't filter out resources without dates

--- a/src/components/content/resource/helpers/view-date-range.ts
+++ b/src/components/content/resource/helpers/view-date-range.ts
@@ -3,8 +3,9 @@ import { ViewOption } from "./view-button";
 
 function dateFilter<T extends object>(field: keyof T, days: number) {
   const now = new Date();
+  // Return any that don't have a date or are within "days".
   return (data: T[]) =>
-    data.filter((d) => d[field] && differenceInDays(now, new Date(String(d[field]))) <= days);
+    data.filter((d) => !d[field] || differenceInDays(now, new Date(String(d[field]))) <= days);
 }
 
 export function getDateRangeView<T extends object>(field: Extract<keyof T, string>) {


### PR DESCRIPTION
CDEV-54

This way, medications that don't have a date, will still show up regardless of the date range view selection (e.g. "Past 6 Months" will return medications that have a date for that range AND any medications without a date).