### PR TITLE
CDEV-296: Only fetch trend data if Patient is new

### DIFF
--- a/.changeset/empty-zebras-draw.md
+++ b/.changeset/empty-zebras-draw.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Only fetch trend data when a Patient was created after 07/19/2023

--- a/src/components/content/observations/helpers/drawer.tsx
+++ b/src/components/content/observations/helpers/drawer.tsx
@@ -8,16 +8,12 @@ import { keys } from "@/utils/nodash";
 
 export function useObservationsDetailsDrawer() {
   const { openDrawer } = useDrawer();
-  const observations = usePatientObservations(keys(LOINC_ANALYTES));
+  const { data } = usePatientObservations(keys(LOINC_ANALYTES));
 
   return (diagnosticReport: DiagnosticReportModel) => {
     openDrawer({
       component: (props) => (
-        <ObservationsDrawer
-          diagnosticReport={diagnosticReport}
-          observations={observations.data}
-          {...props}
-        />
+        <ObservationsDrawer diagnosticReport={diagnosticReport} observations={data} {...props} />
       ),
     });
   };

--- a/src/components/content/observations/helpers/drawer.tsx
+++ b/src/components/content/observations/helpers/drawer.tsx
@@ -8,12 +8,16 @@ import { keys } from "@/utils/nodash";
 
 export function useObservationsDetailsDrawer() {
   const { openDrawer } = useDrawer();
-  const { data } = usePatientObservations(keys(LOINC_ANALYTES));
+  const observations = usePatientObservations(keys(LOINC_ANALYTES));
 
   return (diagnosticReport: DiagnosticReportModel) => {
     openDrawer({
       component: (props) => (
-        <ObservationsDrawer diagnosticReport={diagnosticReport} observations={data} {...props} />
+        <ObservationsDrawer
+          diagnosticReport={diagnosticReport}
+          observations={observations.data}
+          {...props}
+        />
       ),
     });
   };

--- a/src/components/core/providers/patient-provider.tsx
+++ b/src/components/core/providers/patient-provider.tsx
@@ -94,6 +94,29 @@ export function usePatient(): UseQueryResult<PatientModel, unknown> {
   );
 }
 
+export function usePatientVersion(version: number): UseQueryResult<PatientModel, unknown> {
+  const { getRequestContext } = useCTW();
+  const patient = usePatient();
+  const patientId = patient.data?.id;
+
+  return useQuery(
+    [QUERY_KEY_PATIENT, patientId, version],
+    withTimerMetric(async () => {
+      const requestContext = await getRequestContext();
+      if (patientId) {
+        const p = (await requestContext.fhirClient.vread({
+          resourceType: "Patient",
+          id: patientId,
+          version: `${version}`,
+        })) as fhir4.Patient;
+        const model = new PatientModel(p);
+        return model;
+      }
+      return {};
+    }, "req.get_builder_fhir_patient")
+  );
+}
+
 export function usePatientPromise() {
   const { getRequestContext } = useCTW();
 

--- a/src/components/core/providers/patient-provider.tsx
+++ b/src/components/core/providers/patient-provider.tsx
@@ -113,7 +113,7 @@ export function usePatientVersion(version: number): UseQueryResult<PatientModel,
         return model;
       }
       return {};
-    }, "req.get_builder_fhir_patient")
+    }, "req.get_builder_fhir_patient_version")
   );
 }
 

--- a/src/fhir/observations.ts
+++ b/src/fhir/observations.ts
@@ -1,7 +1,10 @@
 import { ObservationModel, PatientModel } from "./models";
 import { SYSTEM_LOINC } from "./system-urls";
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
-import { useQueryWithPatient } from "@/components/core/providers/patient-provider";
+import {
+  usePatientVersion,
+  useQueryWithPatient,
+} from "@/components/core/providers/patient-provider";
 import { useTrendingLabsFeatureToggle } from "@/hooks/use-feature-toggle";
 import { createGraphqlClient, fqsRequest } from "@/services/fqs/client";
 import { ObservationGraphqlResponse, observationQuery } from "@/services/fqs/queries/observations";
@@ -10,10 +13,17 @@ import { Telemetry, withTimerMetric } from "@/utils/telemetry";
 
 export function usePatientObservations(loincCodes: string[]) {
   const trendingLabs = useTrendingLabsFeatureToggle();
+  const patient = usePatientVersion(1);
+
+  // TODO: Remove the usePatientVersion() call above and conditional below once DRT backfills Observations.
   return useQueryWithPatient(
     `${QUERY_KEY_PATIENT_OBSERVATIONS}_${loincCodes.join("_")}`,
-    [trendingLabs.enabled],
-    trendingLabs.enabled
+    [trendingLabs.enabled, patient.data],
+    trendingLabs.enabled &&
+      patient.data?.resource &&
+      patient.data.resource.meta &&
+      patient.data.resource.meta.lastUpdated &&
+      patient.data.resource.meta.lastUpdated >= "2023-07-20" // don't bother fetching observations if this patient was created before 07/20
       ? withTimerMetric(fetchObservations(loincCodes), "req.timing.all_observations")
       : async () =>
           new Promise<ObservationModel[]>((resolve) => {


### PR DESCRIPTION
https://zeushealth.atlassian.net/browse/CDEV-296

The FQS "filter Observations by LOINC code" feature is now available, but unfortunately only net-new Observations will be returned until a backfill of all historical data is complete. This means that we could possibly return incomplete trend data if a Patient has historical Observations **and** net-new Observations.

To guard against returning incomplete trend data, this PR checks when the Patient was created and will only fetch Observations when the Patient was created after the 7/19/2023 date (which is when FQS first introduced the filter feature). 

This means we will only show trend data on recently created Patients. Once the FQS backfill of Observation data is complete, we can remove this restriction and show trend data for all Patients.