### PR TITLE
Allow Unread Encounters Notification Icon to Appear Outside of Components

### DIFF
--- a/.changeset/strong-beers-sneeze.md
+++ b/.changeset/strong-beers-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Allow the unread encounters notification icon to show up outside of the components.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export * from "@/components/content/document/patient-documents";
 export * from "@/components/content/document/unread-documents-notification";
 export * from "@/components/content/forms/actions/patients";
 export * from "@/components/content/encounters/patient-encounters";
+export * from "@/components/content/encounters/unread-encounters-notification";
 export * from "@/components/content/immunizations/patient-immunizations";
 export * from "@/components/content/immunizations/unread-immunizations-notification";
 export * from "@/components/content/medications/patient-medications";


### PR DESCRIPTION
Currently the red dot is missing from CTW's side tab for Encounters & Notes. This exports the component, allowing it to be used in the standalone app.