### PR TITLE
CTW-1282 Further refactoring of unread notifications

### DIFF
--- a/.changeset/lucky-bulldogs-lay.md
+++ b/.changeset/lucky-bulldogs-lay.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Refactor unread notifications and expose className.

--- a/src/components/content/allergies/unread-allergies-notification.tsx
+++ b/src/components/content/allergies/unread-allergies-notification.tsx
@@ -1,29 +1,11 @@
-import { useEffect, useState } from "react";
-import { useCTW } from "@/components/core/providers/use-ctw";
 import { UnreadNotification } from "@/components/core/unread-notification";
 import { usePatientAllergies } from "@/fhir/allergies";
 
-export const UnreadAllergiesNotification = () => {
+export type UnreadAllergiesNotificationProps = {
+  className?: string;
+};
+
+export const UnreadAllergiesNotification = ({ className }: UnreadAllergiesNotificationProps) => {
   const query = usePatientAllergies();
-  const { getRequestContext } = useCTW();
-
-  const [userBuilderId, setUserBuilderId] = useState("");
-
-  useEffect(() => {
-    async function load() {
-      const requestContext = await getRequestContext();
-      setUserBuilderId(requestContext.builderId);
-    }
-
-    void load();
-  }, [getRequestContext]);
-
-  const unreadOutsideAllergies = query.data.filter(
-    (allergy) => !allergy.isDismissed && !allergy.isRead && !allergy.ownedByBuilder(userBuilderId)
-  );
-
-  if (unreadOutsideAllergies.length > 0) {
-    return <UnreadNotification />;
-  }
-  return null;
+  return <UnreadNotification className={className} query={query} />;
 };

--- a/src/components/content/conditions/patient-conditions-outside-badge.tsx
+++ b/src/components/content/conditions/patient-conditions-outside-badge.tsx
@@ -1,4 +1,4 @@
-import { UnreadNotification } from "@/components/core/unread-notification";
+import { UnreadNotificationIcon } from "@/components/core/unread-notification-icon";
 import { usePatientConditionsOutside } from "@/services/conditions";
 
 export const PatientConditionsOutsideBadge = () => {
@@ -8,7 +8,7 @@ export const PatientConditionsOutsideBadge = () => {
   );
 
   if (activeUnarchivedConditions.length > 0) {
-    return <UnreadNotification />;
+    return <UnreadNotificationIcon />;
   }
   return null;
 };

--- a/src/components/content/immunizations/unread-immunizations-notification.tsx
+++ b/src/components/content/immunizations/unread-immunizations-notification.tsx
@@ -1,39 +1,13 @@
-import { useEffect, useState } from "react";
-import { useCTW } from "@/components/core/providers/use-ctw";
+import { UnreadNotification } from "@/components/core/unread-notification";
 import { usePatientImmunizations } from "@/fhir/immunizations";
 
-export const UnreadImmunizationsNotification = () => {
+export type UnreadImmunizationsNotificationProps = {
+  className?: string;
+};
+
+export const UnreadImmunizationsNotification = ({
+  className,
+}: UnreadImmunizationsNotificationProps) => {
   const query = usePatientImmunizations();
-  const { getRequestContext } = useCTW();
-
-  const [userBuilderId, setUserBuilderId] = useState("");
-
-  useEffect(() => {
-    async function load() {
-      const requestContext = await getRequestContext();
-      setUserBuilderId(requestContext.builderId);
-    }
-
-    void load();
-  }, [getRequestContext]);
-
-  const unreadOutsideImmunizations = query.data.filter(
-    (imm) => !imm.isDismissed && !imm.isRead && !imm.ownedByBuilder(userBuilderId)
-  );
-
-  if (unreadOutsideImmunizations.length > 0) {
-    return (
-      <span>
-        <svg
-          height={10}
-          className="ctw-fill-notification-icon"
-          viewBox="0 0 10 10"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <circle cx="5" cy="5" r="5" />
-        </svg>
-      </span>
-    );
-  }
-  return null;
+  return <UnreadNotification className={className} query={query} />;
 };

--- a/src/components/content/medications/patient-medications-outside-badge.tsx
+++ b/src/components/content/medications/patient-medications-outside-badge.tsx
@@ -1,4 +1,4 @@
-import { UnreadNotification } from "@/components/core/unread-notification";
+import { UnreadNotificationIcon } from "@/components/core/unread-notification-icon";
 import { useQueryAllPatientMedications } from "@/hooks/use-medications";
 
 export const PatientMedicationsOutsideBadge = () => {
@@ -8,7 +8,7 @@ export const PatientMedicationsOutsideBadge = () => {
   );
 
   if (activeUnarchivedMedications.length > 0) {
-    return <UnreadNotification />;
+    return <UnreadNotificationIcon />;
   }
   return null;
 };

--- a/src/components/core/unread-notification-icon.tsx
+++ b/src/components/core/unread-notification-icon.tsx
@@ -1,0 +1,11 @@
+export type UnreadNotificationIconProps = {
+  className?: string;
+};
+
+export const UnreadNotificationIcon = ({
+  className = "ctw-fill-notification-icon",
+}: UnreadNotificationIconProps) => (
+  <svg height={10} className={className} viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="5" cy="5" r="5" />
+  </svg>
+);

--- a/src/components/core/unread-notification.tsx
+++ b/src/components/core/unread-notification.tsx
@@ -1,11 +1,38 @@
+import { useEffect, useState } from "react";
+import { useCTW } from "./providers/use-ctw";
+import { UnreadNotificationIcon } from "./unread-notification-icon";
+import { FHIRModel } from "@/fhir/models/fhir-model";
+
 export type UnreadNotificationProps = {
   className?: string;
+  query: {
+    isLoading: boolean;
+    isError: boolean;
+    isFetching: boolean;
+    data: FHIRModel<fhir4.Resource>[];
+  };
 };
 
-export const UnreadNotification = ({
-  className = "ctw-fill-notification-icon",
-}: UnreadNotificationProps) => (
-  <svg height={10} className={className} viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-    <circle cx="5" cy="5" r="5" />
-  </svg>
-);
+export const UnreadNotification = ({ className, query }: UnreadNotificationProps) => {
+  const { getRequestContext } = useCTW();
+
+  const [userBuilderId, setUserBuilderId] = useState("");
+
+  useEffect(() => {
+    async function load() {
+      const requestContext = await getRequestContext();
+      setUserBuilderId(requestContext.builderId);
+    }
+
+    void load();
+  }, [getRequestContext]);
+
+  const unreadOutsideRecords = query.data.filter(
+    (record) => !record.isDismissed && !record.isRead && !record.ownedByBuilder(userBuilderId)
+  );
+
+  if (unreadOutsideRecords.length > 0) {
+    return <UnreadNotificationIcon className={className} />;
+  }
+  return null;
+};


### PR DESCRIPTION
Always nice when you can delete more code than you add... (by one line :p). 

Exposing `className` prop in the allergies/immz unread notifications and making the logic for the unread notification components more generic.