### PR TITLE
Fix to display of unknown condition type

### DIFF
--- a/.changeset/sixty-trees-hang.md
+++ b/.changeset/sixty-trees-hang.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Make unknown condition type display as "Unknown".

--- a/src/fhir/models/condition.ts
+++ b/src/fhir/models/condition.ts
@@ -143,9 +143,9 @@ export class ConditionModel extends FHIRModel<fhir4.Condition> {
     );
   }
 
-  get type(): string | undefined {
-    const type = findCoding(SYSTEM_CCI, this.resource.code)?.display;
-    return type?.toLocaleLowerCase() === "both" ? "Chronic and acute" : type;
+  get type() {
+    const type = findCoding(SYSTEM_CCI, this.resource.code)?.display || "Unknown";
+    return type.toLocaleLowerCase() === "both" ? "Chronic and acute" : type;
   }
 
   get encounter(): string | undefined {


### PR DESCRIPTION
Minor fix so we display unknown condition types with the string "Unknown".