### PR TITLE
CDEV-293: Resolving issue w/ repeated observation values

### DIFF
--- a/.changeset/young-snails-glow.md
+++ b/.changeset/young-snails-glow.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Resolved bug with lab trend values

--- a/src/components/content/observations/helpers/columns.tsx
+++ b/src/components/content/observations/helpers/columns.tsx
@@ -87,9 +87,9 @@ export const ObservationsColumns = (): TableColumn<ObservationModel>[] => {
     {
       title: "Trends",
       render: (model) => (
-        <div className="ctw-flex ctw-text-sm ctw-font-normal">
+        <div className="ctw-text-sm ctw-font-normal">
           {model.trends.length > 1 && (
-            <div className="ctw-pt-1">
+            <div className="ctw-pt-2">
               <button
                 aria-label="trends"
                 className="ctw-btn-clear"
@@ -106,18 +106,19 @@ export const ObservationsColumns = (): TableColumn<ObservationModel>[] => {
               </button>
               {isTrendsShown &&
                 model.trends.map((trend) => (
-                  <div
-                    key={trend.id}
-                    className="ctw-relative ctw-clear-both ctw-columns-2 ctw-py-px"
-                  >
+                  <div key={trend.id} className="ctw-ml-4 ctw-py-px">
                     <div
-                      className={cx("ctw-relative ctw-left-4 ctw-top-1 ctw-text-sm", {
+                      className={cx("ctw-relative ctw-top-1 ctw-float-left ctw-w-24 ctw-text-sm", {
                         "ctw-font-bold": trend.id === model.id,
                       })}
                     >
                       {trend.effectiveStart}
                     </div>
-                    <BubbleIcon result={model.value} className={trend.acceptedInterpretations} />
+                    <BubbleIcon
+                      result={trend.value}
+                      interpretation={trend.interpretation}
+                      className={trend.acceptedInterpretations}
+                    />
                   </div>
                 ))}
             </div>

--- a/src/components/content/observations/helpers/details.tsx
+++ b/src/components/content/observations/helpers/details.tsx
@@ -134,12 +134,15 @@ function filterAndSortTrends(model: ObservationModel, trends: ObservationModel[]
       return 0;
     }
     if (!a.effectiveStartRaw) {
-      return -1;
-    }
-    if (!b.effectiveStartRaw) {
       return 1;
     }
+    if (!b.effectiveStartRaw) {
+      return -1;
+    }
     if (a.effectiveStartRaw > b.effectiveStartRaw) {
+      return -1;
+    }
+    if (a.effectiveStartRaw < b.effectiveStartRaw) {
       return 1;
     }
     return 0;

--- a/src/services/fqs/queries/observations.ts
+++ b/src/services/fqs/queries/observations.ts
@@ -35,15 +35,11 @@ export const observationQuery = gql`
         node {
           id
           resourceType
-          meta {
-            extension {
-              url
-              valueInstant
+          interpretation {
+            text
+            coding {
+              ...Coding
             }
-          }
-          extension {
-            url
-            valueString
           }
           code {
             text
@@ -56,6 +52,17 @@ export const observationQuery = gql`
             start
             end
           }
+          valueCodeableConcept {
+            text
+            coding {
+              ...Coding
+            }
+          }
+          valueQuantity {
+            value
+            unit
+          }
+          valueString
         }
       }
     }


### PR DESCRIPTION
https://zeushealth.atlassian.net/browse/CDEV-293

Resolved issue where observation trends were displaying the same value: this was due to the UI being incorrectly wired to pull from the clicked-Observation value vs the trend value.

Additionally:

1. Fixed sorting issue where trends weren't always being chronologically sorted
2. Updated some styling to better display result values
3. Added missing `interpretation` fields to graphql query that are responsible for showing interpretation text in the UI

![Screenshot 2023-07-18 at 11 49 07 AM](https://github.com/zeus-health/ctw-component-library/assets/5325813/2e264bfd-94cc-456d-a468-d8bea04df8d5)
![Screenshot 2023-07-18 at 11 49 16 AM](https://github.com/zeus-health/ctw-component-library/assets/5325813/d47e4ba6-aa56-4891-90a9-ae75121bba7d)

