### PR TITLE
CTW-1240 Preventing non-builder users from marking records as read in production

### DIFF
--- a/.changeset/dirty-pugs-help.md
+++ b/.changeset/dirty-pugs-help.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Prevent non-builder users from being able to mark records as read in production.

--- a/src/components/content/hooks/use-toggle-read.ts
+++ b/src/components/content/hooks/use-toggle-read.ts
@@ -27,6 +27,12 @@ export function useToggleRead(...queriesToInvalidate: string[]): UseToggleReadRe
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const handleToggleRead = useCallback(async (model: FHIRModel<fhir4.Resource>) => {
+    const requestContext = await getRequestContext();
+    // In production we want to avoid non-builder users from inadvertantly marking records as read
+    // In lower environments this is allowed for demos/testing
+    if (requestContext.env === "production" && !(requestContext.userType === "builder")) {
+      return;
+    }
     setIsLoading(true);
     await toggleRead(model, await getRequestContext());
     await Promise.all(

--- a/src/components/content/hooks/use-toggle-read.ts
+++ b/src/components/content/hooks/use-toggle-read.ts
@@ -30,7 +30,7 @@ export function useToggleRead(...queriesToInvalidate: string[]): UseToggleReadRe
     const requestContext = await getRequestContext();
     // In production we want to avoid non-builder users from inadvertantly marking records as read
     // In lower environments this is allowed for demos/testing
-    if (requestContext.env === "production" && !(requestContext.userType === "builder")) {
+    if (requestContext.env === "production" && requestContext.userType !== "builder") {
       return;
     }
     setIsLoading(true);

--- a/src/components/core/providers/ctw-context.tsx
+++ b/src/components/core/providers/ctw-context.tsx
@@ -20,6 +20,7 @@ export type CTWRequestContext = {
   authToken: string;
   // The user's builder ID.
   builderId: string;
+  userType: string | undefined;
   // The optional builder ID used in case the user is impersonating a builder.
   contextBuilderId: string | undefined;
   fhirClient: Client;

--- a/src/components/core/providers/use-ctw.ts
+++ b/src/components/core/providers/use-ctw.ts
@@ -3,7 +3,7 @@ import { useGetAuthToken } from "./authentication/use-get-auth-token";
 import { CTWRequestContext, CTWStateContext } from "./ctw-context";
 import { getFhirClients } from "@/fhir/client";
 import { getFetchFromFqs } from "@/services/fqs/client";
-import { claimsBuilderId } from "@/utils/auth";
+import { claimsBuilderId, claimsUserType } from "@/utils/auth";
 
 export function useCTW() {
   const context = useContext(CTWStateContext);
@@ -25,6 +25,7 @@ export function useCTW() {
       fhirClient,
       fhirWriteBackClient,
       env: context.env,
+      userType: claimsUserType(authToken) ?? undefined,
       builderId: context.builderId ?? claimsBuilderId(authToken) ?? "",
       contextBuilderId: context.builderId,
       fetchFromFqs: getFetchFromFqs(context.env, authToken, context.builderId),

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -41,6 +41,10 @@ function getClaims(authToken: string): ZusJWT {
   }
 }
 
+export function claimsUserType(authToken: string): string | undefined {
+  return getClaims(authToken)[AUTH_USER_TYPE];
+}
+
 export function claimsBuilderId(authToken: string): string | undefined {
   return getClaims(authToken)[AUTH_BUILDER_ID];
 }


### PR DESCRIPTION
Checking the environment and user type when marking a record as read, if we're in production and it's a non-builder user then don't allow it. We could add this protection to dismissal but this feels a bit hack and it's really to protect against Zus users marking records as read because they simply clicked on them.