### PR TITLE
fixing styling of notification icons

### DIFF
--- a/.changeset/smart-ties-lie.md
+++ b/.changeset/smart-ties-lie.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix styling on notification icons.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,12 +108,16 @@ const components: DemoComponent[] = [
         includePatientDemographicsForm={false}
         resources={[
           "allergies",
+          "conditions",
           "conditions-outside",
+          "medications",
+          "medications-outside",
+          "observations",
+          "timeline",
+          "observations-outside",
+          "care-team",
           "documents",
           "immunizations",
-          "medications-outside",
-          "care-team",
-          "timeline",
         ]}
         title="ZAP"
       />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,16 +108,12 @@ const components: DemoComponent[] = [
         includePatientDemographicsForm={false}
         resources={[
           "allergies",
-          "conditions",
           "conditions-outside",
-          "medications",
-          "medications-outside",
-          "observations",
-          "timeline",
-          "observations-outside",
-          "care-team",
           "documents",
           "immunizations",
+          "medications-outside",
+          "care-team",
+          "timeline",
         ]}
         title="ZAP"
       />

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile-tabs.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile-tabs.tsx
@@ -52,7 +52,7 @@ export const zusAggregatedProfileTabs: ZusAggregatedProfileTabs = {
     key: "allergies",
     getPanelClassName: () => "ctw-pt-5",
     display: () => (
-      <div className="ctw-space-x-2">
+      <div className="ctw-flex ctw-items-center ctw-space-x-2">
         <UnreadAllergiesNotification />
         <span className="ctw-capitalize">allergies</span>
       </div>
@@ -80,7 +80,7 @@ export const zusAggregatedProfileTabs: ZusAggregatedProfileTabs = {
   "conditions-outside": (props: PatientConditionsOutsideProps = {}) => ({
     key: "conditions-outside",
     display: () => (
-      <div className="ctw-space-x-2">
+      <div className="ctw-flex ctw-items-center ctw-space-x-2">
         <PatientConditionsOutsideBadge />
         <span className="ctw-capitalize">{i18next.t("zap.tabs.conditionsOutside")}</span>
       </div>
@@ -121,7 +121,7 @@ export const zusAggregatedProfileTabs: ZusAggregatedProfileTabs = {
   "medications-outside": (props: PatientMedicationsOutsideProps = {}) => ({
     key: "medications-outside",
     display: () => (
-      <div className="ctw-space-x-2">
+      <div className="ctw-flex ctw-items-center ctw-space-x-2">
         <PatientMedicationsOutsideBadge />
         <span className="ctw-capitalize">{i18next.t("zap.tabs.medicationsOutside")}</span>
       </div>


### PR DESCRIPTION
Right now the notification icon doesn't always display to the left, and vertically aligned, with the tab title.

We do still have an issue with the tab title content shifting when the notification icon goes away (ie. you've read the last resource). We could address this by having the icon always there and adjusting the opacity, but that looks pretty awkward with the icon on the left. Perhaps if/when we move the icon to the right we can take this approach.

<img width="500" alt="image" src="https://github.com/zeus-health/ctw-component-library/assets/97455910/4ea152c6-ace9-4bf2-93b2-46b255f6a315">
