### PR TITLE
Add all value types to observation fragment

### DIFF
--- a/.changeset/real-bananas-own.md
+++ b/.changeset/real-bananas-own.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fetch all types of values for observations from FQS. This fixes an issue where some diagnostic report observations don't show any results.

--- a/src/services/fqs/queries/diagnostic-reports-query.ts
+++ b/src/services/fqs/queries/diagnostic-reports-query.ts
@@ -95,6 +95,7 @@ export const diagnosticReportQuery = gql`
           }
           result {
             reference
+            display
             resource {
               ...Observation
             }

--- a/src/services/fqs/queries/fragments.ts
+++ b/src/services/fqs/queries/fragments.ts
@@ -217,6 +217,55 @@ export const fragmentObservation = gql`
       system
       code
     }
+    valueCodeableConcept {
+      text
+      coding {
+        system
+        code
+        display
+      }
+    }
+    valueString
+    valueBoolean
+    valueInteger
+    valueRange {
+      low {
+        comparator
+        unit
+        value
+        system
+        code
+      }
+      high {
+        comparator
+        unit
+        value
+        system
+        code
+      }
+    }
+    valueRatio {
+      numerator {
+        comparator
+        unit
+        value
+        system
+        code
+      }
+      denominator {
+        comparator
+        unit
+        value
+        system
+        code
+      }
+    }
+    valueTime
+    valueDateTime
+    valuePeriod {
+      start
+      end
+    }
     interpretation {
       text
       coding {


### PR DESCRIPTION
We now fetch all value types that a https://fhir-ru.github.io/observation.html can have.