### PR TITLE
Revamp documents component (add sort, encounter date, cleanup details)

### DIFF
--- a/.changeset/forty-files-talk.md
+++ b/.changeset/forty-files-talk.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Revamp documents component (add sort, encounter date, cleanup details).

--- a/src/components/content/document/helpers/columns.tsx
+++ b/src/components/content/document/helpers/columns.tsx
@@ -3,21 +3,29 @@ import { DocumentModel } from "@/fhir/models/document";
 
 export const patientDocumentColumns: TableColumn<DocumentModel>[] = [
   {
-    widthPercent: 20,
-    minWidth: 100,
-    title: "Date Created",
-    render: (document) => <div className="group-hover:ctw-underline">{document.dateCreated}</div>,
-  },
-  {
-    widthPercent: 30,
+    widthPercent: 35,
     minWidth: 200,
     title: "Title",
-    render: (document) => <div>{document.title}</div>,
+    render: (document) => (
+      <div className="ctw-font-medium group-hover:ctw-underline">{document.title}</div>
+    ),
   },
   {
-    widthPercent: 30,
+    widthPercent: 15,
+    minWidth: 128,
+    title: "Encounter Date",
+    dataIndex: "encounterDate",
+  },
+  {
+    widthPercent: 15,
+    minWidth: 128,
+    title: "Date Retrieved",
+    dataIndex: "dateCreated",
+  },
+  {
+    widthPercent: 35,
     minWidth: 200,
-    title: "Managing Organization",
+    title: "Author",
     render: (document) => <div>{document.custodian}</div>,
   },
 ];

