### PR TITLE
Fix: outside meds history caching

### DIFF
--- a/.changeset/happy-berries-return.md
+++ b/.changeset/happy-berries-return.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix cache issue for outside medications history requests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "1.26.5",
+  "version": "1.27.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "1.26.5",
+      "version": "1.27.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,14 +112,7 @@ const components: DemoComponent[] = [
           hideRequestRecords: true,
         }}
         includePatientDemographicsForm={false}
-        resources={[
-          "allergies",
-          "conditions",
-          "conditions-outside",
-          "documents",
-          "immunizations",
-          "medications-outside",
-        ]}
+        resources={["allergies", "conditions", "conditions-outside", "documents", "immunizations"]}
         title="ZAP"
       />
     ),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,7 +112,14 @@ const components: DemoComponent[] = [
           hideRequestRecords: true,
         }}
         includePatientDemographicsForm={false}
-        resources={["allergies", "conditions", "conditions-outside", "documents", "immunizations"]}
+        resources={[
+          "allergies",
+          "conditions",
+          "conditions-outside",
+          "documents",
+          "immunizations",
+          "medications-outside",
+        ]}
         title="ZAP"
       />
     ),

--- a/src/fhir/medications.ts
+++ b/src/fhir/medications.ts
@@ -586,7 +586,7 @@ export function splitMedications(
 export function useMedicationHistory(medication?: fhir4.MedicationStatement) {
   return useFeatureFlaggedQueryWithPatient(
     QUERY_KEY_MEDICATION_HISTORY,
-    [],
+    [medication?.id],
     "medications",
     "req.timing.medication_history",
     getMedicationHistoryFQS(medication),


### PR DESCRIPTION
The outside medications history requests were not using a specific enough caching key and so the cache entry was being shared across all meds for a given patient. This PR adds the medication ID to the cache key so that each medication history has a separate cache entry.