### PR TITLE
CDEV-257: Force med results to be sorted by resource ID

### DIFF
--- a/.changeset/breezy-parrots-heal.md
+++ b/.changeset/breezy-parrots-heal.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Forcing medication history results to be sorted by resource ID before de-duplicating.


### PR DESCRIPTION
https://zeushealth.atlassian.net/browse/CDEV-257

A discrepancy that was noticed in the attached JIRA ticket surfaced an issue where the med history deduping logic just grabs the first med history in the result set. This results in discrepancies between which med history gets displayed in the UI when the data from ODS comes in a different order than the data from FQS.

This ticket forces the results to be sorted by resource ID, which ensures that- regardless of the data source- the data displayed should be the same.