### PR TITLE
Remove default filter for conditions-all table + changeset

### DIFF
--- a/.changeset/big-falcons-change.md
+++ b/.changeset/big-falcons-change.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Remove default filter from the Conditions table that shows all conditions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "1.56.1",
+  "version": "1.57.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "1.56.1",
+      "version": "1.57.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/content/conditions/patient-conditions-all.tsx
+++ b/src/components/content/conditions/patient-conditions-all.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 import { useMemo } from "react";
 import { patientConditionsAllColumns } from "./helpers/columns";
 import { useConditionDetailsDrawer } from "./helpers/details";
-import { conditionFilters, defaultConditionFilters } from "./helpers/filters";
+import { conditionFilters } from "./helpers/filters";
 import {
   useAddConditionForm,
   useConfirmDeleteCondition,
@@ -76,7 +76,6 @@ function PatientConditionsAllComponent({
         <ResourceTableActions
           filterOptions={{
             onChange: setFilters,
-            defaultState: defaultConditionFilters,
             filters: conditionFilters(
               query.data,
               true,


### PR DESCRIPTION
CDEV-368

Previously I removed the default filter in the base Conditions table, a component used by some of the displayed Conditions tables but not `conditions-all`. This PR removes it from `conditions-all`.