### PR TITLE
Add extensions to graphQL queries

### DIFF
--- a/.changeset/tall-ways-film.md
+++ b/.changeset/tall-ways-film.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Update graphql queries to include extensions.

--- a/src/fhir/models/fhir-model.ts
+++ b/src/fhir/models/fhir-model.ts
@@ -52,6 +52,7 @@ export abstract class FHIRModel<T extends fhir4.Resource> {
   }
 
   get patientUPID(): string | undefined {
+    console.log("true or not", isFHIRDomainResource(this.resource));
     if (isFHIRDomainResource(this.resource)) {
       return find(this.resource.extension, { url: SYSTEM_ZUS_UNIVERSAL_ID })?.valueString;
     }

--- a/src/fhir/provenance.ts
+++ b/src/fhir/provenance.ts
@@ -95,6 +95,10 @@ export async function searchProvenances<T extends fhir4.Resource>(
 ): Promise<Provenance[]> {
   if (models.length === 0) return [];
 
+  console.log("enableFQS", enableFQS);
+
+  console.log("models", models);
+
   const targets = uniq(models.map((m) => `${m.resourceType}/${m.id}}`));
   const ids = models.map((m) => m.id);
 

--- a/src/services/fqs/queries/allergies.ts
+++ b/src/services/fqs/queries/allergies.ts
@@ -49,6 +49,10 @@ export const allergyQuery = gql`
               ...Coding
             }
           }
+          extension {
+            url
+            valueString
+          }
           verificationStatus {
             text
             coding {

--- a/src/services/fqs/queries/care-teams.ts
+++ b/src/services/fqs/queries/care-teams.ts
@@ -35,6 +35,10 @@ export const careTeamsQuery = gql`
             }
             versionId
           }
+          extension {
+            url
+            valueString
+          }
           status
           category {
             text

--- a/src/services/fqs/queries/diagnostic-reports-query.ts
+++ b/src/services/fqs/queries/diagnostic-reports-query.ts
@@ -51,6 +51,10 @@ export const diagnosticReportQuery = gql`
               valueInstant
             }
           }
+          extension {
+            url
+            valueString
+          }
           basedOn {
             reference
             resource {

--- a/src/services/fqs/queries/documents.ts
+++ b/src/services/fqs/queries/documents.ts
@@ -40,6 +40,10 @@ export const documentsQuery = gql`
             }
             versionId
           }
+          extension {
+            url
+            valueString
+          }
           status
           docStatus
           type {

--- a/src/services/fqs/queries/fragments.ts
+++ b/src/services/fqs/queries/fragments.ts
@@ -16,6 +16,10 @@ export const fragmentEncounterReference = gql`
   fragment Encounter on Encounter {
     id
     resourceType
+    extension {
+      url
+      valueString
+    }
     status
     priority {
       text
@@ -32,6 +36,10 @@ export const fragmentPractitioner = gql`
   fragment Practitioner on Practitioner {
     id
     resourceType
+    extension {
+      url
+      valueString
+    }
     name {
       family
       given
@@ -47,6 +55,10 @@ export const fragmentMedicationRequest = gql`
   fragment MedicationRequest on MedicationRequest {
     id
     resourceType
+    extension {
+      url
+      valueString
+    }
     status
     intent
   }
@@ -56,6 +68,10 @@ export const fragmentPatient = gql`
   fragment Patient on Patient {
     id
     resourceType
+    extension {
+      url
+      valueString
+    }
     active
     identifier {
       use
@@ -158,6 +174,10 @@ export const fragmentObservation = gql`
   fragment Observation on Observation {
     id
     resourceType
+    extension {
+      url
+      valueString
+    }
     status
     category {
       text
@@ -216,6 +236,10 @@ export const fragmentOrganization = gql`
   fragment Organization on Organization {
     id
     resourceType
+    extension {
+      url
+      valueString
+    }
     name
     telecom {
       system

--- a/src/services/fqs/queries/fragments/condition.ts
+++ b/src/services/fqs/queries/fragments/condition.ts
@@ -32,6 +32,10 @@ export function fragmentCondition(isConditionHistory: boolean) {
         }
         versionId
       }
+      extension {
+        url
+        valueString
+      }
       ${subjectFragment}
       abatementAge {
         value

--- a/src/services/fqs/queries/fragments/encounter.ts
+++ b/src/services/fqs/queries/fragments/encounter.ts
@@ -14,6 +14,10 @@ export const fragmentEncounter = gql`
       }
       versionId
     }
+    extension {
+      url
+      valueString
+    }
     status
     class {
       system

--- a/src/services/fqs/queries/fragments/location.ts
+++ b/src/services/fqs/queries/fragments/location.ts
@@ -4,6 +4,10 @@ export const fragmentLocation = gql`
   fragment Location on Location {
     id
     resourceType
+    extension {
+      url
+      valueString
+    }
     status
     name
     description

--- a/src/services/fqs/queries/immunizations.ts
+++ b/src/services/fqs/queries/immunizations.ts
@@ -31,6 +31,10 @@ export const immunizationsQuery = gql`
             }
             versionId
           }
+          extension {
+            url
+            valueString
+          }
           status
           statusReason {
             text

--- a/src/services/fqs/queries/medication-administration.ts
+++ b/src/services/fqs/queries/medication-administration.ts
@@ -35,6 +35,10 @@ export const medicationAdministrationQuery = gql`
         node {
           id
           resourceType
+          extension {
+            url
+            valueString
+          }
           dosage {
             text
             dose {

--- a/src/services/fqs/queries/medication-dispense.ts
+++ b/src/services/fqs/queries/medication-dispense.ts
@@ -35,6 +35,10 @@ export const medicationDispenseQuery = gql`
         node {
           id
           resourceType
+          extension {
+            url
+            valueString
+          }
           contained {
             resource {
               ... on Practitioner {

--- a/src/services/fqs/queries/medication-request.ts
+++ b/src/services/fqs/queries/medication-request.ts
@@ -36,6 +36,10 @@ export const medicationRequestQuery = gql`
         node {
           id
           resourceType
+          extension {
+            url
+            valueString
+          }
           authoredOn
           contained {
             resource {


### PR DESCRIPTION
This PR adds the extension field to the graphQL queries so that the source document link shows up. 