### PR TITLE
ignore FQS graphql errors when there is also data returned

### DIFF
--- a/.changeset/grumpy-weeks-flash.md
+++ b/.changeset/grumpy-weeks-flash.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Use data from FQS queries that return errors and data

--- a/src/fhir/allergies.ts
+++ b/src/fhir/allergies.ts
@@ -8,7 +8,7 @@ import { applyAllergyFilters } from "@/components/content/allergies/helpers/alle
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
 import { useFeatureFlaggedQueryWithPatient } from "@/components/core/providers/patient-provider";
 import { useFQSFeatureToggle } from "@/hooks/use-fqs-feature-toggle";
-import { createGraphqlClient } from "@/services/fqs/client";
+import { createGraphqlClient, fqsRequest } from "@/services/fqs/client";
 import { AllergyGraphqlResponse, allergyQuery } from "@/services/fqs/queries/allergies";
 import { QUERY_KEY_PATIENT_ALLERGIES } from "@/utils/query-keys";
 import { Telemetry } from "@/utils/telemetry";
@@ -62,15 +62,14 @@ async function getAllergyIntoleranceFromFQS(
 ) {
   try {
     const graphClient = createGraphqlClient(requestContext);
-    const data = (await graphClient.request(allergyQuery, {
+    const { data } = await fqsRequest<AllergyGraphqlResponse>(graphClient, allergyQuery, {
       upid: patient.UPID,
       cursor: "",
       first: 1000,
       sort: {
         lastUpdated: "DESC",
       },
-    })) as AllergyGraphqlResponse;
-
+    });
     const nodes = data.AllergyIntoleranceConnection.edges.map((x) => x.node);
     const results = applyAllergyFilters(nodes, requestContext.builderId);
     if (results.length === 0) {

--- a/src/fhir/care-team.ts
+++ b/src/fhir/care-team.ts
@@ -2,7 +2,7 @@ import { getIncludedResources } from "./bundle";
 import { searchCommonRecords } from "./search-helpers";
 import { CTWRequestContext, PatientModel, useFeatureFlaggedQueryWithPatient } from "..";
 import { applyCareTeamFilters } from "@/components/content/care-team/helpers/filters";
-import { createGraphqlClient } from "@/services/fqs/client";
+import { createGraphqlClient, fqsRequest } from "@/services/fqs/client";
 import { CareTeamGraphqlResponse, careTeamsQuery } from "@/services/fqs/queries/care-teams";
 import { QUERY_KEY_CARETEAM } from "@/utils/query-keys";
 import { Telemetry } from "@/utils/telemetry";
@@ -39,14 +39,15 @@ async function getCareTeamODS(requestContext: CTWRequestContext, patient: Patien
 async function getCareTeamFQS(requestContext: CTWRequestContext, patient: PatientModel) {
   try {
     const graphClient = createGraphqlClient(requestContext);
-    const data = (await graphClient.request(careTeamsQuery, {
+    const { data } = await fqsRequest<CareTeamGraphqlResponse>(graphClient, careTeamsQuery, {
       upid: patient.UPID,
       cursor: "",
       first: 1000,
       sort: {
         lastUpdated: "DESC",
       },
-    })) as CareTeamGraphqlResponse;
+    });
+
     const nodes = data.CareTeamConnection.edges.map((x) => x.node);
     const results = applyCareTeamFilters(nodes, {});
 

--- a/src/fhir/diagnostic-report.ts
+++ b/src/fhir/diagnostic-report.ts
@@ -4,7 +4,7 @@ import { CTWRequestContext } from "@/components/core/providers/ctw-context";
 import { useFeatureFlaggedQueryWithPatient } from "@/components/core/providers/patient-provider";
 import { getIncludedResources } from "@/fhir/bundle";
 import { DiagnosticReportModel, PatientModel } from "@/fhir/models";
-import { createGraphqlClient } from "@/services/fqs/client";
+import { createGraphqlClient, fqsRequest } from "@/services/fqs/client";
 import {
   DiagnosticReportGraphqlResponse,
   diagnosticReportQuery,
@@ -92,19 +92,23 @@ async function diagnosticReportBuilderQueryFQS(
   patient: PatientModel
 ) {
   const graphClient = createGraphqlClient(requestContext);
-  const data = (await graphClient.request(diagnosticReportQuery, {
-    upid: patient.UPID,
-    cursor: "",
-    sort: {
-      lastUpdated: "DESC",
-    },
-    filter: {
-      tag: {
-        nonematch: [SYSTEM_ZUS_THIRD_PARTY],
+  const { data } = await fqsRequest<DiagnosticReportGraphqlResponse>(
+    graphClient,
+    diagnosticReportQuery,
+    {
+      upid: patient.UPID,
+      cursor: "",
+      sort: {
+        lastUpdated: "DESC",
       },
-    },
-    first: 1000,
-  })) as DiagnosticReportGraphqlResponse;
+      filter: {
+        tag: {
+          nonematch: [SYSTEM_ZUS_THIRD_PARTY],
+        },
+      },
+      first: 1000,
+    }
+  );
   return data;
 }
 

--- a/src/fhir/diagnostic-report.ts
+++ b/src/fhir/diagnostic-report.ts
@@ -117,19 +117,23 @@ async function diagnosticReportCommonQueryFQS(
   patient: PatientModel
 ) {
   const graphClient = createGraphqlClient(requestContext);
-  const data = (await graphClient.request(diagnosticReportQuery, {
-    upid: patient.UPID,
-    cursor: "",
-    sort: {
-      lastUpdated: "DESC",
-    },
-    filter: {
-      tag: {
-        allmatch: [SYSTEM_ZUS_THIRD_PARTY],
+  const { data } = await fqsRequest<DiagnosticReportGraphqlResponse>(
+    graphClient,
+    diagnosticReportQuery,
+    {
+      upid: patient.UPID,
+      cursor: "",
+      sort: {
+        lastUpdated: "DESC",
       },
-    },
-    first: 1000,
-  })) as DiagnosticReportGraphqlResponse;
+      filter: {
+        tag: {
+          allmatch: [SYSTEM_ZUS_THIRD_PARTY],
+        },
+      },
+      first: 1000,
+    }
+  );
   return data;
 }
 

--- a/src/fhir/document.ts
+++ b/src/fhir/document.ts
@@ -2,7 +2,7 @@ import { searchCommonRecords } from "./search-helpers";
 import { PatientModel, useFeatureFlaggedQueryWithPatient } from "..";
 import { applyDocumentFilters } from "@/components/content/document/helpers/filters";
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
-import { createGraphqlClient } from "@/services/fqs/client";
+import { createGraphqlClient, fqsRequest } from "@/services/fqs/client";
 import { DocumentReferenceGraphqlResponse, documentsQuery } from "@/services/fqs/queries/documents";
 import { orderBy } from "@/utils/nodash";
 import { QUERY_KEY_PATIENT_DOCUMENTS } from "@/utils/query-keys";
@@ -22,14 +22,18 @@ export function usePatientDocument() {
 async function getDocumentFromFQS(requestContext: CTWRequestContext, patient: PatientModel) {
   try {
     const graphClient = createGraphqlClient(requestContext);
-    const data = (await graphClient.request(documentsQuery, {
-      upid: patient.UPID,
-      cursor: "",
-      first: 1000,
-      sort: {
-        lastUpdated: "DESC",
-      },
-    })) as DocumentReferenceGraphqlResponse;
+    const { data } = await fqsRequest<DocumentReferenceGraphqlResponse>(
+      graphClient,
+      documentsQuery,
+      {
+        upid: patient.UPID,
+        cursor: "",
+        first: 1000,
+        sort: {
+          lastUpdated: "DESC",
+        },
+      }
+    );
     const nodes = data.DocumentReferenceConnection.edges.map((x) => x.node);
     const results = orderBy(
       applyDocumentFilters(nodes),

--- a/src/fhir/encounters.ts
+++ b/src/fhir/encounters.ts
@@ -4,7 +4,7 @@ import { EncounterModel } from "./models/encounter";
 import { searchCommonRecords } from "./search-helpers";
 import { useFeatureFlaggedQueryWithPatient } from "..";
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
-import { createGraphqlClient } from "@/services/fqs/client";
+import { createGraphqlClient, fqsRequest } from "@/services/fqs/client";
 import { EncounterGraphqlResponse, encountersQuery } from "@/services/fqs/queries/encounters";
 import { QUERY_KEY_PATIENT_ENCOUNTERS } from "@/utils/query-keys";
 import { Telemetry } from "@/utils/telemetry";
@@ -34,14 +34,14 @@ function setupEncounterModels(
 async function getEncountersFromFQS(requestContext: CTWRequestContext, patient: PatientModel) {
   try {
     const graphClient = createGraphqlClient(requestContext);
-    const data = (await graphClient.request(encountersQuery, {
+    const { data } = await fqsRequest<EncounterGraphqlResponse>(graphClient, encountersQuery, {
       upid: patient.UPID,
       cursor: "",
       first: 1000,
       sort: {
         lastUpdated: "DESC",
       },
-    })) as EncounterGraphqlResponse;
+    });
     const nodes = data.EncounterConnection.edges.map((x) => x.node);
     const results = setupEncounterModels(nodes);
     if (results.length === 0) {

--- a/src/fhir/immunizations.ts
+++ b/src/fhir/immunizations.ts
@@ -3,7 +3,7 @@ import { searchCommonRecords } from "./search-helpers";
 import { useFeatureFlaggedQueryWithPatient } from "..";
 import { applyImmunizationFilters } from "@/components/content/immunizations/helpers/filters";
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
-import { createGraphqlClient } from "@/services/fqs/client";
+import { createGraphqlClient, fqsRequest } from "@/services/fqs/client";
 import {
   ImmunizationGraphqlResponse,
   immunizationsQuery,
@@ -26,14 +26,18 @@ export function usePatientImmunizations() {
 async function getImmunizationFromFQS(requestContext: CTWRequestContext, patient: PatientModel) {
   try {
     const graphClient = createGraphqlClient(requestContext);
-    const data = (await graphClient.request(immunizationsQuery, {
-      upid: patient.UPID,
-      cursor: "",
-      first: 1000,
-      sort: {
-        lastUpdated: "DESC",
-      },
-    })) as ImmunizationGraphqlResponse;
+    const { data } = await fqsRequest<ImmunizationGraphqlResponse>(
+      graphClient,
+      immunizationsQuery,
+      {
+        upid: patient.UPID,
+        cursor: "",
+        first: 1000,
+        sort: {
+          lastUpdated: "DESC",
+        },
+      }
+    );
     const nodes = data.ImmunizationConnection.edges.map((x) => x.node);
     const results = orderBy(
       applyImmunizationFilters(nodes),

--- a/src/fhir/medications.ts
+++ b/src/fhir/medications.ts
@@ -213,7 +213,7 @@ export async function getMedicationStatementsForPatientByIdFQS(
     const graphClient = createGraphqlClient(requestContext);
     const { data } = await fqsRequest<MedicationStatementGraphqlResponse>(
       graphClient,
-      medicationDispenseQuery,
+      medicationStatementQuery,
       {
         upid: patient.UPID,
         cursor: "",

--- a/src/services/conditions.ts
+++ b/src/services/conditions.ts
@@ -17,7 +17,7 @@ import { getIncludedBasics } from "@/fhir/bundle";
 import { ConditionModel } from "@/fhir/models/condition";
 import { searchBuilderRecords, searchSummaryRecords } from "@/fhir/search-helpers";
 import { useFQSFeatureToggle } from "@/hooks/use-fqs-feature-toggle";
-import { createGraphqlClient } from "@/services/fqs/client";
+import { createGraphqlClient, fqsRequest } from "@/services/fqs/client";
 import { ConditionGraphqlResponse, conditionsQuery } from "@/services/fqs/queries/conditions";
 import { cloneDeep, orderBy } from "@/utils/nodash";
 import {
@@ -186,7 +186,7 @@ async function fetchPatientBuilderConditionsFQS(
 ) {
   try {
     const graphClient = createGraphqlClient(requestContext);
-    const data = (await graphClient.request(conditionsQuery, {
+    const { data } = await fqsRequest<ConditionGraphqlResponse>(graphClient, conditionsQuery, {
       upid: patient.UPID,
       cursor: "",
       first: 1000,
@@ -201,8 +201,7 @@ async function fetchPatientBuilderConditionsFQS(
           // allmatch: [`${SYSTEM_ZUS_OWNER}|builder/${requestContext.builderId}`],
         },
       },
-    })) as ConditionGraphqlResponse;
-
+    });
     let nodes = data.ConditionConnection.edges.map((x) => x.node);
     // TODO: No longer needed once https://zeushealth.atlassian.net/browse/DRT-249 is resolved.
     nodes = filterResourcesByBuilderId(
@@ -244,7 +243,7 @@ async function fetchPatientSummaryConditionsFQS(
 ) {
   try {
     const graphClient = createGraphqlClient(requestContext);
-    const data = (await graphClient.request(conditionsQuery, {
+    const { data } = await fqsRequest<ConditionGraphqlResponse>(graphClient, conditionsQuery, {
       upid: patient.UPID,
       cursor: "",
       first: 1000,
@@ -259,7 +258,7 @@ async function fetchPatientSummaryConditionsFQS(
           ],
         },
       },
-    })) as ConditionGraphqlResponse;
+    });
     const nodes = data.ConditionConnection.edges.map((x) => x.node);
     const conditions = setupConditionModelsWithFQS(nodes);
     const results = filterAndSort(conditions);

--- a/src/services/fqs/client.ts
+++ b/src/services/fqs/client.ts
@@ -35,7 +35,9 @@ export const fqsRequest = async <T>(client: GraphQLClient, query: string, variab
   const fhirData = graphQLToFHIR(data);
   if (errors) {
     if (data) {
-      Telemetry.logger.error(`Errors in FQS request:${errors}`);
+      errors.forEach((e) => {
+        Telemetry.logger.error("Error in FQS request", undefined, e);
+      });
       return { data: fhirData };
     }
     throw errors;

--- a/src/services/fqs/client.ts
+++ b/src/services/fqs/client.ts
@@ -5,6 +5,7 @@ import { CTWRequestContext } from "@/components/core/providers/ctw-context";
 import { Env } from "@/components/core/providers/types";
 import { ResourceType, ResourceTypeString } from "@/fhir/types";
 import { CTW_REQUEST_HEADER } from "@/utils/request";
+import { Telemetry } from "@/utils/telemetry";
 
 export interface GraphqlPageInfo {
   hasNextPage: boolean;
@@ -34,7 +35,7 @@ export const fqsRequest = async <T>(client: GraphQLClient, query: string, variab
   const fhirData = graphQLToFHIR(data);
   if (errors) {
     if (data) {
-      // TODO: log the errors?
+      Telemetry.logger.error(`Errors in FQS request:${errors}`);
       return { data: fhirData };
     }
     throw errors;

--- a/src/services/fqs/client.ts
+++ b/src/services/fqs/client.ts
@@ -21,10 +21,29 @@ export interface GenericConnection<T extends ResourceTypeString> {
 export const createGraphqlClient = (requestContext: CTWRequestContext) => {
   const endpoint = `${getZusApiBaseUrl(requestContext.env)}/fqs/query`;
   return new GraphQLClient(endpoint, {
+    errorPolicy: "all",
     headers: {
       authorization: `Bearer ${requestContext.authToken}`,
     },
   });
+};
+
+export const request = async <T>(
+  client: GraphQLClient,
+  query: string,
+  upid: string,
+  filters: object
+) => {
+  const { data, errors } = await client.rawRequest<T>(query, {
+    upid,
+    cursor: "",
+    first: 1000,
+    sort: {
+      lastUpdated: "DESC",
+    },
+    filter: filters,
+  });
+  return { data, errors };
 };
 
 export function getFetchFromFqs(env: Env, accessToken: string, builderId?: string) {


### PR DESCRIPTION
Fixes both https://zeushealth.atlassian.net/browse/CDEV-246 and https://zeushealth.atlassian.net/browse/CDEV-247

FQS can return both `errors` and `data` for a single request. 
This PR allows us to still use `data`, if it exists, even if there are `errors`.

 i got all the requests except these which are a bit different:
* https://github.com/zeus-health/ctw-component-library/blob/29b24fe333ed1c375f33e6dcdbb5f03f2c096f9f/src/components/content/resource/history.ts#L196
* https://github.com/zeus-health/ctw-component-library/blob/29b24fe333ed1c375f33e6dcdbb5f03f2c096f9f/src/components/content/resource/history.ts#L223
* https://github.com/zeus-health/ctw-component-library/blob/29b24fe333ed1c375f33e6dcdbb5f03f2c096f9f/src/services/fqs/long-poll-fqs.ts#L40
* https://github.com/zeus-health/ctw-component-library/blob/29b24fe333ed1c375f33e6dcdbb5f03f2c096f9f/src/services/fqs/queries/provenances.ts#L18