### PR TITLE
CDEV-290: Adding user ID tag to metrics

### DIFF
--- a/.changeset/eleven-cycles-exist.md
+++ b/.changeset/eleven-cycles-exist.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Added user_id to telemetry metrics

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "1.36.0",
+  "version": "1.38.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "1.36.0",
+      "version": "1.38.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/utils/telemetry.test.ts
+++ b/src/utils/telemetry.test.ts
@@ -56,6 +56,7 @@ describe("telemetry", () => {
       tags: [
         "service:ctw-component-library",
         "env:test",
+        "user_id:undefined",
         "is_super:false",
         "ehr:unknown",
         versionTag,

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -233,6 +233,7 @@ export class Telemetry {
       "service:ctw-component-library",
       `env:${this.environment}`,
       user[AUTH_BUILDER_NAME] ? `builder_name:${user[AUTH_BUILDER_NAME]}` : undefined,
+      `user_id:${user[AUTH_USER_ID]}`,
       `is_super:${user[AUTH_IS_SUPER_ORG] || "false"}`,
       this.ehr ? `ehr:${this.ehr}` : undefined,
       `version:${packageJson.version}`,


### PR DESCRIPTION
https://zeushealth.atlassian.net/browse/CDEV-290

Adding a `user_id` tag to our existing metrics that get collected for easier reporting on unique users per action