### PR TITLE
Increasing specificity of CSS selectors for unread/dismissed

### DIFF
--- a/.changeset/eleven-queens-build.md
+++ b/.changeset/eleven-queens-build.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Increase specificity of unread/dismiss selectors.

--- a/src/components/content/resource/resource-table.scss
+++ b/src/components/content/resource/resource-table.scss
@@ -1,12 +1,9 @@
-.ctw-resource-table {
-  .ctw-tr-dismissed {
-    td,
-    td span,
-    td div {
-      @apply ctw-text-content-lighter;
-    }
-  }
-  .ctw-tr-unread {
-    @apply ctw-font-semibold;
-  }
+.ctw-resource-table .ctw-tr-dismissed td,
+.ctw-resource-table .ctw-tr-dismissed td span,
+.ctw-resource-table .ctw-tr-dismissed td div {
+  @apply ctw-text-content-lighter;
+}
+
+.ctw-resource-table .ctw-tr-unread {
+  @apply ctw-font-semibold;
 }


### PR DESCRIPTION
Unread/dismissed styles are being overridden in a consumer app. Increasing the specificity of the selectors to address this so that the styles win out.