### PR TITLE
CTW-1114/Track active session and generic drawer open

### DIFF
--- a/.changeset/metal-paws-buy.md
+++ b/.changeset/metal-paws-buy.md
@@ -1,0 +1,6 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Add unique session tracking whenever an interaction is made.
+Track drawer opens metrics by drawer type.

--- a/src/components/content/conditions/helpers/modal-hooks.tsx
+++ b/src/components/content/conditions/helpers/modal-hooks.tsx
@@ -32,6 +32,7 @@ export function useAddConditionForm() {
     );
 
     openDrawer({
+      telemetryName: "add_condition",
       component: (props) => (
         <DrawerFormWithFields
           title={t("resource.add", { resource: t("glossary:condition_one") })}
@@ -53,6 +54,7 @@ export function useEditConditionForm() {
 
   return (condition: ConditionModel) => {
     openDrawer({
+      telemetryName: "edit_condition",
       component: (props) => (
         <DrawerFormWithFields
           title={t("resource.edit", { resource: t("glossary:condition_one") })}

--- a/src/components/content/medications/helpers/add-new-med-drawer.tsx
+++ b/src/components/content/medications/helpers/add-new-med-drawer.tsx
@@ -16,6 +16,7 @@ export function useAddMedicationForm() {
 
   return (medication: MedicationStatementModel) => {
     openDrawer({
+      telemetryName: "add_medication",
       component: (props) => <AddNewMedDrawer medication={medication.resource} {...props} />,
     });
   };

--- a/src/components/content/observations/helpers/drawer.tsx
+++ b/src/components/content/observations/helpers/drawer.tsx
@@ -12,6 +12,7 @@ export function useObservationsDetailsDrawer() {
 
   return (diagnosticReport: DiagnosticReportModel) => {
     openDrawer({
+      telemetryName: "observations_details",
       component: (props) => (
         <ObservationsDrawer diagnosticReport={diagnosticReport} observations={data} {...props} />
       ),

--- a/src/components/content/patient-history/use-patient-history.tsx
+++ b/src/components/content/patient-history/use-patient-history.tsx
@@ -58,6 +58,7 @@ export function usePatientHistory(includePatientDemographicsForm?: boolean) {
         patient = undefined;
       }
       openDrawer({
+        telemetryName: "patient_history",
         component: (props) => (
           <PatientHistoryRequestDrawer
             includePatientDemographicsForm={includePatientDemographicsForm}

--- a/src/components/content/resource/resource-details-drawer.tsx
+++ b/src/components/content/resource/resource-details-drawer.tsx
@@ -37,6 +37,7 @@ export function useResourceDetailsDrawer<T extends fhir4.Resource, M extends FHI
 
   return (model: M) => {
     openDrawer({
+      telemetryName: "resource_details",
       component: (drawerProps) => (
         <ResourceDetailsDrawer model={model} {...props} {...drawerProps} />
       ),

--- a/src/components/core/providers/drawer-context.ts
+++ b/src/components/core/providers/drawer-context.ts
@@ -3,11 +3,14 @@ import { DrawerProps } from "../drawer";
 
 export type OpenDrawerProps = {
   component: ({
+    title,
     isOpen,
     onClose,
     onOpen,
     onAfterOpen,
-  }: Pick<DrawerProps, "isOpen" | "onClose" | "onOpen" | "onAfterOpen">) => JSX.Element | undefined;
+  }: Pick<DrawerProps, "isOpen" | "onClose" | "onOpen" | "onAfterOpen" | "title">) =>
+    | JSX.Element
+    | undefined;
 };
 
 export type DrawerState = {

--- a/src/components/core/providers/drawer-context.ts
+++ b/src/components/core/providers/drawer-context.ts
@@ -2,6 +2,7 @@ import { createContext } from "react";
 import { DrawerProps } from "../drawer";
 
 export type OpenDrawerProps = {
+  telemetryName?: string;
   component: ({
     title,
     isOpen,

--- a/src/components/core/providers/drawer-context.ts
+++ b/src/components/core/providers/drawer-context.ts
@@ -4,14 +4,11 @@ import { DrawerProps } from "../drawer";
 export type OpenDrawerProps = {
   telemetryName?: string;
   component: ({
-    title,
     isOpen,
     onClose,
     onOpen,
     onAfterOpen,
-  }: Pick<DrawerProps, "isOpen" | "onClose" | "onOpen" | "onAfterOpen" | "title">) =>
-    | JSX.Element
-    | undefined;
+  }: Pick<DrawerProps, "isOpen" | "onClose" | "onOpen" | "onAfterOpen">) => JSX.Element | undefined;
 };
 
 export type DrawerState = {

--- a/src/components/core/providers/drawer-provider.tsx
+++ b/src/components/core/providers/drawer-provider.tsx
@@ -27,7 +27,7 @@ export function DrawerProvider({ children }: ProviderProps) {
         setIsOpen(false);
         setTimeout(() => {
           setIsOpen(true);
-          Telemetry.trackInteraction("drawer_open");
+          Telemetry.trackInteraction(`open_drawer.${props.telemetryName}`.replace(/(\.)$/, ""));
         });
       },
     }),
@@ -39,6 +39,7 @@ export function DrawerProvider({ children }: ProviderProps) {
     <DrawerContext.Provider value={state}>
       {drawerProps.component({
         title: "",
+        telemetryName: "",
         isOpen,
         onClose: () => {
           setIsOpen(false);

--- a/src/components/core/providers/drawer-provider.tsx
+++ b/src/components/core/providers/drawer-provider.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useContext, useMemo, useState } from "react";
 import { DrawerContext, DrawerState, OpenDrawerProps } from "./drawer-context";
+import { Telemetry } from "@/utils/telemetry";
 
 interface ProviderProps {
   children: ReactNode;
@@ -26,6 +27,7 @@ export function DrawerProvider({ children }: ProviderProps) {
         setIsOpen(false);
         setTimeout(() => {
           setIsOpen(true);
+          Telemetry.trackInteraction("drawer_open");
         });
       },
     }),
@@ -36,6 +38,7 @@ export function DrawerProvider({ children }: ProviderProps) {
   return (
     <DrawerContext.Provider value={state}>
       {drawerProps.component({
+        title: "",
         isOpen,
         onClose: () => {
           setIsOpen(false);

--- a/src/components/core/providers/drawer-provider.tsx
+++ b/src/components/core/providers/drawer-provider.tsx
@@ -27,7 +27,9 @@ export function DrawerProvider({ children }: ProviderProps) {
         setIsOpen(false);
         setTimeout(() => {
           setIsOpen(true);
-          Telemetry.trackInteraction(`open_drawer.${props.telemetryName}`.replace(/(\.)$/, ""));
+          Telemetry.trackInteraction(
+            `open_drawer.${props.telemetryName ?? ""}`.replace(/(\.)$/, "")
+          );
         });
       },
     }),
@@ -38,8 +40,6 @@ export function DrawerProvider({ children }: ProviderProps) {
   return (
     <DrawerContext.Provider value={state}>
       {drawerProps.component({
-        title: "",
-        telemetryName: "",
         isOpen,
         onClose: () => {
           setIsOpen(false);

--- a/src/components/core/view-fhir.tsx
+++ b/src/components/core/view-fhir.tsx
@@ -15,6 +15,7 @@ export function useFHIRDrawer() {
 
   return (name: string, resource: fhir4.Resource) => {
     openDrawer({
+      telemetryName: "view_fhir",
       component: (props) => <FHIRDrawer name={name} resource={resource} {...props} />,
     });
   };

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,40 @@
+const SESSION_INACTIVE_TIME_MS = 1000 * 60 * 60; // 1 hour
+const SESSION_TIMESTAMP_KEY = "zus:sessionLastActiveTimestamp";
+const SESSION_USER_ID_KEY = "zus:sessionUserId";
+
+export class Session {
+  static isActive() {
+    const timestampStr = localStorage.getItem(SESSION_TIMESTAMP_KEY);
+    if (timestampStr) {
+      const lastActiveTimestamp = parseInt(timestampStr, 10);
+      const now = new Date().getTime();
+      return now - SESSION_INACTIVE_TIME_MS > lastActiveTimestamp;
+    }
+    return false;
+  }
+
+  static setSessionLastActiveTimestamp() {
+    localStorage.setItem(SESSION_TIMESTAMP_KEY, new Date().getTime().toString());
+  }
+
+  static clearSessionLastActiveTimestamp() {
+    localStorage.removeItem(SESSION_TIMESTAMP_KEY);
+  }
+
+  /**
+   * Sets the session user id. If the user id is already set and not of the
+   * same value, the active session will be cleared.
+   */
+  static setSessionUserId(userId: string) {
+    const sessionUserId = localStorage.getItem(SESSION_USER_ID_KEY);
+    if (sessionUserId !== userId) {
+      Session.clearSession();
+      localStorage.setItem(SESSION_USER_ID_KEY, userId);
+    }
+  }
+
+  static clearSession() {
+    localStorage.removeItem(SESSION_USER_ID_KEY);
+    localStorage.removeItem(SESSION_TIMESTAMP_KEY);
+  }
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -8,7 +8,7 @@ export class Session {
     if (timestampStr) {
       const lastActiveTimestamp = parseInt(timestampStr, 10);
       const now = new Date().getTime();
-      return now - SESSION_INACTIVE_TIME_MS > lastActiveTimestamp;
+      return now - SESSION_INACTIVE_TIME_MS < lastActiveTimestamp;
     }
     return false;
   }

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -296,19 +296,7 @@ export class Telemetry {
       const user = jwtDecode(this.accessToken) as ZusJWT;
       Session.setSessionUserId(user[AUTH_USER_ID]);
       Session.setSessionLastActiveTimestamp();
-      await fetch(`${getMetricsBaseUrl(this.environment)}/report/session`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${this.accessToken}`,
-        },
-        body: JSON.stringify({
-          userId: user[AUTH_USER_ID],
-          builder: user[AUTH_BUILDER_NAME],
-          isSuper: user[AUTH_IS_SUPER_ORG] === "true",
-          ehr: this.ehr,
-        }),
-        mode: "cors",
-      });
+      await Telemetry.reportMetric("increment", "active_session", 1, []);
     } catch (error) {
       // Clear the session last active timestamp because we didn't report it
       Session.clearSessionLastActiveTimestamp();

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -284,6 +284,7 @@ export class Telemetry {
   static async reportActiveSession() {
     // Return if the session is already active or we don't need to report
     if (
+      Session.isActive() ||
       !this.environment ||
       (process.env.NODE_ENV !== "test" &&
         ["http://localhost:3000", "http://127.0.0.1:3000"].includes(window.location.origin))

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -188,7 +188,7 @@ export class Telemetry {
 
   static trackInteraction(action: string) {
     // We send an action metric to CTW
-    this.countMetric(`interaction.${action}`, 1);
+    this.countMetric(`action.${action}`, 1);
     // We report an active session to CTW
     this.reportActiveSession().catch((error) => Telemetry.logError(error as Error));
   }


### PR DESCRIPTION
Send a metric for active session and for opening a drawer.
When an interaction is made (currently just opening a drawer) we track a session in localStorage. A new session doesn't begin until an hour after no other interaction is made by the same user. We send a `ctw.active_session` metric count to DataDog.

This doesn't cover the whole of CTW-1114, it doesn't do any tracking in DynamoDB so we can't yet track user retention, only user activity totals. I want to get this merged a bit early to allow others to work on some interaction metrics and while I spike on the best way to complete the rest of CTW-1114 ticket in a way that supports better long term outcomes.
