### PR TITLE
Fix capitalization for resource table title/description column

### DIFF
--- a/.changeset/hot-doors-approve.md
+++ b/.changeset/hot-doors-approve.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix capitalization logic for resource table titles.

--- a/src/components/content/diagnostic-reports/helpers/columns.tsx
+++ b/src/components/content/diagnostic-reports/helpers/columns.tsx
@@ -15,6 +15,7 @@ export const patientDiagnosticReportsColumns = (
       <ResourceTitleColumn
         title={diagnostic.displayName}
         ownedByBuilder={diagnostic.ownedByBuilder(builderId)}
+        capitalizeTitle={false}
       />
     ),
   },

--- a/src/components/content/resource/helpers/resource-title-column.tsx
+++ b/src/components/content/resource/helpers/resource-title-column.tsx
@@ -1,6 +1,5 @@
 import { faCircleCheck } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { capitalize } from "@/utils/nodash";
 
 export type ResourceTitleColumnProps = {
   title?: string;
@@ -13,11 +12,10 @@ export const ResourceTitleColumn = ({
   title,
   subTitle,
   ownedByBuilder,
-  capitalizeTitle = true,
 }: ResourceTitleColumnProps) => (
   <div>
     <div className="ctw-flow-root group-hover:ctw-underline">
-      {capitalizeTitle ? capitalize(title) : title}
+      {title}
       <span className="ctw-float-right">
         {ownedByBuilder ? (
           <FontAwesomeIcon className="ctw-text-content-light" icon={faCircleCheck} />

--- a/src/fhir/models/allergies.ts
+++ b/src/fhir/models/allergies.ts
@@ -4,7 +4,7 @@ import { findReference } from "../resource-helper";
 import { SYSTEM_NDC, SYSTEM_RXNORM, SYSTEM_SNOMED } from "../system-urls";
 import { codeableConceptLabel, CodePreference, findCoding } from "@/fhir/codeable-concept";
 import { displayOnset } from "@/fhir/display-onset";
-import { compact, uniqWith } from "@/utils/nodash";
+import { capitalize, compact, uniqWith } from "@/utils/nodash";
 
 export class AllergyModel extends FHIRModel<fhir4.AllergyIntolerance> {
   kind = "Allergy" as const;
@@ -26,7 +26,7 @@ export class AllergyModel extends FHIRModel<fhir4.AllergyIntolerance> {
   }
 
   get display(): string | undefined {
-    return codeableConceptLabel(this.resource.code);
+    return capitalize(codeableConceptLabel(this.resource.code));
   }
 
   get lowercaseDisplay(): string {

--- a/src/fhir/models/condition.ts
+++ b/src/fhir/models/condition.ts
@@ -26,7 +26,7 @@ import {
   findCodingByOrderOfPreference,
   findCodingWithEnrichment,
 } from "@/fhir/codeable-concept";
-import { compact, find, intersectionWith, uniqWith } from "@/utils/nodash";
+import { capitalize, compact, find, intersectionWith, uniqWith } from "@/utils/nodash";
 
 type VerificationStatus =
   | "unconfirmed"
@@ -137,9 +137,9 @@ export class ConditionModel extends FHIRModel<fhir4.Condition> {
   }
 
   get display(): string | undefined {
-    return (
+    return capitalize(
       findCodingByOrderOfPreference(CONDITION_CODE_PREFERENCE_ORDER, this.resource.code)?.display ??
-      codeableConceptLabel(this.resource.code)
+        codeableConceptLabel(this.resource.code)
     );
   }
 

--- a/src/fhir/models/document.ts
+++ b/src/fhir/models/document.ts
@@ -3,6 +3,7 @@ import { FHIRModel } from "./fhir-model";
 import { codeableConceptLabel } from "../codeable-concept";
 import { formatISODateStringToDate } from "../formatters";
 import { findReference } from "../resource-helper";
+import { capitalize } from "@/utils/nodash";
 
 export class DocumentModel extends FHIRModel<fhir4.DocumentReference> {
   kind = "Document" as const;
@@ -34,7 +35,7 @@ export class DocumentModel extends FHIRModel<fhir4.DocumentReference> {
   }
 
   get title(): string | undefined {
-    return this.resource.content[0].attachment.title;
+    return capitalize(this.resource.content[0].attachment.title);
   }
 
   get dateCreated(): string | undefined {


### PR DESCRIPTION
Our default behavior was to capitalize the resource table title but that's really a very case-by-case decision. Labs/immz/meds all have strings that don't make sense when you generically apply the lodash capitalize function. So this PR removes that behavior from the title component and leaves it up to the model getter to decide how to capitalize.