### PR TITLE
CDEV-290: Cleaning up observation requests and telemetry

### DIFF
--- a/.changeset/nice-humans-collect.md
+++ b/.changeset/nice-humans-collect.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Removed first-party filter from FQS request when fetching observations and cleaned up corresponding telemetry

--- a/src/components/content/observations/helpers/columns.tsx
+++ b/src/components/content/observations/helpers/columns.tsx
@@ -87,12 +87,16 @@ export const ObservationsColumns = (): TableColumn<ObservationModel>[] => {
     {
       title: "Trends",
       render: (model) => (
-        <div className="ctw-text-sm ctw-font-normal">
+        <div
+          className="ctw-text-sm ctw-font-normal"
+          data-zus-telemetry-namespace="Trending Observations"
+        >
           {model.trends.length > 1 && (
             <div className="ctw-pt-2">
               <button
                 aria-label="trends"
                 className="ctw-btn-clear"
+                data-zus-telemetry-click={isTrendsShown ? "Collapsed" : "Expanded"}
                 type="button"
                 onClick={() => setIsTrendsShown(!isTrendsShown)}
               >

--- a/src/fhir/observations.ts
+++ b/src/fhir/observations.ts
@@ -1,5 +1,5 @@
 import { ObservationModel, PatientModel } from "./models";
-import { SYSTEM_LOINC, SYSTEM_ZUS_OWNER } from "./system-urls";
+import { SYSTEM_LOINC } from "./system-urls";
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
 import { useQueryWithPatient } from "@/components/core/providers/patient-provider";
 import { useTrendingLabsFeatureToggle } from "@/hooks/use-feature-toggle";
@@ -14,7 +14,7 @@ export function usePatientObservations(loincCodes: string[]) {
     `${QUERY_KEY_PATIENT_OBSERVATIONS}_${loincCodes.join("_")}`,
     [trendingLabs.enabled],
     trendingLabs.enabled
-      ? withTimerMetric(fetchObservations(loincCodes), "req.timing.observations")
+      ? withTimerMetric(fetchObservations(loincCodes), "req.timing.all_observations")
       : async () =>
           new Promise<ObservationModel[]>((resolve) => {
             resolve([]);
@@ -33,21 +33,14 @@ function fetchObservations(loincCodes: string[]) {
         sort: {
           lastUpdated: "DESC",
         },
-        filter: {
-          tag: {
-            allmatch: [`${SYSTEM_ZUS_OWNER}|builder/${requestContext.builderId}`],
-          },
-        },
       });
       const nodes = data.ObservationConnection.edges.map((x) => x.node);
       const observations = nodes.map((o) => new ObservationModel(o));
       const filteredObservations = filterObservationsByLOINCCodes(observations, loincCodes);
       if (filteredObservations.length === 0) {
-        Telemetry.countMetric("req.count.builder_observations.none", 1, ["fqs"]);
+        Telemetry.countMetric("req.count.all_observations.none", 1, ["fqs"]);
       }
-      Telemetry.histogramMetric(`req.count.builder_observations`, filteredObservations.length, [
-        "fqs",
-      ]);
+      Telemetry.histogramMetric(`req.count.all_observations`, filteredObservations.length, ["fqs"]);
       return filteredObservations;
     } catch (e) {
       throw Telemetry.logError(


### PR DESCRIPTION
https://zeushealth.atlassian.net/browse/CDEV-290

Removed first-party filter from FQS request when fetching observations, and cleaned up corresponding telemetry. Adding click telemetry to Trends.