### PR TITLE
CDEV-350: Adding support for contained resources to Diagnostics Report Drawer

### DIFF
--- a/.changeset/six-buttons-yawn.md
+++ b/.changeset/six-buttons-yawn.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Added support for contained resources to Diagnostics Report Drawer

--- a/src/fhir/models/diagnostic-report.ts
+++ b/src/fhir/models/diagnostic-report.ts
@@ -28,7 +28,7 @@ export class DiagnosticReportModel extends FHIRModel<fhir4.DiagnosticReport> {
       this.observationModels = this.resource.result?.map((result) => {
         const reference = findReference(
           "Observation",
-          resource.contained.map((r) => r.resource),
+          resource.contained,
           includedResources,
           result
         );

--- a/src/fhir/models/diagnostic-report.ts
+++ b/src/fhir/models/diagnostic-report.ts
@@ -26,10 +26,17 @@ export class DiagnosticReportModel extends FHIRModel<fhir4.DiagnosticReport> {
     if (resource.id) {
       const resourceId = resource.id;
       this.observationModels = this.resource.result?.map((result) => {
-        // @ts-ignore: Unreachable code error
+        const reference = findReference(
+          "Observation",
+          resource.contained.map((r) => r.resource),
+          includedResources,
+          result
+        );
+
+        // @ts-ignore
         // We are disabling it for this line as the FHIR spec doesn't support this
         // customized result field that now has the observation resource and not only just a reference.
-        const model = new ObservationModel(result.resource, {
+        const model = new ObservationModel(result.resource || reference, {
           [resourceId]: resource,
         });
 

--- a/src/services/fqs/queries/diagnostic-reports-query.ts
+++ b/src/services/fqs/queries/diagnostic-reports-query.ts
@@ -102,40 +102,7 @@ export const diagnosticReportQuery = gql`
           }
           contained {
             resource {
-              ... on Observation {
-                id
-                resourceType
-                status
-                category {
-                  text
-                  coding {
-                    code
-                    display
-                    system
-                    extension {
-                      url
-                      valueString
-                    }
-                  }
-                }
-                effectivePeriod {
-                  start
-                  end
-                }
-                effectiveDateTime
-                interpretation {
-                  text
-                  coding {
-                    code
-                    display
-                    system
-                    extension {
-                      url
-                      valueString
-                    }
-                  }
-                }
-              }
+              ...Observation
             }
           }
         }


### PR DESCRIPTION
https://zeushealth.atlassian.net/browse/CDEV-350

The Diagnostics Report Drawer was erroring out when loading Diagnostic Reports that had contained Observations. This PR:

1. Updates the Diagnostics Report FQS query to include all fields required by the Diagnostics Report Drawer
2. Updates the Diagnostics Report model to **additionally** populate Observations from contained Observations
3. **Updates the `findReference` resource helper to support finding contained resources in GraphQL responses, as previously it would not properly traverse these nodes... GraphQL contained resources are nested another level deep when compared to the previous ODS contained resource responses**