### PR TITLE
CDEV-296: Updating trend fetching to include patients created on 07/19

### DIFF
--- a/.changeset/fresh-apricots-ring.md
+++ b/.changeset/fresh-apricots-ring.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Updated trending labs logic to include Patients created on 07/19/2023

--- a/src/fhir/observations.ts
+++ b/src/fhir/observations.ts
@@ -23,7 +23,7 @@ export function usePatientObservations(loincCodes: string[]) {
       patient.data?.resource &&
       patient.data.resource.meta &&
       patient.data.resource.meta.lastUpdated &&
-      patient.data.resource.meta.lastUpdated >= "2023-07-20" // don't bother fetching observations if this patient was created before 07/20
+      patient.data.resource.meta.lastUpdated >= "2023-07-19" // don't bother fetching observations if this patient was created before 07/19
       ? withTimerMetric(fetchObservations(loincCodes), "req.timing.all_observations")
       : async () =>
           new Promise<ObservationModel[]>((resolve) => {


### PR DESCRIPTION
https://zeushealth.atlassian.net/browse/CDEV-296

Only fetch trend data for patients created on or after 07/19/2023 (previously 07/20/2023)