### PR TITLE
CDEV-70/details drawer actions

### DIFF
--- a/.changeset/beige-berries-sort.md
+++ b/.changeset/beige-berries-sort.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Add table row actions to details drawer (dismiss/add/mark as new/etc).

--- a/src/components/content/allergies/patient-allergies.tsx
+++ b/src/components/content/allergies/patient-allergies.tsx
@@ -11,7 +11,6 @@ import { withErrorBoundary } from "@/components/core/error-boundary";
 import { useUserBuilderId } from "@/components/core/providers/user-builder-id";
 import { usePatientAllergies } from "@/fhir/allergies";
 import { AllergyModel } from "@/fhir/models/allergies";
-import { useFQSFeatureToggle } from "@/hooks/use-feature-toggle";
 import { useFilteredSortedData } from "@/hooks/use-filtered-sorted-data";
 import { capitalize } from "@/utils/nodash";
 
@@ -20,7 +19,6 @@ export type PatientAllergiesProps = {
 };
 
 function PatientAllergiesComponent({ className }: PatientAllergiesProps) {
-  const { enabled } = useFQSFeatureToggle("allergies");
   const patientAllergiesQuery = usePatientAllergies();
   const { data, setFilters, setSort } = useFilteredSortedData({
     defaultFilters: defaultAllergyFilters,
@@ -36,7 +34,7 @@ function PatientAllergiesComponent({ className }: PatientAllergiesProps) {
     details: allergyData,
     getHistory: useAllergiesHistory,
     getSourceDocument: true,
-    enableFQS: enabled,
+    enableDismissAndReadActions: true,
   });
 
   return (

--- a/src/components/content/care-team/patient-careteam.tsx
+++ b/src/components/content/care-team/patient-careteam.tsx
@@ -6,7 +6,6 @@ import { Table } from "@/components/core/table/table";
 import { usePatientCareTeam } from "@/fhir/care-team";
 import { CareTeamPractitionerModel } from "@/fhir/models/careteam-practitioner";
 import { useBreakpoints } from "@/hooks/use-breakpoints";
-import { useFQSFeatureToggle } from "@/hooks/use-feature-toggle";
 
 export type PatientCareTeamProps = {
   className?: string;
@@ -20,7 +19,6 @@ export type CareTeamDetailsDrawerProps = {
 };
 
 export function PatientCareTeam({ className }: PatientCareTeamProps) {
-  const { enabled } = useFQSFeatureToggle("careTeams");
   const containerRef = useRef<HTMLDivElement>(null);
   const breakpoints = useBreakpoints(containerRef);
   const patientCareTeamQuery = usePatientCareTeam();
@@ -30,7 +28,6 @@ export function PatientCareTeam({ className }: PatientCareTeamProps) {
     subHeader: (m) => m.qualification,
     details: careTeamData,
     getSourceDocument: true,
-    enableFQS: enabled,
   });
 
   return (

--- a/src/components/content/conditions/helpers/details.tsx
+++ b/src/components/content/conditions/helpers/details.tsx
@@ -1,29 +1,21 @@
 import { useConditionHistory } from "./history";
-import { useConfirmDeleteCondition, useEditConditionForm } from "./modal-hooks";
 import { useResourceDetailsDrawer } from "../../resource/resource-details-drawer";
 import { NotesList } from "@/components/core/notes-list";
+import { RowActionsProp } from "@/components/core/table/table-rows";
 import { ConditionModel } from "@/fhir/models";
-import { useFQSFeatureToggle } from "@/hooks/use-feature-toggle";
 import { capitalize } from "@/utils/nodash";
 
 export const useConditionDetailsDrawer = ({
-  canEdit,
+  RowActions,
+  enableDismissAndReadActions,
 }: {
-  canEdit: boolean;
-  canRemove: boolean;
-}) => {
-  const { enabled } = useFQSFeatureToggle("conditions");
-  const showEditConditionForm = useEditConditionForm();
-  const confirmDelete = useConfirmDeleteCondition();
-
-  return useResourceDetailsDrawer({
+  RowActions?: RowActionsProp<ConditionModel>;
+  enableDismissAndReadActions?: boolean;
+}) =>
+  useResourceDetailsDrawer({
     header: (condition: ConditionModel) => condition.display,
     subHeader: (condition: ConditionModel) => condition.ccsChapter,
     getSourceDocument: true,
-    readOnly: !canEdit,
-    enableFQS: enabled,
-    onEdit: showEditConditionForm,
-    onRemove: confirmDelete,
     details: (condition: ConditionModel) => [
       { label: "Recorder", value: condition.recorder },
       { label: "Recorded Date", value: condition.recordedDate },
@@ -41,5 +33,6 @@ export const useConditionDetailsDrawer = ({
       },
     ],
     getHistory: useConditionHistory,
+    RowActions,
+    enableDismissAndReadActions,
   });
-};

--- a/src/components/content/conditions/helpers/patient-conditions-base.tsx
+++ b/src/components/content/conditions/helpers/patient-conditions-base.tsx
@@ -6,12 +6,13 @@ import { patientConditionsColumns } from "./columns";
 import { useConditionDetailsDrawer } from "./details";
 import { conditionFilters, defaultConditionFilters } from "./filters";
 import { conditionSortOptions, defaultConditionSort } from "./sorts";
-import { ResourceTable, ResourceTableProps } from "../../resource/resource-table";
+import { ResourceTable } from "../../resource/resource-table";
 import {
   ResourceTableActions,
   ResourceTableActionsProps,
 } from "../../resource/resource-table-actions";
 import { EmptyTable } from "@/components/core/empty-table";
+import { RowActionsProp } from "@/components/core/table/table-rows";
 import { ConditionModel } from "@/fhir/models";
 import { useFilteredSortedData } from "@/hooks/use-filtered-sorted-data";
 
@@ -21,7 +22,7 @@ export type PatientConditionsTableProps = {
   query: { data?: ConditionModel[]; isLoading: boolean };
   outside?: boolean;
   readOnly?: boolean;
-  rowActions?: ResourceTableProps<ConditionModel>["RowActions"];
+  RowActions?: RowActionsProp<ConditionModel>;
   emptyMessage?: string | ReactElement | undefined;
   isLoading?: boolean;
 };
@@ -31,15 +32,11 @@ export const PatientConditionsBase = ({
   className,
   query,
   outside = false,
-  readOnly = false,
-  rowActions,
+  RowActions,
   emptyMessage,
   isLoading,
 }: PatientConditionsTableProps) => {
-  const openDetailsDrawer = useConditionDetailsDrawer({
-    canRemove: !readOnly && !outside,
-    canEdit: !readOnly && !outside,
-  });
+  const openDetailsDrawer = useConditionDetailsDrawer({ RowActions });
 
   const { data, setFilters, setSort } = useFilteredSortedData({
     defaultFilters: defaultConditionFilters,
@@ -79,7 +76,7 @@ export const PatientConditionsBase = ({
         emptyMessage={empty}
         isLoading={isLoading || query.isLoading}
         onRowClick={openDetailsDrawer}
-        RowActions={rowActions}
+        RowActions={RowActions}
       />
     </div>
   );

--- a/src/components/content/conditions/patient-conditions-all.tsx
+++ b/src/components/content/conditions/patient-conditions-all.tsx
@@ -49,15 +49,15 @@ function PatientConditionsAllComponent({
     <EmptyTable hasZeroFilteredRecords={hasZeroFilteredRecords} resourceName="conditions" />
   );
 
-  const openDetails = useConditionDetailsDrawer({
-    canRemove: !readOnly && !onlyAllowAddOutsideConditions,
-    canEdit: !readOnly && !onlyAllowAddOutsideConditions,
-  });
-
-  const rowActions = useMemo(
+  const RowActions = useMemo(
     () => (!readOnly ? getRowActions(userBuilderId, onlyAllowAddOutsideConditions) : undefined),
     [userBuilderId, readOnly, onlyAllowAddOutsideConditions]
   );
+
+  const openDetails = useConditionDetailsDrawer({
+    RowActions,
+    enableDismissAndReadActions: true,
+  });
 
   const action = !readOnly && !onlyAllowAddOutsideConditions && (
     <button type="button" className="ctw-btn-primary" onClick={() => showAddConditionForm()}>
@@ -89,7 +89,7 @@ function PatientConditionsAllComponent({
         data={data}
         columns={patientConditionsAllColumns(userBuilderId)}
         onRowClick={openDetails}
-        RowActions={rowActions}
+        RowActions={RowActions}
         enableDismissAndReadActions
         emptyMessage={empty}
       />
@@ -130,13 +130,14 @@ const getRowActions =
         </div>
       );
     }
+
     if (!record.ownedByBuilder(userBuilderId)) {
       return (
         <button
           type="button"
           className="ctw-btn-primary"
           onClick={() => {
-            toggleRead(record);
+            void toggleRead(record);
             showAddConditionForm(record);
           }}
         >

--- a/src/components/content/conditions/patient-conditions-outside.tsx
+++ b/src/components/content/conditions/patient-conditions-outside.tsx
@@ -42,7 +42,7 @@ const PatientConditionsOutsideComponent = ({
       className={className}
       query={query}
       readOnly={readOnly}
-      rowActions={readOnly ? undefined : RowActions}
+      RowActions={readOnly ? undefined : RowActions}
       isLoading={patientHistoryQuery.isLoading}
     />
   );
@@ -53,7 +53,7 @@ export const PatientConditionsOutside = withErrorBoundary(
   "PatientConditions"
 );
 
-const RowActions = ({ record }: RowActionsProps<ConditionModel>) => {
+const RowActions = ({ record, onSuccess }: RowActionsProps<ConditionModel>) => {
   const { t } = useBaseTranslations();
   const showAddConditionForm = useAddConditionForm();
   const { isLoading, toggleDismiss } = useToggleDismiss(
@@ -68,8 +68,9 @@ const RowActions = ({ record }: RowActionsProps<ConditionModel>) => {
         type="button"
         className="ctw-btn-default"
         disabled={isLoading}
-        onClick={() => {
-          toggleDismiss(record);
+        onClick={async () => {
+          await toggleDismiss(record);
+          onSuccess?.();
         }}
       >
         {isLoading ? (

--- a/src/components/content/conditions/patient-conditions.tsx
+++ b/src/components/content/conditions/patient-conditions.tsx
@@ -33,21 +33,25 @@ const PatientConditionsComponent = ({ className, readOnly = false }: PatientCond
       className={cx(className)}
       query={query}
       readOnly={readOnly}
-      rowActions={readOnly ? undefined : RowActions}
+      RowActions={readOnly ? undefined : RowActions}
     />
   );
 };
 
 export const PatientConditions = withErrorBoundary(PatientConditionsComponent, "PatientConditions");
 
-const RowActions = ({ record }: RowActionsProps<ConditionModel>) => {
+const RowActions = ({ record, onSuccess }: RowActionsProps<ConditionModel>) => {
   const showEditConditionForm = useEditConditionForm();
   const confirmDelete = useConfirmDeleteCondition();
 
   return (
     <div className="ctw-flex ctw-space-x-2">
       {!record.isDeleted && (
-        <button type="button" className="ctw-btn-default" onClick={() => confirmDelete(record)}>
+        <button
+          type="button"
+          className="ctw-btn-default"
+          onClick={() => confirmDelete(record, onSuccess)}
+        >
           Remove
         </button>
       )}

--- a/src/components/content/document/patient-documents.tsx
+++ b/src/components/content/document/patient-documents.tsx
@@ -14,7 +14,6 @@ import { RowActionsProps } from "@/components/core/table/table";
 import { getBinaryDocument } from "@/fhir/binaries";
 import { usePatientDocuments } from "@/fhir/document";
 import { DocumentModel } from "@/fhir/models/document";
-import { useFQSFeatureToggle } from "@/hooks/use-feature-toggle";
 import { useFilteredSortedData } from "@/hooks/use-filtered-sorted-data";
 import { useBaseTranslations } from "@/i18n";
 
@@ -25,7 +24,6 @@ export type PatientDocumentsProps = {
 
 function PatientDocumentsComponent({ className, onAddToRecord }: PatientDocumentsProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { enabled } = useFQSFeatureToggle("documents");
 
   const patientDocumentQuery = usePatientDocuments();
   const rowActions = useMemo(() => getRowActions({ onAddToRecord }), [onAddToRecord]);
@@ -44,7 +42,8 @@ function PatientDocumentsComponent({ className, onAddToRecord }: PatientDocument
     header: (m) => m.title,
     subHeader: (m) => m.encounterDate,
     details: documentData,
-    enableFQS: enabled,
+    RowActions: rowActions,
+    enableDismissAndReadActions: true,
   });
 
   return (
@@ -96,7 +95,7 @@ const getRowActions =
 
 type RowActionsProps2 = RowActionsProps<DocumentModel> & ExtraRowActionProps;
 
-const RowActions = ({ record, onAddToRecord }: RowActionsProps2) => {
+const RowActions = ({ record, onSuccess, onAddToRecord }: RowActionsProps2) => {
   const { t } = useBaseTranslations();
   const { getRequestContext } = useCTW();
   const { binaryId } = record;
@@ -111,6 +110,7 @@ const RowActions = ({ record, onAddToRecord }: RowActionsProps2) => {
         onClick={async () => {
           const binary = await getBinaryDocument(await getRequestContext(), binaryId);
           onAddToRecord(record, binary);
+          onSuccess?.();
         }}
       >
         {t("resourceTable.add")}

--- a/src/components/content/hooks/use-toggle-dismiss.ts
+++ b/src/components/content/hooks/use-toggle-dismiss.ts
@@ -34,10 +34,7 @@ export function useToggleDismiss(...queriesToInvalidate: string[]): UseToggleDis
         queryClient.invalidateQueries([queryToInvalidate])
       )
     );
-
-    // Timeout here fixes bug where we would briefly flash
-    // the old dismiss/restore text.
-    setTimeout(() => setIsLoading(false), 0);
+    setIsLoading(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/content/hooks/use-toggle-dismiss.ts
+++ b/src/components/content/hooks/use-toggle-dismiss.ts
@@ -8,7 +8,7 @@ interface UseToggleDismissResult {
   /**
    * Function to call to toggle the archive status of the FHIR model
    */
-  toggleDismiss: (model: FHIRModel<fhir4.Resource>) => void;
+  toggleDismiss: (model: FHIRModel<fhir4.Resource>) => Promise<void>;
 
   /**
    * True when `toggleArchive` is called

--- a/src/components/content/hooks/use-toggle-read.ts
+++ b/src/components/content/hooks/use-toggle-read.ts
@@ -35,10 +35,7 @@ export function useToggleRead(): UseToggleReadResult {
     setIsLoading(true);
     await toggleRead(model, await getRequestContext());
     await queryClient.invalidateQueries([QUERY_KEY_BASIC]);
-
-    // Timeout here fixes bug where we would briefly flash
-    // the old mark as read/new text.
-    setTimeout(() => setIsLoading(false), 0);
+    setIsLoading(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/content/hooks/use-toggle-read.ts
+++ b/src/components/content/hooks/use-toggle-read.ts
@@ -9,7 +9,7 @@ interface UseToggleReadResult {
   /**
    * Function to call to toggle the read status of the FHIR model
    */
-  toggleRead: (model: FHIRModel<fhir4.Resource>) => void;
+  toggleRead: (model: FHIRModel<fhir4.Resource>) => Promise<void>;
 
   /**
    * True when `toggleRead` is called

--- a/src/components/content/immunizations/patient-immunizations.tsx
+++ b/src/components/content/immunizations/patient-immunizations.tsx
@@ -11,7 +11,6 @@ import { withErrorBoundary } from "@/components/core/error-boundary";
 import { useUserBuilderId } from "@/components/core/providers/user-builder-id";
 import { usePatientImmunizations } from "@/fhir/immunizations";
 import { ImmunizationModel } from "@/fhir/models/immunization";
-import { useFQSFeatureToggle } from "@/hooks/use-feature-toggle";
 import { useFilteredSortedData } from "@/hooks/use-filtered-sorted-data";
 
 export type PatientImmunizationsProps = {
@@ -20,7 +19,6 @@ export type PatientImmunizationsProps = {
 
 function PatientImmunizationsComponent({ className }: PatientImmunizationsProps) {
   const userBuilderId = useUserBuilderId();
-  const { enabled } = useFQSFeatureToggle("immunizations");
   const patientImmunizationsQuery = usePatientImmunizations();
   const { data, setFilters, setSort } = useFilteredSortedData({
     defaultFilters: defaultImmunizationsFilters,
@@ -35,7 +33,7 @@ function PatientImmunizationsComponent({ className }: PatientImmunizationsProps)
     header: (m) => m.description,
     details: immunizationData,
     getSourceDocument: true,
-    enableFQS: enabled,
+    enableDismissAndReadActions: true,
   });
 
   return (

--- a/src/components/content/medications/helpers/details.tsx
+++ b/src/components/content/medications/helpers/details.tsx
@@ -2,10 +2,17 @@ import { useMedicationHistoryEntries } from "./history";
 import { useResourceDetailsDrawer } from "../../resource/resource-details-drawer";
 import { entryFromArray } from "@/components/core/data-list";
 import { Loading } from "@/components/core/loading";
+import { RowActionsProp } from "@/components/core/table/table-rows";
 import { useLastPrescriber } from "@/fhir/medications";
 import { MedicationStatementModel } from "@/fhir/models";
 
-export const useMedicationDetailsDrawer = () =>
+export const useMedicationDetailsDrawer = ({
+  RowActions,
+  enableDismissAndReadActions,
+}: {
+  RowActions?: RowActionsProp<MedicationStatementModel>;
+  enableDismissAndReadActions?: boolean;
+}) =>
   useResourceDetailsDrawer({
     header: (medication: MedicationStatementModel) => medication.display,
     getHistory: useMedicationHistoryEntries,
@@ -23,6 +30,8 @@ export const useMedicationDetailsDrawer = () =>
       { label: "Last Prescribed Date", value: medication.lastPrescribedDate },
       ...entryFromArray("Note", medication.notesDisplay),
     ],
+    RowActions,
+    enableDismissAndReadActions,
   });
 
 function LastPrescriber({ medication }: { medication: MedicationStatementModel }) {

--- a/src/components/content/medications/helpers/patient-medications-base.tsx
+++ b/src/components/content/medications/helpers/patient-medications-base.tsx
@@ -4,13 +4,14 @@ import { useMedicationDetailsDrawer } from "./details";
 import { defaultMedicationFilters } from "./filters";
 import { defaultMedicationSort, medicationSortOptions } from "./sorts";
 import { ViewOption } from "../../resource/helpers/view-button";
-import { ResourceTable, ResourceTableProps } from "../../resource/resource-table";
+import { ResourceTable } from "../../resource/resource-table";
 import {
   ResourceTableActions,
   ResourceTableActionsProps,
 } from "../../resource/resource-table-actions";
 import { EmptyTable } from "@/components/core/empty-table";
 import { FilterItem } from "@/components/core/filter-bar/filter-bar-types";
+import { RowActionsProp } from "@/components/core/table/table-rows";
 import { MedicationStatementModel } from "@/fhir/models";
 import { useFilteredSortedData } from "@/hooks/use-filtered-sorted-data";
 import "./patient-medications.scss";
@@ -19,7 +20,7 @@ export type PatientMedicationsBaseProps = {
   action?: ResourceTableActionsProps<MedicationStatementModel>["action"];
   className?: string;
   query: { data?: MedicationStatementModel[]; isLoading: boolean };
-  rowActions?: ResourceTableProps<MedicationStatementModel>["RowActions"];
+  rowActions?: RowActionsProp<MedicationStatementModel>;
   filters: FilterItem[];
   defaultView?: ViewOption<MedicationStatementModel>;
   views?: ViewOption<MedicationStatementModel>[];
@@ -37,7 +38,7 @@ export const PatientMedicationsBase = ({
   views,
   onOpenHistoryDrawer,
 }: PatientMedicationsBaseProps) => {
-  const openDetailsDrawer = useMedicationDetailsDrawer();
+  const openDetailsDrawer = useMedicationDetailsDrawer({ RowActions: rowActions });
   const { data, setFilters, setSort, setViewOption } = useFilteredSortedData({
     defaultView,
     defaultFilters: defaultMedicationFilters,

--- a/src/components/content/medications/patient-medications-all.tsx
+++ b/src/components/content/medications/patient-medications-all.tsx
@@ -42,12 +42,15 @@ function PatientMedicationsAllComponent({
     <EmptyTable hasZeroFilteredRecords={hasZeroFilteredRecords} resourceName="medications" />
   );
 
-  const openDetails = useMedicationDetailsDrawer();
-
   const rowActions = useMemo(
     () => (!readOnly ? getRowActions(userBuilderId, onAddToRecord) : undefined),
     [userBuilderId, readOnly, onAddToRecord]
   );
+
+  const openDetails = useMedicationDetailsDrawer({
+    RowActions: rowActions,
+    enableDismissAndReadActions: true,
+  });
 
   return (
     <div
@@ -87,7 +90,7 @@ export const PatientMedicationsAll = withErrorBoundary(
 
 const getRowActions =
   (userBuilderId: string, onAddToRecord?: (record: MedicationStatementModel) => void) =>
-  ({ record }: RowActionsProps<MedicationStatementModel>) => {
+  ({ record, onSuccess }: RowActionsProps<MedicationStatementModel>) => {
     const { t } = useBaseTranslations();
     const showAddMedicationForm = useAddMedicationForm();
     const { toggleRead } = useToggleRead();
@@ -97,10 +100,11 @@ const getRowActions =
         <button
           type="button"
           className="ctw-btn-primary"
-          onClick={() => {
-            toggleRead(record);
+          onClick={async () => {
+            void toggleRead(record);
             if (onAddToRecord) {
               onAddToRecord(record);
+              onSuccess?.();
             } else {
               showAddMedicationForm(record);
             }

--- a/src/components/content/medications/patient-medications-outside.tsx
+++ b/src/components/content/medications/patient-medications-outside.tsx
@@ -59,7 +59,7 @@ const getRowActions =
 
 type RowActionsProps2 = RowActionsProps<MedicationStatementModel> & ExtraRowActionProps;
 
-const RowActions = ({ record, onAddToRecord }: RowActionsProps2) => {
+const RowActions = ({ record, onSuccess, onAddToRecord }: RowActionsProps2) => {
   const { t } = useBaseTranslations();
   const showAddMedicationForm = useAddMedicationForm();
   const { isLoading, toggleDismiss: toggleArchive } = useToggleDismiss(
@@ -74,8 +74,9 @@ const RowActions = ({ record, onAddToRecord }: RowActionsProps2) => {
         type="button"
         className="ctw-btn-default"
         disabled={isLoading}
-        onClick={() => {
-          toggleArchive(record);
+        onClick={async () => {
+          await toggleArchive(record);
+          onSuccess?.();
         }}
       >
         {isLoading ? (
@@ -96,6 +97,7 @@ const RowActions = ({ record, onAddToRecord }: RowActionsProps2) => {
         onClick={() => {
           if (onAddToRecord) {
             onAddToRecord(record);
+            onSuccess?.();
           } else {
             showAddMedicationForm(record);
           }

--- a/src/components/content/observations/helpers/drawer.tsx
+++ b/src/components/content/observations/helpers/drawer.tsx
@@ -1,3 +1,4 @@
+import { useAdditionalResourceActions } from "../../resource/use-additional-resource-actions";
 import { ObservationDetails } from "@/components/content/observations/helpers/details";
 import { Drawer } from "@/components/core/drawer";
 import { useDrawer } from "@/components/core/providers/drawer-provider";
@@ -34,17 +35,19 @@ export function ObservationsDrawer({
   isOpen,
   onClose,
 }: ObservationsDrawerProps) {
+  const ResourceActions = useAdditionalResourceActions({ enableDismissAndReadActions: true });
+
   return (
-    <Drawer
-      className={className}
-      title="Diagnostic Report"
-      isOpen={isOpen}
-      onClose={onClose}
-      showCloseFooter
-    >
+    <Drawer className={className} title="Diagnostic Report" isOpen={isOpen} onClose={onClose}>
       <Drawer.Body>
         <ObservationDetails diagnosticReport={diagnosticReport} observationTrends={observations} />
       </Drawer.Body>
+      <Drawer.Footer>
+        <div className="ctw-flex ctw-justify-between">
+          <Drawer.CloseButton onClose={onClose} label="Close" />
+          {ResourceActions && <ResourceActions record={diagnosticReport} onSuccess={onClose} />}
+        </div>
+      </Drawer.Footer>
     </Drawer>
   );
 }

--- a/src/components/content/resource/resource-table.tsx
+++ b/src/components/content/resource/resource-table.tsx
@@ -55,7 +55,7 @@ export const ResourceTable = <T extends fhir4.Resource, M extends FHIRModel<T>>(
           enableDismissAndReadActions &&
           !record.ownedByBuilder(userBuilderId)
         ) {
-          await toggleRead(record);
+          void toggleRead(record);
         }
         onRowClick(record);
       }

--- a/src/components/content/resource/use-additional-resource-actions.tsx
+++ b/src/components/content/resource/use-additional-resource-actions.tsx
@@ -1,0 +1,104 @@
+import { useToggleDismiss } from "../hooks/use-toggle-dismiss";
+import { useToggleRead } from "../hooks/use-toggle-read";
+import { useCTW } from "@/components/core/providers/use-ctw";
+import { useUserBuilderId } from "@/components/core/providers/user-builder-id";
+import { Spinner } from "@/components/core/spinner";
+import { RowActionsProps, TableProps } from "@/components/core/table/table";
+import { MinRecordItem } from "@/components/core/table/table-helpers";
+import { ViewFHIR } from "@/components/core/view-fhir";
+import { FHIRModel } from "@/fhir/models/fhir-model";
+import { useBaseTranslations } from "@/i18n";
+import { QUERY_KEY_BASIC } from "@/utils/query-keys";
+
+export type ResourceTableProps<T extends MinRecordItem> = {
+  RowActions?: TableProps<T>["RowActions"];
+  enableDismissAndReadActions?: boolean;
+};
+
+export const useAdditionalResourceActions = <T extends fhir4.Resource, M extends FHIRModel<T>>({
+  RowActions,
+  enableDismissAndReadActions,
+}: ResourceTableProps<M>) => {
+  const { featureFlags } = useCTW();
+  const userBuilderId = useUserBuilderId();
+
+  const DismissAndReadActions = enableDismissAndReadActions
+    ? getDismissAndReadActions(userBuilderId)
+    : undefined;
+
+  return featureFlags?.enableViewFhirButton || RowActions || DismissAndReadActions
+    ? ({ record, onSuccess }: RowActionsProps<M>) => {
+        // We call these right away so we'll know if they return null and then
+        // so should we. This helps consumers like ResourceDetailsDrawer know
+        // whether or not the row actions are empty or not.
+        const actions = RowActions && RowActions({ record, onSuccess });
+        const extraActions = DismissAndReadActions && DismissAndReadActions({ record, onSuccess });
+        if (!extraActions && !actions && !featureFlags?.enableViewFhirButton) return null;
+
+        return (
+          <div className="ctw-flex ctw-space-x-2">
+            {featureFlags?.enableViewFhirButton && <ViewFHIR resource={record.resource} />}
+            {extraActions}
+            {actions}
+          </div>
+        );
+      }
+    : undefined;
+};
+
+const getDismissAndReadActions =
+  (userBuilderId: string) =>
+  ({ record, onSuccess }: RowActionsProps<FHIRModel<fhir4.Resource>>) => {
+    const { t } = useBaseTranslations();
+
+    const { isLoading: isToggleDismissLoading, toggleDismiss } = useToggleDismiss(QUERY_KEY_BASIC);
+    const { isLoading: isToggleReadLoading, toggleRead } = useToggleRead();
+    const archiveLabel = record.isDismissed
+      ? t("resourceTable.restore")
+      : t("resourceTable.dismiss");
+
+    const readLabel = record.isRead ? t("resourceTable.unread") : t("resourceTable.read");
+
+    return record.ownedByBuilder(userBuilderId) ? null : (
+      <div className="ctw-flex ctw-space-x-2">
+        <button
+          type="button"
+          className="ctw-btn-default"
+          disabled={isToggleDismissLoading || isToggleReadLoading}
+          onClick={async () => {
+            await toggleDismiss(record);
+            if (!record.isRead) {
+              await toggleRead(record);
+            }
+            onSuccess?.();
+          }}
+        >
+          {isToggleDismissLoading ? (
+            <div className="ctw-flex">
+              <Spinner className="ctw-mx-4 ctw-align-middle" />
+            </div>
+          ) : (
+            archiveLabel
+          )}
+        </button>
+
+        <button
+          type="button"
+          className="ctw-btn-default"
+          disabled={isToggleDismissLoading || isToggleReadLoading}
+          onClick={async () => {
+            await toggleRead(record);
+            onSuccess?.();
+          }}
+        >
+          {isToggleReadLoading ? (
+            <div className="ctw-flex">
+              <Spinner className="ctw-mx-4 ctw-align-middle" />
+            </div>
+          ) : (
+            readLabel
+          )}
+        </button>
+      </div>
+    );
+  };

--- a/src/components/content/timeline/helpers/modal-hooks.tsx
+++ b/src/components/content/timeline/helpers/modal-hooks.tsx
@@ -1,18 +1,14 @@
 import { useResourceDetailsDrawer } from "../../resource/resource-details-drawer";
 import { CodingList } from "@/components/core/coding-list";
 import { EncounterModel } from "@/fhir/models/encounter";
-import { useFQSFeatureToggle } from "@/hooks/use-feature-toggle";
 import { capitalize } from "@/utils/nodash/fp";
 
 export function usePatientEncounterDetailsDrawer() {
-  const { enabled } = useFQSFeatureToggle("encounters");
-
   return useResourceDetailsDrawer({
     header: (m) => `${m.periodStart} - ${m.periodEnd}`,
     subHeader: (m) => m.typeDisplay,
     getSourceDocument: true,
     details: encounterData,
-    enableFQS: enabled,
   });
 }
 

--- a/src/components/core/drawer.scss
+++ b/src/components/core/drawer.scss
@@ -1,0 +1,8 @@
+.ctw-drawer {
+  .ctw-footer {
+    // Boost font size for footer buttons.
+    button {
+      @apply ctw-text-base;
+    }
+  }
+}

--- a/src/components/core/drawer.tsx
+++ b/src/components/core/drawer.tsx
@@ -45,8 +45,6 @@ export function Drawer({
 }: DrawerProps) {
   const transitionClasses = "ctw-transform ctw-transition ctw-ease-in-out ctw-duration-300";
 
-  console.log("core drawer className", className);
-
   return (
     <Transition.Root show={isOpen} as={Fragment}>
       <Dialog

--- a/src/components/core/drawer.tsx
+++ b/src/components/core/drawer.tsx
@@ -1,3 +1,5 @@
+import "./drawer.scss";
+
 import { Dialog, Transition } from "@headlessui/react";
 import { XIcon } from "@heroicons/react/outline";
 import cx from "classnames";
@@ -43,12 +45,14 @@ export function Drawer({
 }: DrawerProps) {
   const transitionClasses = "ctw-transform ctw-transition ctw-ease-in-out ctw-duration-300";
 
+  console.log("core drawer className", className);
+
   return (
     <Transition.Root show={isOpen} as={Fragment}>
       <Dialog
         as="div"
         data-zus-telemetry-namespace={`Drawer[${title}]`}
-        className={cx("ctw-relative ctw-z-[10000]", className)}
+        className={cx("ctw-drawer ctw-relative ctw-z-[10000]", className)}
         onClose={() => {
           if (!disableCloseOnBlur) {
             onClose();
@@ -123,7 +127,7 @@ export function Drawer({
 }
 
 Drawer.Footer = ({ children }: { children: ReactNode }) => (
-  <div className="ctw-border-default ctw-border-t ctw-p-6">{children}</div>
+  <div className="ctw-footer ctw-border-default ctw-border-t ctw-p-6">{children}</div>
 );
 
 Drawer.CloseButton = ({ label, onClose }: { label: string; onClose: () => void }) => (

--- a/src/components/core/table/table-rows.tsx
+++ b/src/components/core/table/table-rows.tsx
@@ -1,13 +1,18 @@
 import cx from "classnames";
-import { ComponentType, ReactElement } from "react";
+import { FunctionComponent, ReactElement } from "react";
 import { TableDataCell } from "./table-data-cell";
 import { TableFullLengthRow } from "./table-full-length-row";
 import { MinRecordItem, TableColumn } from "./table-helpers";
 import { Spinner } from "../spinner";
 import { isFunction } from "@/utils/nodash";
 
+export type RowActionsProp<T extends MinRecordItem> = FunctionComponent<{
+  record: T;
+  onSuccess?: () => void;
+}>;
+
 export type TableRowsProps<T extends MinRecordItem> = {
-  RowActions?: ComponentType<{ record: T }>;
+  RowActions?: RowActionsProp<T>;
   columns: TableColumn<T>[];
   emptyMessage: string | ReactElement;
   getRowClassName?: (record: T) => cx.Argument;

--- a/src/components/core/table/table.tsx
+++ b/src/components/core/table/table.tsx
@@ -8,7 +8,7 @@ import { MinRecordItem, TableColumn } from "./table-helpers";
 import { TableRows, TableRowsProps } from "./table-rows";
 import { DEFAULT_PAGE_SIZE, PaginationList } from "../pagination/pagination-list";
 
-export type RowActionsProps<T extends MinRecordItem> = { record: T };
+export type RowActionsProps<T extends MinRecordItem> = { record: T; onSuccess?: () => void };
 
 export type TableProps<T extends MinRecordItem> = {
   children?: ReactNode;

--- a/src/fhir/basic.ts
+++ b/src/fhir/basic.ts
@@ -124,7 +124,7 @@ export async function toggleDismiss<T extends fhir4.Resource>(
 ) {
   const existingBasic = model.getLatestBasicResourceByActions(["archive", "unarchive"]);
   const profileAction = model.isDismissed ? "unarchive" : "archive";
-
+  model.optimisticToggleIsDismiss();
   await recordProfileAction(existingBasic, model, requestContext, profileAction);
 }
 
@@ -134,7 +134,7 @@ export async function toggleRead<T extends fhir4.Resource>(
 ) {
   const existingBasic = model.getLatestBasicResourceByActions(["read", "unread"]);
   const profileAction = model.isRead ? "unread" : "read";
-
+  model.optimisticToggleIsRead();
   await recordProfileAction(existingBasic, model, requestContext, profileAction);
 }
 


### PR DESCRIPTION
Reworked row actions and plumbed them to the details drawer. This way details drawer will always show the same actions as shown on row hover.

Additionally:
* Reworked row actions to optionally take an `onSuccess` prop so that we can close the drawer for certain actions (dismiss/mark as new/remove).
* Refactored the addition of dismiss & read actions into `useAdditionalResourceActions` so that it can be used by both the `ResourceTable` and `ResourceDetailsDrawer`.
* Reworked dismiss/restore and read/new to update the model record optimistically. This fixes a bug where the row action button on hover would briefly show the old state after the spinner was done. It also allows us to mark a record as read and not wait before opening the drawer. The drawer will then correctly render a "mark as new" button and not a "mark as viewed" button.
* Reworked rendering of row actions to return null if there are no row actions. This allows the details drawer footer to be hidden when there are zero row actions.
* Details drawer was previously taking `enableFQS` but not doing anything with it. Removed!

<img width="571" alt="Screenshot 2023-07-21 at 1 13 31 PM" src="https://github.com/zeus-health/ctw-component-library/assets/1568246/9f3af0e9-5c22-42a4-8183-959fe0f41cb0">
