### PR TITLE
Setting up default resources for the ZAP

### DIFF
--- a/.changeset/eighty-pants-brake.md
+++ b/.changeset/eighty-pants-brake.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Set default resources for ZAP.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,26 +115,15 @@ const components: DemoComponent[] = [
   {
     name: "zap",
     render: () => {
-      const resources: ZAPResourceName[] = [
-        "conditions-all",
-        "medications-all",
-        "diagnostic-reports",
-        "timeline",
-        "documents",
-        "allergies",
-        "immunizations",
-        "care-team",
-      ];
       return (
         <div>
-          <UnreadRecordsNotification resources={resources} text="Patient has unread records" />
+          <UnreadRecordsNotification text="Patient has unread records" />
           <ZusAggregatedProfile
             conditionsOutsideProps={{
               hideRequestRecords: true,
             }}
             conditionsAllProps={{ onlyAllowAddOutsideConditions: true }}
             includePatientDemographicsForm={false}
-            resources={resources}
             title="ZAP"
           />
         </div>

--- a/src/components/content/unread-records-notification.tsx
+++ b/src/components/content/unread-records-notification.tsx
@@ -1,5 +1,8 @@
 import fhir4 from "fhir/r4";
-import { ZAPResourceName } from "./zus-aggregated-profile/zus-aggregated-profile";
+import {
+  defaultZAPResources,
+  ZAPResourceName,
+} from "./zus-aggregated-profile/zus-aggregated-profile";
 import { useUserBuilderId } from "../core/providers/user-builder-id";
 import { UnreadNotificationIcon } from "../core/unread-notification-icon";
 import { usePatientAllergies } from "@/fhir/allergies";
@@ -12,13 +15,13 @@ import { usePatientConditionsAll } from "@/services/conditions";
 
 export type UnreadRecordsNotificationProps = {
   className?: string;
-  resources: ZAPResourceName[];
+  resources?: ZAPResourceName[];
   text?: string;
 };
 
 export const UnreadRecordsNotification = ({
   className,
-  resources,
+  resources = defaultZAPResources,
   text,
 }: UnreadRecordsNotificationProps) => {
   const userBuilderId = useUserBuilderId();

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile.tsx
@@ -35,8 +35,19 @@ export type ZAPResourceName =
   | "medications-all"
   | "timeline";
 
+export const defaultZAPResources: ZAPResourceName[] = [
+  "conditions-all",
+  "medications-all",
+  "diagnostic-reports",
+  "timeline",
+  "documents",
+  "allergies",
+  "immunizations",
+  "care-team",
+];
+
 export type ZusAggregatedProfileProps = {
-  resources: ZAPResourceName[];
+  resources?: ZAPResourceName[];
   forceHorizontalTabs?: boolean;
   includePatientDemographicsForm?: boolean;
   title?: string;
@@ -75,7 +86,7 @@ const ZusAggregatedProfileComponent = ({
   medicationsOutsideProps,
   medicationsAllProps,
   timelineProps,
-  resources,
+  resources = defaultZAPResources,
   hideTitle = false,
   title = "Outside Records",
   removeBranding = false,


### PR DESCRIPTION
Sets up the ZAP so that you don't _need_ to pass in the resources and we have a default set. Will follow this up with a corresponding update in standalone.