### PR TITLE
CDEV-215/FQS provenance

### DIFF
--- a/.changeset/dry-balloons-sit.md
+++ b/.changeset/dry-balloons-sit.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Enable fetching provenances from FQS if "provenances" feature-flag variant is enabled.

--- a/src/components/content/observations/helpers/details.tsx
+++ b/src/components/content/observations/helpers/details.tsx
@@ -31,7 +31,8 @@ export const Component = ({ diagnosticReport }: ObservationDetailsProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [binaryId, setBinaryId] = useState<string>();
   const { getRequestContext } = useCTW();
-  const fqs = useFQSFeatureToggle("observations");
+  const fqsObservations = useFQSFeatureToggle("observations");
+  const fqsProvenances = useFQSFeatureToggle("provenances");
 
   // We optionally look for any associated binary CCDAs
   // if getSourceDocument is true.
@@ -39,20 +40,24 @@ export const Component = ({ diagnosticReport }: ObservationDetailsProps) => {
     async function load() {
       setIsLoading(true);
       const requestContext = await getRequestContext();
-      const provenances = await searchProvenances(requestContext, [diagnosticReport], fqs.enabled);
+      const provenances = await searchProvenances(
+        requestContext,
+        [diagnosticReport],
+        fqsProvenances.enabled
+      );
       setBinaryId(getBinaryId(provenances, diagnosticReport.id));
       setIsLoading(false);
     }
 
-    if (fqs.ready) {
+    if (fqsProvenances.ready) {
       void load();
     }
-  }, [diagnosticReport, getRequestContext, fqs.enabled, fqs.ready]);
+  }, [diagnosticReport, getRequestContext, fqsProvenances.enabled, fqsProvenances.ready]);
 
   useEffect(() => {
-    if (fqs.ready) {
+    if (fqsObservations.ready) {
       setObservationsEntries(
-        fqs.enabled
+        fqsObservations.enabled
           ? compact(
               diagnosticReport.resource.result?.map(
                 (result) =>
@@ -82,7 +87,7 @@ export const Component = ({ diagnosticReport }: ObservationDetailsProps) => {
             )
       );
     }
-  }, [diagnosticReport, fqs.ready, fqs.enabled]);
+  }, [diagnosticReport, fqsObservations.ready, fqsObservations.enabled]);
 
   return (
     <div className="ctw-space-y-6" data-zus-telemetry-namespace="Observations">

--- a/src/fhir/provenance.ts
+++ b/src/fhir/provenance.ts
@@ -4,6 +4,7 @@ import { getUsersPractitionerReference } from "./practitioner";
 import { searchAllRecords } from "./search-helpers";
 import { SYSTEM_PROVENANCE_ACTIVITY_TYPE, SYSTEM_PROVENANCE_AGENT_TYPE } from "./system-urls";
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
+import { searchProvenancesFQS } from "@/services/fqs/queries/provenances";
 import { claimsBuilderName } from "@/utils/auth";
 import { uniq } from "@/utils/nodash";
 import { QUERY_KEY_PROVENANCE } from "@/utils/query-keys";
@@ -84,17 +85,15 @@ export const createProvenance = async (
 export async function searchProvenances<T extends fhir4.Resource>(
   requestContext: CTWRequestContext,
   models: FHIRModel<T>[],
-  // TODO remove underscore prefix when used.
-  _enableFQS = false
+  enableFQS = false
 ): Promise<Provenance[]> {
   if (models.length === 0) return [];
 
   const targets = uniq(models.map((m) => `${m.resourceType}/${m.id}`));
 
-  // TODO uncomment when FQS supports provenance on all resources and is back-filled.
-  // if (enableFQS) {
-  //   return searchProvenancesFQS(requestContext, models[0].resourceType, targets);
-  // }
+  if (enableFQS) {
+    return searchProvenancesFQS(requestContext, models[0].resourceType, targets);
+  }
   return searchProvenancesODS(requestContext, targets);
 }
 


### PR DESCRIPTION
Setup provenance queries on-top of FQS. This is follow-up to https://github.com/zeus-health/ctw-component-library/pull/838.

* Enable provenance queries on FQS (feature-flagged)
* Use `provenances` variant feature flag for all provenance queries.