### PR TITLE
Use semibold for unread records

### DIFF
--- a/.changeset/grumpy-planets-nail.md
+++ b/.changeset/grumpy-planets-nail.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Use semibold for unread records.

--- a/src/components/content/resource/resource-table.scss
+++ b/src/components/content/resource/resource-table.scss
@@ -7,6 +7,6 @@
     }
   }
   .ctw-tr-unread {
-    @apply ctw-font-bold;
+    @apply ctw-font-semibold;
   }
 }


### PR DESCRIPTION
Per guidance from UX small change to make unread records semibold instead of full blown bold.