### PR TITLE
Cdev 292 dont show unrenderable source documents

### DIFF
--- a/.changeset/chatty-parrots-clap.md
+++ b/.changeset/chatty-parrots-clap.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+In drawers, do not show the Source Document link when the document is not renderable.

--- a/.changeset/poor-paws-fry.md
+++ b/.changeset/poor-paws-fry.md
@@ -1,5 +1,0 @@
----
-"@zus-health/ctw-component-library": patch
----
-
-In drawers, do not show the Source Document link when the document is not renderable.

--- a/.changeset/poor-paws-fry.md
+++ b/.changeset/poor-paws-fry.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+In drawers, do not show the Source Document link when the document is not renderable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "1.47.2",
+  "version": "1.49.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "1.47.2",
+      "version": "1.49.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -41996,7 +41996,7 @@
           "dev": true,
           "requires": {
             "follow-redirects": "^1.15.0",
-            "form-data": "4.0.0",
+            "form-data": "^4.0.0",
             "proxy-from-env": "^1.1.0"
           }
         },
@@ -46439,7 +46439,7 @@
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "form-data": "4.0.0"
+        "form-data": "^3.0.0"
       }
     },
     "@types/normalize-package-data": {
@@ -51851,7 +51851,7 @@
         "@graphql-typed-document-node/core": "^3.1.1",
         "cross-fetch": "^3.1.5",
         "extract-files": "^9.0.0",
-        "form-data": "4.0.0"
+        "form-data": "^3.0.0"
       }
     },
     "gunzip-maybe": {
@@ -55780,7 +55780,7 @@
         "decimal.js": "^10.4.2",
         "domexception": "^4.0.0",
         "escodegen": "^2.0.0",
-        "form-data": "4.0.0",
+        "form-data": "^4.0.0",
         "html-encoding-sniffer": "^3.0.0",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.1",

--- a/src/components/content/document/helpers/filters.test.ts
+++ b/src/components/content/document/helpers/filters.test.ts
@@ -1,4 +1,5 @@
-import { applyDocumentFilters, THIRD_PARTY_SOURCE_SYSTEM, ZUS_CREATION_DATE_URL } from "./filters";
+import { applyDocumentFilters, ZUS_CREATION_DATE_URL } from "./filters";
+import { THIRD_PARTY_SOURCE_SYSTEM } from "../../resource/helpers/filters";
 import { DocumentModel } from "@/fhir/models/document";
 
 interface SyntheticDocRefProps {

--- a/src/components/content/document/helpers/filters.ts
+++ b/src/components/content/document/helpers/filters.ts
@@ -1,9 +1,9 @@
 import { dismissFilter } from "../../resource/filters";
+import { isRenderableBinary } from "../../resource/helpers/filters";
 import { FilterChangeEvent, FilterItem } from "@/components/core/filter-bar/filter-bar-types";
 import { DocumentModel } from "@/fhir/models/document";
 import { isEqual, uniqWith } from "@/utils/nodash";
 
-export const THIRD_PARTY_SOURCE_SYSTEM = "https://zusapi.com/thirdparty/source";
 export const ZUS_CREATION_DATE_URL = "https://zusapi.com/created-at";
 const RAINBOW_CUTOVER_DATE = new Date("2023-03-08T05:00:00.000Z");
 
@@ -44,12 +44,6 @@ const isViewablePostRainbow = (docRef: fhir4.DocumentReference) => {
 export function isSectionDocument(document: DocumentModel) {
   return document.category && document.category.length < 2;
 }
-
-export const isRenderableBinary = (doc: fhir4.DocumentReference): boolean => {
-  const thirdPartyTag = doc.meta?.tag?.find((tag) => tag.system === THIRD_PARTY_SOURCE_SYSTEM);
-  const isSupportedThirdParty = ["commonwell", "carequality"].includes(thirdPartyTag?.code || "");
-  return isSupportedThirdParty;
-};
 
 export const applyDocumentFilters = (data: DocumentModel[]) => {
   const documentModels = data.filter(

--- a/src/components/content/document/helpers/filters.ts
+++ b/src/components/content/document/helpers/filters.ts
@@ -45,7 +45,7 @@ export function isSectionDocument(document: DocumentModel) {
   return document.category && document.category.length < 2;
 }
 
-const isRenderableBinary = (doc: fhir4.DocumentReference): boolean => {
+export const isRenderableBinary = (doc: fhir4.DocumentReference): boolean => {
   const thirdPartyTag = doc.meta?.tag?.find((tag) => tag.system === THIRD_PARTY_SOURCE_SYSTEM);
   const isSupportedThirdParty = ["commonwell", "carequality"].includes(thirdPartyTag?.code || "");
   return isSupportedThirdParty;

--- a/src/components/content/resource/helpers/filters.ts
+++ b/src/components/content/resource/helpers/filters.ts
@@ -1,0 +1,7 @@
+export const THIRD_PARTY_SOURCE_SYSTEM = "https://zusapi.com/thirdparty/source";
+
+export const isRenderableBinary = (doc: fhir4.Resource): boolean => {
+  const thirdPartyTag = doc.meta?.tag?.find((tag) => tag.system === THIRD_PARTY_SOURCE_SYSTEM);
+  const isSupportedThirdParty = ["commonwell", "carequality"].includes(thirdPartyTag?.code || "");
+  return isSupportedThirdParty;
+};

--- a/src/components/content/resource/resource-details-drawer.tsx
+++ b/src/components/content/resource/resource-details-drawer.tsx
@@ -4,7 +4,6 @@ import { Notes } from "./helpers/notes";
 import { useAdditionalResourceActions } from "./use-additional-resource-actions";
 import { DocumentButton } from "../CCDA/document-button";
 import { useCCDAModal } from "../CCDA/modal-ccda";
-import { isRenderableBinary } from "../document/helpers/filters";
 import { DetailsCard, DetailsProps } from "@/components/content/resource/helpers/details-card";
 import { Drawer } from "@/components/core/drawer";
 import { Loading } from "@/components/core/loading";
@@ -93,6 +92,7 @@ function ResourceDetailsDrawer<T extends fhir4.Resource, M extends FHIRModel<T>>
     }
 
     if (model instanceof DocumentModel) {
+      console.log("model instanceof DocumentModel");
       // Special handling for document models which already have a binaryID.
       setBinaryId(model.binaryId);
     } else if (getSourceDocument && fqsProvenances.ready) {
@@ -125,9 +125,7 @@ function ResourceDetailsDrawer<T extends fhir4.Resource, M extends FHIRModel<T>>
             <DetailsCard
               details={details(model)}
               documentButton={
-                binaryId &&
-                model instanceof DocumentModel &&
-                isRenderableBinary(model.resource) && (
+                binaryId && (
                   <DocumentButton
                     onClick={() => openCCDAModal(binaryId, model.resourceTypeTitle)}
                     text="Source Document"

--- a/src/components/content/resource/resource-details-drawer.tsx
+++ b/src/components/content/resource/resource-details-drawer.tsx
@@ -92,7 +92,6 @@ function ResourceDetailsDrawer<T extends fhir4.Resource, M extends FHIRModel<T>>
     }
 
     if (model instanceof DocumentModel) {
-      console.log("model instanceof DocumentModel");
       // Special handling for document models which already have a binaryID.
       setBinaryId(model.binaryId);
     } else if (getSourceDocument && fqsProvenances.ready) {

--- a/src/components/content/resource/resource-details-drawer.tsx
+++ b/src/components/content/resource/resource-details-drawer.tsx
@@ -4,6 +4,7 @@ import { Notes } from "./helpers/notes";
 import { useAdditionalResourceActions } from "./use-additional-resource-actions";
 import { DocumentButton } from "../CCDA/document-button";
 import { useCCDAModal } from "../CCDA/modal-ccda";
+import { isRenderableBinary } from "../document/helpers/filters";
 import { DetailsCard, DetailsProps } from "@/components/content/resource/helpers/details-card";
 import { Drawer } from "@/components/core/drawer";
 import { Loading } from "@/components/core/loading";
@@ -92,8 +93,7 @@ function ResourceDetailsDrawer<T extends fhir4.Resource, M extends FHIRModel<T>>
     }
 
     if (model instanceof DocumentModel) {
-      // Special handling for document models
-      // which already have a binaryID.
+      // Special handling for document models which already have a binaryID.
       setBinaryId(model.binaryId);
     } else if (getSourceDocument && fqsProvenances.ready) {
       void load();
@@ -125,7 +125,9 @@ function ResourceDetailsDrawer<T extends fhir4.Resource, M extends FHIRModel<T>>
             <DetailsCard
               details={details(model)}
               documentButton={
-                binaryId && (
+                binaryId &&
+                model instanceof DocumentModel &&
+                isRenderableBinary(model.resource) && (
                   <DocumentButton
                     onClick={() => openCCDAModal(binaryId, model.resourceTypeTitle)}
                     text="Source Document"

--- a/src/fhir/binaries.ts
+++ b/src/fhir/binaries.ts
@@ -1,17 +1,19 @@
 import { Provenance } from "fhir/r4";
+import { isRenderableBinary } from "@/components/content/resource/helpers/filters";
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
 import { find, some } from "@/utils/nodash";
 import { QUERY_KEY_BINARY } from "@/utils/query-keys";
 import { queryClient } from "@/utils/request";
 import { withTimerMetric } from "@/utils/telemetry";
 
+// Get the binary ID from provenance, if document is renderable
 export function getBinaryId(provenances: Provenance[], targetId: string): string | undefined {
   for (let i = 0; i < provenances.length; i += 1) {
     const provenance = provenances[i];
 
     const hasTarget = some(provenance.target, (t) => t.reference?.includes(targetId));
 
-    if (hasTarget) {
+    if (hasTarget && isRenderableBinary(provenance)) {
       const source = find(provenance.entity, { role: "source" });
       if (source?.what.reference) {
         // Return the ID portion of the reference.

--- a/src/services/fqs/queries/provenances.ts
+++ b/src/services/fqs/queries/provenances.ts
@@ -45,6 +45,12 @@ function provenanceQuery(resourceType: ResourceTypeString, targetId: string, ind
     provenance${index}: ${resourceType}(id: "${targetId}") {
       ProvenanceList(_reference: "target") {
         id
+        meta {
+          tag {
+            system
+            code
+          }
+        }
         target {
           reference
         }


### PR DESCRIPTION
CDEV-292
Updated fix without the bug that removed the "Source Document" button for all resources caused by the "instanceof DocumentModel" condition.
Follows Bryan's solution, which can be found in the ticket comments