### PR TITLE
Improve surfacing category text/display

### DIFF
--- a/.changeset/sour-shrimps-arrive.md
+++ b/.changeset/sour-shrimps-arrive.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Improve surfacing category text/display and avoid showing category codes.

--- a/src/components/content/conditions/helpers/history.tsx
+++ b/src/components/content/conditions/helpers/history.tsx
@@ -68,7 +68,7 @@ function getHistoryEntry(condition: ConditionModel): HistoryEntryProps {
     },
     {
       label: "Category",
-      value: startCase(condition.categories[0]),
+      value: startCase(condition.category),
     },
     {
       label: "Note",
@@ -113,7 +113,7 @@ const valuesToDedupeOn = (condition: ConditionModel) => [
   condition.verificationStatus,
   condition.recordedDate,
   condition.notes,
-  condition.categories[0],
+  condition.category,
   condition.onset,
   condition.abatement,
   condition.encounter,

--- a/src/fhir/codeable-concept.ts
+++ b/src/fhir/codeable-concept.ts
@@ -3,10 +3,20 @@
 // E.g. find(concepts, codeableConceptPredicate("C")) will find the first
 
 import { SYSTEM_ENRICHMENT } from "./system-urls";
-import { find } from "@/utils/nodash";
+import { compact, find } from "@/utils/nodash";
 
 export const codeableConceptLabel = (concept?: fhir4.CodeableConcept): string =>
   concept?.text ?? concept?.coding?.[0]?.display ?? concept?.coding?.[0]?.code ?? "";
+
+// Returns text if there is one, otherwise returns the first display text or an empty string.
+export const codeableConceptTextOrDisplay = (concept?: fhir4.CodeableConcept): string => {
+  if (concept?.text) {
+    return concept.text;
+  }
+
+  const firstDisplay = compact(concept?.coding?.map((c) => c.display))[0] as string | undefined;
+  return firstDisplay ?? "";
+};
 
 export function findCoding(
   system: string,

--- a/src/fhir/models/condition.ts
+++ b/src/fhir/models/condition.ts
@@ -19,6 +19,7 @@ import {
 } from "@/components/content/forms/actions/conditions";
 import {
   codeableConceptLabel,
+  codeableConceptTextOrDisplay,
   CodePreference,
   findCoding,
   findCodingByOrderOfPreference,
@@ -97,8 +98,13 @@ export class ConditionModel extends FHIRModel<fhir4.Condition> {
     return this.resource.bodySite?.map((bodySite) => codeableConceptLabel(bodySite)) || [];
   }
 
-  get categories(): string[] {
-    return this.resource.category?.map((category) => codeableConceptLabel(category)) || [];
+  // Returns the first category text or display.
+  get category(): string {
+    return (
+      compact(
+        this.resource.category?.map((category) => codeableConceptTextOrDisplay(category))
+      )[0] ?? ""
+    );
   }
 
   get ccsChapter(): string | undefined {


### PR DESCRIPTION
CDEV-9

Finds the first text or display from the categories, otherwise we don't show category. So if the only categories that exist only have codes, we'll just not show category at all.

The following `category` would result in `Diagnosis`.
```js
[
    {
      coding: [
        {
          system: "http://snomed.info/sct",
          code: "282291009",
        },
      ],
    },
    {
      coding: [
        {
          system: "http://snomed.info/sct",
          code: "282291009",
        },
        {
          system: "http://loinc.org",
          code: "29308-4",
          display: "Diagnosis",
        },
        {
          display: "Foobar",
        },
      ],
    },
  ];
```

![Screenshot 2023-07-14 at 11 44 05 AM](https://github.com/zeus-health/ctw-component-library/assets/1568246/56916a9b-129a-4622-8c7a-a244d2481fe1)
