### PR TITLE
Only toggle read on add if not already read

### DIFF
--- a/.changeset/tidy-meals-explain.md
+++ b/.changeset/tidy-meals-explain.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Only toggle read when adding a condition or medication if the record is not yet marked as having been read.

--- a/src/components/content/conditions/patient-conditions-all.tsx
+++ b/src/components/content/conditions/patient-conditions-all.tsx
@@ -133,7 +133,9 @@ const getRowActions =
           type="button"
           className="ctw-btn-primary"
           onClick={() => {
-            toggleRead(record);
+            if (!record.isRead) {
+              toggleRead(record);
+            }
             showAddConditionForm(record);
           }}
         >

--- a/src/components/content/medications/patient-medications-all.tsx
+++ b/src/components/content/medications/patient-medications-all.tsx
@@ -95,7 +95,9 @@ const getRowActions =
           type="button"
           className="ctw-btn-primary"
           onClick={() => {
-            toggleRead(record);
+            if (!record.isRead) {
+              toggleRead(record);
+            }
             if (onAddToRecord) {
               onAddToRecord(record);
             } else {


### PR DESCRIPTION
This fixes a bug where an already read record could get marked as unread when hitting the "Add" row action.