### PR TITLE
Removing padding from top of allergies/documents/immunizations/timelines

### DIFF
--- a/.changeset/odd-crabs-grin.md
+++ b/.changeset/odd-crabs-grin.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Remove padding from top of allergies/documents/immunizations/timeline.

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile-tabs.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile-tabs.tsx
@@ -51,7 +51,6 @@ export type ZusAggregatedProfileTabs = Record<ZAPResourceName, (props: object) =
 export const zusAggregatedProfileTabs: ZusAggregatedProfileTabs = {
   allergies: (props: PatientAllergiesProps = {}) => ({
     key: "allergies",
-    getPanelClassName: () => "ctw-pt-5",
     display: () => (
       <div className="ctw-flex ctw-items-center ctw-space-x-2">
         <UnreadAllergiesNotification />
@@ -91,7 +90,6 @@ export const zusAggregatedProfileTabs: ZusAggregatedProfileTabs = {
 
   documents: (props: PatientDocumentsProps = {}) => ({
     key: "documents",
-    getPanelClassName: () => "ctw-pt-5",
     display: () => (
       <div className="ctw-space-x-1">
         <span className="ctw-capitalize">documents</span>
@@ -103,7 +101,6 @@ export const zusAggregatedProfileTabs: ZusAggregatedProfileTabs = {
 
   immunizations: (props: PatientImmunizationsProps = {}) => ({
     key: "immunizations",
-    getPanelClassName: () => "ctw-pt-5",
     display: () => (
       <div className="ctw-flex ctw-items-center ctw-space-x-2">
         <UnreadImmunizationsNotification />
@@ -150,7 +147,6 @@ export const zusAggregatedProfileTabs: ZusAggregatedProfileTabs = {
 
   timeline: (props: PatientTimelineProps = {}) => ({
     key: "timeline",
-    getPanelClassName: () => "ctw-pt-5",
     display: () => (
       <div className="ctw-space-x-1">
         <span className="ctw-capitalize">Timeline</span>

--- a/src/components/core/tab-group/tab-group.tsx
+++ b/src/components/core/tab-group/tab-group.tsx
@@ -20,7 +20,6 @@ export type TabGroupProps = {
 
 export type TabGroupItem = {
   display: () => string | ReactNode;
-  getPanelClassName?: (sm: boolean) => cx.Argument;
   key: string;
   render: (sm: boolean) => string | ReactNode;
 };
@@ -128,10 +127,7 @@ function TabGroupComponent({
           {content.map((item, index) => (
             <Tab.Panel
               key={item.key}
-              className={cx(
-                "ctw-scrollable-pass-through-height",
-                item.getPanelClassName?.(breakpoints.sm)
-              )}
+              className={cx("ctw-scrollable-pass-through-height")}
               // Don't unmount our tabs. This fixes an issue
               // where ZAP filters/sort selections would get reset
               // when switching to a new tab and back again.


### PR DESCRIPTION
This `ctw-pt-5` class is adding padding to the top of some of the tabs in the ZAP and it does not appear necessary anymore. See video below for the discrepancy between conditions (where it looks good) and allergies (where it currently looks bad).


https://github.com/zeus-health/ctw-component-library/assets/97455910/0b75b3d7-ad1d-4672-9b8e-e66d6f6796a0