--- a/src/components/content/document/helpers/columns.tsx
+++ b/src/components/content/document/helpers/columns.tsx
@@ -6,9 +6,7 @@ export const patientDocumentColumns: TableColumn<DocumentModel>[] = [
     widthPercent: 35,
     minWidth: 200,
     title: "Title",
-    render: (document) => (
-      <div className="ctw-font-medium group-hover:ctw-underline">{document.title}</div>
-    ),
+    render: (document) => <div className="group-hover:ctw-underline">{document.title}</div>,
   },
   {
     widthPercent: 15,

--- a/src/components/content/document/helpers/sorts.ts
+++ b/src/components/content/document/helpers/sorts.ts
@@ -1,0 +1,29 @@
+import { SortOption } from "@/components/core/sort-button/sort-button";
+import { DocumentModel } from "@/fhir/models/document";
+
+export const documentSortOptions: SortOption<DocumentModel>[] = [
+  {
+    display: "Name (A-Z)",
+    sorts: [{ key: "title", dir: "asc" }],
+  },
+  {
+    display: "Name (Z-A)",
+    sorts: [{ key: "title", dir: "desc" }],
+  },
+  {
+    display: "Date (Old to New)",
+    sorts: [
+      { key: "dateForSort", dir: "asc", isDate: true },
+      { key: "title", dir: "asc" },
+    ],
+  },
+  {
+    display: "Date (New To Old)",
+    sorts: [
+      { key: "dateForSort", dir: "desc", isDate: true },
+      { key: "title", dir: "asc" },
+    ],
+  },
+];
+
+export const defaultDocumentSort = documentSortOptions[3];

--- a/src/components/content/document/patient-documents.tsx
+++ b/src/components/content/document/patient-documents.tsx
@@ -1,6 +1,7 @@
 import cx from "classnames";
 import { useMemo, useRef } from "react";
 import { patientDocumentColumns } from "./helpers/columns";
+import { defaultDocumentSort, documentSortOptions } from "./helpers/sorts";
 import { getDateRangeView } from "../resource/helpers/view-date-range";
 import { useResourceDetailsDrawer } from "../resource/resource-details-drawer";
 import { ResourceTable } from "../resource/resource-table";
@@ -27,9 +28,10 @@ function PatientDocumentsComponent({ className, onAddToRecord }: PatientDocument
 
   const patientDocumentQuery = usePatientDocuments();
   const rowActions = useMemo(() => getRowActions({ onAddToRecord }), [onAddToRecord]);
-  const { viewOptions, defaultView } = getDateRangeView<DocumentModel>("dateCreated");
-  const { data, setViewOption } = useFilteredSortedData({
-    defaultView,
+  const { viewOptions, allTime } = getDateRangeView<DocumentModel>("dateCreated");
+  const { data, setViewOption, setSort } = useFilteredSortedData({
+    defaultSort: defaultDocumentSort,
+    defaultView: allTime,
     records: patientDocumentQuery.data,
   });
 
@@ -37,7 +39,8 @@ function PatientDocumentsComponent({ className, onAddToRecord }: PatientDocument
   const hasZeroFilteredRecords = !isEmptyQuery && data.length === 0;
 
   const openDetails = useResourceDetailsDrawer({
-    header: (m) => `${m.dateCreated} - ${m.title}`,
+    header: (m) => m.title,
+    subHeader: (m) => m.encounterDate,
     details: documentData,
     enableFQS: enabled,
   });
@@ -49,10 +52,15 @@ function PatientDocumentsComponent({ className, onAddToRecord }: PatientDocument
       className={cx(className, "ctw-scrollable-pass-through-height")}
     >
       <ResourceTableActions
+        sortOptions={{
+          defaultSort: defaultDocumentSort,
+          options: documentSortOptions,
+          onChange: setSort,
+        }}
         viewOptions={{
           onChange: setViewOption,
           options: viewOptions,
-          defaultView,
+          defaultView: allTime,
         }}
       />
       <ResourceTable
@@ -106,18 +114,17 @@ const RowActions = ({ record, onAddToRecord }: RowActionsProps2) => {
 export const PatientDocuments = withErrorBoundary(PatientDocumentsComponent, "PatientDocuments");
 
 const documentData = (document: DocumentModel) => [
-  { label: "status", value: document.status },
-  { label: "docStatus", value: document.docStatus },
-  { label: "Managing Organization", value: document.custodian },
+  { label: "Date Retrieved", value: document.dateCreated },
+  { label: "Author", value: document.custodian },
   {
     label: "Section Display",
     value: document.sectionDisplays && (
-      <div>
+      <ul className="ctw-m-0 ctw-pl-4">
         {document.sectionDisplays.map((item, index) => (
           // eslint-disable-next-line react/no-array-index-key
-          <div key={item + index}>{item}</div>
+          <li key={item + index}>{item}</li>
         ))}
-      </div>
+      </ul>
     ),
   },
 ];

--- a/src/components/content/medications/patient-medications-outside.tsx
+++ b/src/components/content/medications/patient-medications-outside.tsx
@@ -27,7 +27,7 @@ const PatientMedicationsOutsideComponent = ({
 }: PatientMedicationsOutsideProps) => {
   const { otherProviderMedications, isLoading } = useQueryAllPatientMedications();
   const rowActions = useMemo(() => getRowActions({ onAddToRecord }), [onAddToRecord]);
-  const { viewOptions, defaultView } =
+  const { viewOptions, past6Months } =
     getDateRangeView<MedicationStatementModel>("lastActivityDate");
 
   return (
@@ -37,7 +37,7 @@ const PatientMedicationsOutsideComponent = ({
       filters={medicationFilters(otherProviderMedications, true)}
       rowActions={readOnly ? undefined : rowActions}
       views={viewOptions}
-      defaultView={defaultView}
+      defaultView={past6Months}
       onOpenHistoryDrawer={onOpenHistoryDrawer}
     />
   );

--- a/src/components/content/resource/helpers/view-date-range.ts
+++ b/src/components/content/resource/helpers/view-date-range.ts
@@ -31,5 +31,9 @@ export function getDateRangeView<T extends object>(field: Extract<keyof T, strin
       filters: [],
     },
   ];
-  return { viewOptions, defaultView: viewOptions[2] };
+  return {
+    viewOptions,
+    past6Months: viewOptions[2],
+    allTime: viewOptions[4],
+  };
 }

--- a/src/components/content/timeline/patient-timeline.tsx
+++ b/src/components/content/timeline/patient-timeline.tsx
@@ -20,9 +20,9 @@ export type PatientTimelineProps = {
 export function PatientTimeline({ className }: PatientTimelineProps) {
   const timelineEventsQuery = useTimelineEvents();
   const containerRef = useRef<HTMLDivElement>(null);
-  const { viewOptions, defaultView } = getDateRangeView<TimelineEventModel>("date");
+  const { viewOptions, past6Months } = getDateRangeView<TimelineEventModel>("date");
   const { data, setFilters, setSort, setViewOption } = useFilteredSortedData({
-    defaultView,
+    defaultView: past6Months,
     defaultFilters: defaultTimelineFilters,
     defaultSort: defaultTimelineSort,
     records: timelineEventsQuery.data,
@@ -40,7 +40,7 @@ export function PatientTimeline({ className }: PatientTimelineProps) {
         viewOptions={{
           onChange: setViewOption,
           options: viewOptions,
-          defaultView,
+          defaultView: past6Months,
         }}
         filterOptions={{
           onChange: setFilters,

--- a/src/services/fqs/queries/documents.ts
+++ b/src/services/fqs/queries/documents.ts
@@ -84,6 +84,12 @@ export const documentsQuery = gql`
               display
             }
           }
+          context {
+            period {
+              start
+              end
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
CDEV-40

Revamp documents component:
* Add encounter date which is based on `document.context.period`.
* Re-ordered columns
* Default view is now "All Time"
* Added sort and set default to New to Old (based on `encounterDate || dateCreated`)
* Changes to details drawer:
  * Removed date from title and added encounter date as sub header.
  * Removed `status` and `docStatus`
  * Section display now separates items with bullet points.
  * Added date retrieved (dateCreated)

[Figma documentation](https://www.figma.com/file/c3tY2coG2tYOoWSVwoBKCN/Document-Viewer-V1?type=design&node-id=547-6720&mode=design&t=gZsSOG2u3kbR6k5d-0)

# Screenshots

## BEFORE
<img width="885" alt="Screenshot 2023-07-10 at 2 47 15 PM" src="https://github.com/zeus-health/ctw-component-library/assets/1568246/52406f90-80bd-439e-bbdc-1223856b40de">

<img width="565" alt="Screenshot 2023-07-10 at 2 47 33 PM" src="https://github.com/zeus-health/ctw-component-library/assets/1568246/e11f804c-b330-4c08-b26c-c5606417b97d">

## AFTER
<img width="972" alt="Screenshot 2023-07-10 at 2 47 54 PM" src="https://github.com/zeus-health/ctw-component-library/assets/1568246/93c364b5-0bcc-46dd-aecb-769e24aceb53">

<img width="569" alt="Screenshot 2023-07-10 at 2 48 01 PM" src="https://github.com/zeus-health/ctw-component-library/assets/1568246/36a78f63-e0ee-4186-af06-e9bf244f76d8">

