### PR TITLE
CTW-1348/Embedded ZAP custom fonts

### DIFF
--- a/.changeset/purple-emus-relax.md
+++ b/.changeset/purple-emus-relax.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+CTWProvider theme now accepts optional `iframe` theming to support custom fonts for the embedded ZAP.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import "./App.css";
 
 import {
   CTWProvider,
+  IFrameTheme,
   PatientAllergies,
   PatientConditions,
   PatientConditionsOutside,
@@ -54,12 +55,17 @@ type DemoComponent = {
 const componentsToRender = VITE_DEMO_APP_COMPONENTS.split(",").map(trim);
 
 // Feel free to play with this theme object
-const theme: Theme = {
+const theme: Theme & { iframe?: IFrameTheme } = {
   colors: {
     notification: {
       main: "#a855f7",
       light: "#f3e8ff",
     },
+  },
+  iframe: {
+    fontFamily: "Roboto",
+    fontSize: "16px",
+    lineHeight: "1.5",
   },
 };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,6 @@ import "./App.css";
 
 import {
   CTWProvider,
-  IFrameTheme,
   PatientAllergies,
   PatientConditions,
   PatientConditionsOutside,
@@ -26,7 +25,6 @@ import {
   ZusAggregatedProfileIFrame,
 } from ".";
 
-import { Theme } from "@/styles/tailwind.theme";
 import { PatientMedicationDispense } from "./components/content/medication-dispense/patient-medication-dispense";
 import { PatientsADTAlertsTable } from "./components/content/table/patient-adt-alerts-table";
 import { ThemeProviderProps } from "@/components/core/providers/theme/theme-provider";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import {
 import { Theme } from "@/styles/tailwind.theme";
 import { PatientMedicationDispense } from "./components/content/medication-dispense/patient-medication-dispense";
 import { PatientsADTAlertsTable } from "./components/content/table/patient-adt-alerts-table";
+import { ThemeProviderProps } from "@/components/core/providers/theme/theme-provider";
 
 const {
   VITE_AUTH0_AUDIENCE,
@@ -55,7 +56,7 @@ type DemoComponent = {
 const componentsToRender = VITE_DEMO_APP_COMPONENTS.split(",").map(trim);
 
 // Feel free to play with this theme object
-const theme: Theme & { iframe?: IFrameTheme } = {
+const theme: ThemeProviderProps["theme"] = {
   colors: {
     notification: {
       main: "#a855f7",

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
@@ -11,7 +11,7 @@ import { useCTW } from "@/components/core/providers/use-ctw";
 
 // Theming for iframe which can't be handled via global tailwind theme
 export type IFrameTheme = {
-  fontFamily?: "Inter" | "Avenir" | "Roboto";
+  fontFamily?: "Avenir" | "Roboto";
   fontSize?: string;
   lineHeight?: string;
 };

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
@@ -9,6 +9,13 @@ import { useTelemetry } from "@/components/core/providers/telemetry/use-telemetr
 import { useTheme } from "@/components/core/providers/theme/use-theme";
 import { useCTW } from "@/components/core/providers/use-ctw";
 
+// Theming for iframe which can't be handled via global tailwind theme
+export type IFrameTheme = {
+  fontFamily?: "Avenir" | "Roboto";
+  fontSize?: string;
+  lineHeight?: string;
+};
+
 export const ZusAggregatedProfileIFrameConfigMessageType = "ZusAggregatedProfileIFrameConfig";
 export const ZusAggregatedProfileIFrameReadyMessageType = "ZusAggregatedProfileIFrameReady";
 export const ZusAggregatedProfileOnResourceSaveMessageType = "ZusAggregatedProfileOnResourceSave";
@@ -81,6 +88,7 @@ const ZusAggregatedProfileIFrameComponent = (props: ZusAggregatedProfileProps) =
             CTWProviderProps: ctwProviderProps,
             PatientProviderProps: patientProviderProps,
             ZusAggregatedProfileProps: props,
+            iframeTheme: theme.iframeTheme,
           },
         },
         zapURL as string
@@ -105,6 +113,7 @@ const ZusAggregatedProfileIFrameComponent = (props: ZusAggregatedProfileProps) =
     theme.locals,
     telemetry.enableTelemetry,
     telemetry.ehr,
+    theme.iframeTheme,
   ]);
 
   if (!zapURL) {

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
@@ -11,7 +11,7 @@ import { useCTW } from "@/components/core/providers/use-ctw";
 
 // Theming for iframe which can't be handled via global tailwind theme
 export type IFrameTheme = {
-  fontFamily?: "Avenir" | "Roboto";
+  fontFamily?: "Inter" | "Avenir" | "Roboto";
   fontSize?: string;
   lineHeight?: string;
 };

--- a/src/components/core/providers/theme/context.ts
+++ b/src/components/core/providers/theme/context.ts
@@ -1,9 +1,11 @@
 import { createContext, createRef, RefObject } from "react";
+import { IFrameTheme } from "@/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe";
 import { Locals } from "@/i18n";
 import { DefaultTheme, Theme } from "@/styles/tailwind.theme";
 
 export interface ThemeContextValue {
   theme: Required<Theme>;
+  iframeTheme?: IFrameTheme;
   ctwThemeRef: RefObject<HTMLDivElement>;
   locals?: Locals;
 }

--- a/src/components/core/providers/theme/theme-provider.tsx
+++ b/src/components/core/providers/theme/theme-provider.tsx
@@ -1,12 +1,13 @@
 import { PropsWithChildren, useEffect, useMemo, useRef, useState } from "react";
 import { ThemeContext } from "./context";
+import { IFrameTheme } from "@/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe";
 import i18next, { Locals } from "@/i18n";
 import { DefaultTheme, EmptyTailwindCSSVars, mapToCSSVar, Theme } from "@/styles/tailwind.theme";
 import { merge } from "@/utils/nodash";
 import "../../main.scss";
 
 export type ThemeProviderProps = {
-  theme?: Theme;
+  theme?: Theme & { iframe?: IFrameTheme };
   locals?: Locals;
 };
 
@@ -74,18 +75,19 @@ export function ThemeProvider({
     }
   }, [locals]);
 
-  const contextValue = useMemo(
-    () => ({
+  const contextValue = useMemo(() => {
+    const { iframe, ...tailwindTheme } = theme;
+    return {
       // Set our context theme to our default theme merged
       // with any of the provided theme overwrites.
       // This way consumers of useTheme can get access to
       // the full true theme being applied.
-      theme: merge({}, DefaultTheme, theme),
+      theme: merge({}, DefaultTheme, tailwindTheme),
+      iframeTheme: iframe,
       ctwThemeRef,
       locals,
-    }),
-    [theme, locals, ctwThemeRef]
-  );
+    };
+  }, [theme, locals, ctwThemeRef]);
 
   return (
     <div ref={ctwThemeRef} className="ctw-theme ctw-scrollable-pass-through-height">


### PR DESCRIPTION
The theme passed to the CTWProvider now allows for an optional `iframe` attribute which includes theming that can't be accomplished via tailwind as it is currently. The `iframe` theme has 3 optional properties fontFamily, fontSize and lineHeight which can be used to make the iframe embedded ZAP look more like the rest of the webapp.