### PR TITLE
CDEV-356/Add telemetry to track clicking trends

### DIFF
--- a/.changeset/spicy-dingos-mix.md
+++ b/.changeset/spicy-dingos-mix.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Add ability to track trend activity.

--- a/src/components/content/observations/helpers/trends.tsx
+++ b/src/components/content/observations/helpers/trends.tsx
@@ -50,9 +50,15 @@ export const ObservationTrends = ({ model }: ObservationTrendsProps) => {
                     className={cx("ctw-group/trends ctw-grid ctw-grid-cols-3 ctw-py-1 ctw-pl-4", {
                       "ctw-cursor-pointer hover:ctw-bg-bg-lighter": trend.diagnosticReport,
                     })}
-                    onClick={() =>
-                      trend.diagnosticReport && openDiagnosticReportDetails(trend.diagnosticReport)
-                    }
+                    onClick={() => {
+                      Telemetry.trackInteraction(
+                        trend.diagnosticReport ? "trendClicked" : "noTrend"
+                      );
+                      return (
+                        trend.diagnosticReport &&
+                        openDiagnosticReportDetails(trend.diagnosticReport)
+                      );
+                    }}
                     onKeyDown={(e) =>
                       e.key === "Enter" &&
                       trend.diagnosticReport &&


### PR DESCRIPTION
This PR adds the capability to track when a trend has been clicked. 