### PR TITLE
CDEV-358 Self-adjusting alignment of dropdown for tab groups

### DIFF
--- a/.changeset/seven-points-cough.md
+++ b/.changeset/seven-points-cough.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+The dropdown for hidden tabs will re-align themselves if there's no room to their right.

--- a/src/components/core/tab-group/tab-group.tsx
+++ b/src/components/core/tab-group/tab-group.tsx
@@ -53,7 +53,7 @@ function TabGroupComponent({
   // https://github.com/tailwindlabs/headlessui/issues/2276#issuecomment-1456537475
   const [shown, setShown] = useState<Record<number, boolean>>({ 0: true });
 
-  // Calculate how many tabs can fit in the container.
+  // Calculate how many tabs can fit in the container,
   useEffect(() => {
     // Force everything into the more menu if we are in a small breakpoint
     // and we are not forcing horizontal tabs.
@@ -105,6 +105,7 @@ function TabGroupComponent({
   };
 
   const showTopRightContent = !!topRightContent;
+  const shownContent = content.slice(tabOverflowCutoff);
 
   return (
     <div
@@ -159,9 +160,12 @@ function TabGroupComponent({
                   "after:ctw-bg-content-black": selectedTabIndex - tabOverflowCutoff >= 0,
                 }
               )}
-              optionsClassName="ctw-tab-list ctw-capitalize"
+              optionsClassName={cx(
+                "ctw-tab-list ctw-capitalize",
+                !showTopRightContent && shownContent.length > 1 && "ctw-right-0" // Right-align dropdown if it is rightmost (and not leftmost)
+              )}
               onChange={(index) => handleOnChange(index + tabOverflowCutoff)}
-              items={content.slice(tabOverflowCutoff)}
+              items={shownContent}
             >
               {tabOverflowCutoff !== 0 ? <span>More</span> : undefined}
             </ListBox>


### PR DESCRIPTION
CDEV-358

# Issue
We want to avoid drop down menus for tab groups getting cut off on the right, by making them right-aligned when necessary.
![image](https://github.com/zeus-health/ctw-component-library/assets/33408946/7d5494ba-4000-4a80-97dc-a760f8759ff0)

# Solution
The class `ctw-right-0` is added to right-align the dropdown except in the following conditions:
- If the drop down is not on the rightside edge because of a non-tab element, it looks better left-aligned
![image](https://github.com/zeus-health/ctw-component-library/assets/33408946/cf166af0-be3d-4f59-acf3-3cb23be6dff4)
- If the drop down is on the left side, we want it to be left-aligned
![image](https://github.com/zeus-health/ctw-component-library/assets/33408946/82e1275a-2f4e-45ea-8900-072cd55a1c62)