### PR TITLE
Improve responsiveness of ZAP tabs

### DIFF
--- a/.changeset/strange-bobcats-agree.md
+++ b/.changeset/strange-bobcats-agree.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Improve responsiveness of ZAP tabs to collapse overflowed tabs into a more menu.

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile-tabs.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile-tabs.tsx
@@ -160,8 +160,8 @@ type TabHelperProps = {
 
 function TabHelper({ beta, name, notification }: TabHelperProps) {
   return (
-    <div className="ctw-flex ctw-items-center ctw-space-x-2">
-      {notification}
+    <div className="ctw-flex ctw-items-center ctw-space-x-3">
+      <div className="ctw-absolute -ctw-ml-1">{notification}</div>
       <div className="ctw-flex ctw-items-center ctw-space-x-1">
         <span className="ctw-capitalize">{name}</span>
         {beta && <BetaLabel />}

--- a/src/components/core/tab-group/tab-group.scss
+++ b/src/components/core/tab-group/tab-group.scss
@@ -1,9 +1,14 @@
 .ctw-tab-group {
+  .ctw-more-tab,
   .ctw-tab {
-    @apply ctw-relative ctw-mr-5 ctw-flex ctw-cursor-pointer ctw-items-center ctw-border-0 ctw-border-transparent ctw-bg-transparent ctw-px-1.5 ctw-py-4;
+    @apply ctw-relative ctw-flex ctw-cursor-pointer ctw-items-center ctw-border-0 ctw-border-transparent ctw-bg-transparent ctw-px-1.5 ctw-py-4;
     &:after {
       @apply ctw-absolute ctw-bottom-0 ctw-left-0 ctw-block ctw-h-0.5 ctw-w-full;
-      content: "";
+      content: "" !important;
+    }
+
+    &[aria-expanded="true"]:after {
+      @apply ctw-bg-content-black;
     }
   }
 }

--- a/src/components/core/tab-group/tab-group.tsx
+++ b/src/components/core/tab-group/tab-group.tsx
@@ -38,13 +38,14 @@ function TabGroupComponent({
   onChange,
   topRightContent,
 }: TabGroupProps) {
+  // Ugly cheat to account for margins between tabs (algins with ctw-space-x-5 on Tab.List)
+  const TAB_SPACING = 20;
   // State used for responsive tab dropdown menu.
-  const TAB_SPACING = 20; // Ugly cheat to account for margins between tabs.
   const topRightContentRef = useRef<HTMLDivElement>(null);
   const moreMenuRef = useRef<HTMLDivElement>(null);
-  const [tabOverflowCutoff, setTabOverflowCutoff] = useState(content.length);
   const containerRef = useRef<HTMLDivElement>(null);
   const breakpoints = useBreakpoints(containerRef);
+  const [tabOverflowCutoff, setTabOverflowCutoff] = useState(content.length);
 
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const patientHistoryDetails = usePatientHistory();
@@ -117,6 +118,7 @@ function TabGroupComponent({
       <Tab.Group selectedIndex={selectedTabIndex} onChange={handleOnChange}>
         <Tab.List
           className={cx(
+            // NOTE: Must keep ctw-space-x-5 aligned with the above TAB_SPACING above.
             "ctw-border-default ctw-flex ctw-space-x-5 ctw-border-b ctw-border-divider-light"
           )}
         >


### PR DESCRIPTION
CDEV-278
CDEV-273

Features:
* Takes into account any topRightContent like "Request Records"
* Reserves space for the "More" menu unless we're calculating the space for the last tab as we'd then hide the more menu.
* Only show more menu when breakpoints.sm and when doing so, show the tab name instead of "More".

Additionally:
* Setup ListBox to optionally take a `ref` (used to determine size of more button)
* Added optional `selectedIndex` to ListBox so that we can control the selected item from the outside.
* Tweaked unread notification bullet to be absolutely positioned within ZAP tabs and more menu. This prevents content shifting when notification comes in or out.

![Jul-18-2023 15-34-10](https://github.com/zeus-health/ctw-component-library/assets/1568246/d8ab7abb-b4ad-491b-9528-298581fd94ba)
