### PR TITLE
Cdev 318 deduplicate encounters in encounters notes component

### DIFF
--- a/.changeset/curly-tomatoes-rest.md
+++ b/.changeset/curly-tomatoes-rest.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Dedupes encounters.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "1.57.0",
+  "version": "1.57.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "1.57.0",
+      "version": "1.57.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/content/encounters/helpers/filters.test.ts
+++ b/src/components/content/encounters/helpers/filters.test.ts
@@ -1,6 +1,8 @@
 import { vi } from "vitest";
-import { dedupeAndMergeEncounters } from "./filters";
+import { dedupeAndMergeEncounters, noteTypePredicate, noteTypeValues } from "./filters";
+import { DocumentModel } from "@/fhir/models/document";
 import { EncounterModel } from "@/fhir/models/encounter";
+import { SYSTEM_LOINC } from "@/fhir/system-urls";
 
 describe("encounter dedupe tests", () => {
   const encNew = new EncounterModel(
@@ -233,10 +235,6 @@ describe("encounter dedupe tests", () => {
     ]);
   });
 });
-import { noteTypePredicate, noteTypeValues } from "./filters";
-import { DocumentModel } from "@/fhir/models/document";
-import { EncounterModel } from "@/fhir/models/encounter";
-import { SYSTEM_LOINC } from "@/fhir/system-urls";
 
 describe("noteTypePredicate", () => {
   const docs = noteTypeValues.flatMap((values) =>

--- a/src/components/content/encounters/helpers/filters.test.ts
+++ b/src/components/content/encounters/helpers/filters.test.ts
@@ -1,0 +1,235 @@
+import { vi } from "vitest";
+import { dedupeAndMergeEncounters } from "./filters";
+import { EncounterModel } from "@/fhir/models/encounter";
+
+describe("encounter dedupe tests", () => {
+  const encNew = new EncounterModel(
+    {
+      resourceType: "Encounter",
+      id: "2",
+      meta: {
+        extension: [
+          {
+            url: "https://zusapi.com/created-at",
+            valueInstant: "2022-10-13T20:22:32.613+00:00",
+          },
+        ],
+        lastUpdated: "2022-10-30T04:03:11.968+00:00",
+      },
+      status: "finished",
+      type: [],
+      class: {
+        system: "urn:oid:2.16.840.1.113883.5.4",
+        code: "AMB",
+        display: "Travel",
+      },
+      subject: {
+        reference: "Patient/a1",
+        type: "Patient",
+        display: "FirstName LastName",
+      },
+      period: {
+        start: "2022-09-01",
+      },
+      location: [
+        {
+          location: {
+            display: "Main Street Medical",
+          },
+        },
+      ],
+    },
+    [],
+    []
+  );
+  vi.spyOn(encNew, "patientUPID", "get").mockReturnValue("a1");
+
+  const encOld = new EncounterModel(
+    {
+      resourceType: "Encounter",
+      id: "1",
+      meta: {
+        extension: [
+          {
+            url: "https://zusapi.com/created-at",
+            valueInstant: "2022-10-13T20:22:32.613+00:00",
+          },
+        ],
+      },
+      status: "finished",
+      type: [],
+      class: {
+        system: "urn:oid:2.16.840.1.113883.5.4",
+        code: "AMB",
+        display: "Travel",
+      },
+      subject: {
+        reference: "Patient/a1",
+        type: "Patient",
+        display: "First Last",
+      },
+      period: {
+        start: "2022-09-01",
+        end: "2022-10-24",
+      },
+      location: [
+        {
+          location: {
+            display: "Main Street Medical",
+          },
+        },
+      ],
+    },
+    [],
+    []
+  );
+  vi.spyOn(encOld, "patientUPID", "get").mockReturnValue("a1");
+
+  const encPatientless = new EncounterModel(
+    {
+      resourceType: "Encounter",
+      id: "3",
+      meta: {
+        extension: [
+          {
+            url: "https://zusapi.com/created-at",
+            valueInstant: "2022-10-13T20:22:32.613+00:00",
+          },
+        ],
+        versionId: "2",
+        lastUpdated: "2022-10-30T04:03:11.968+00:00",
+        source: "#s9F0aITJ2AlwfCVw",
+        tag: [
+          {
+            system: "https://zusapi.com/accesscontrol/owner",
+            code: "builder/a",
+          },
+        ],
+      },
+      extension: undefined,
+      status: "finished",
+      type: [],
+      class: {
+        system: "urn:oid:2.16.840.1.113883.5.4",
+        code: "AMB",
+        display: "Travel",
+      },
+      period: {
+        start: "2022-09-01",
+      },
+      location: [
+        {
+          location: {
+            display: "Main Street Medical",
+          },
+        },
+      ],
+    },
+    [],
+    []
+  );
+
+  const encDiff = new EncounterModel(
+    {
+      resourceType: "Encounter",
+      id: "4",
+      meta: {
+        extension: [
+          {
+            url: "https://zusapi.com/created-at",
+            valueInstant: "2022-10-13T20:22:32.613+00:00",
+          },
+        ],
+        versionId: "2",
+        lastUpdated: "2022-10-30T04:03:11.968+00:00",
+        source: "#s9F0aITJ2AlwfCVw",
+        tag: [
+          {
+            system: "https://zusapi.com/accesscontrol/owner",
+            code: "builder/a",
+          },
+        ],
+      },
+      status: "finished",
+      type: [],
+      class: {
+        system: "urn:oid:2.16.840.1.113883.5.4",
+        code: "AMB",
+        display: "Travel",
+      },
+      subject: {
+        reference: "Patient/b2",
+        type: "Patient",
+        display: "First Last",
+      },
+      period: {
+        start: "2022-09-01",
+      },
+      location: [
+        {
+          location: {
+            display: "Side Street Medical",
+          },
+        },
+      ],
+    },
+    [],
+    []
+  );
+
+  vi.spyOn(encDiff, "patientUPID", "get").mockReturnValue("b2");
+
+  test("don't dedupe", () => {
+    const encs = [encOld, encPatientless, encDiff];
+    expect(dedupeAndMergeEncounters(encs)).toEqual(encs);
+  });
+  test("dedupe", () => {
+    const encs = [encOld, encNew];
+    expect(dedupeAndMergeEncounters(encs).length).toBe(1);
+  });
+  test("merge", () => {
+    const encs = [encOld, encNew];
+    expect(dedupeAndMergeEncounters(encs)).toEqual([
+      new EncounterModel(
+        {
+          resourceType: "Encounter",
+          id: "2",
+          meta: {
+            extension: [
+              {
+                url: "https://zusapi.com/created-at",
+                valueInstant: "2022-10-13T20:22:32.613+00:00",
+              },
+            ],
+            lastUpdated: "2022-10-30T04:03:11.968+00:00",
+          },
+          status: "finished",
+          type: [],
+          class: {
+            system: "urn:oid:2.16.840.1.113883.5.4",
+            code: "AMB",
+            display: "Travel",
+          },
+          subject: {
+            reference: "Patient/a1",
+            type: "Patient",
+            display: "FirstName LastName",
+          },
+          period: {
+            start: "2022-09-01",
+            end: "2022-10-24",
+          },
+          location: [
+            {
+              location: {
+                display: "Main Street Medical",
+              },
+            },
+          ],
+        },
+        [],
+        []
+      ),
+    ]);
+  });
+});

--- a/src/components/content/encounters/helpers/filters.tsx
+++ b/src/components/content/encounters/helpers/filters.tsx
@@ -1,5 +1,6 @@
 import { FilterChangeEvent, FilterItem } from "@/components/core/filter-bar/filter-bar-types";
 import { EncounterModel } from "@/fhir/models/encounter";
+import { mergeWith } from "@/utils/nodash";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function encounterFilters(encounters: EncounterModel[] | undefined): FilterItem[] {
@@ -13,3 +14,59 @@ export function encounterFilters(encounters: EncounterModel[] | undefined): Filt
 export const defaultEncounterFilters: FilterChangeEvent = {
   // TODO: filtering on has clinical notes (CDEV-307)
 };
+
+// Dedupes encounters by patient, periodStart, class, type, and location.
+// Merges their properties to maximize information.
+export function dedupeAndMergeEncounters(encounters: EncounterModel[]): EncounterModel[] {
+  const dedupedEncounters: EncounterModel[] = [];
+
+  // Group up the encounters that need to be merged
+  const dupeGroups = new Map<string, EncounterModel[]>();
+  encounters.forEach((encounter) => {
+    if (
+      !encounter.patientUPID ||
+      !encounter.periodStart ||
+      !encounter.class ||
+      !encounter.resource.type ||
+      !encounter.location
+    ) {
+      // Only group it if all necessary values are non-null.
+      dedupedEncounters.push(encounter);
+    } else {
+      const key: string = JSON.stringify({
+        upid: encounter.patientUPID,
+        periodStart: encounter.periodStart || "",
+        class: encounter.resource.class,
+        type: encounter.resource.type,
+        location: encounter.location || "",
+      });
+      const val = dupeGroups.get(key);
+      if (val) {
+        val.push(encounter);
+      } else {
+        dupeGroups.set(key, [encounter]);
+      }
+    }
+  });
+
+  // Merge the encounters in each group
+  dupeGroups.forEach((encs) => {
+    // Sort them to prioritize the most recently updated encounter
+    encs.sort((a, b) => {
+      const aVal = a.lastUpdated ? new Date(a.lastUpdated).valueOf() : 0;
+      const bVal = b.lastUpdated ? new Date(b.lastUpdated).valueOf() : 0;
+      return bVal - aVal;
+    });
+    const mergedEncounter: EncounterModel = encs[0];
+
+    if (encs.length > 1) {
+      const sortedEncResources = encs.map((enc) => enc.resource);
+      // Merge the encounters
+      const mergedResource = sortedEncResources.reduce((merged, curr) => mergeWith(merged, curr));
+      mergedEncounter.resource = mergedResource;
+    }
+    dedupedEncounters.push(mergedEncounter);
+  });
+
+  return dedupedEncounters;
+}

--- a/src/fhir/encounters.ts
+++ b/src/fhir/encounters.ts
@@ -4,6 +4,7 @@ import { PatientModel } from "./models";
 import { DocumentModel } from "./models/document";
 import { EncounterModel } from "./models/encounter";
 import { useQueryWithPatient } from "..";
+import { dedupeAndMergeEncounters } from "@/components/content/encounters/helpers/filters";
 import { CTWRequestContext } from "@/components/core/providers/ctw-context";
 import { createGraphqlClient, fqsRequest } from "@/services/fqs/client";
 import {
@@ -61,7 +62,7 @@ function getEncountersFromFQS(documents: DocumentModel[]) {
         Telemetry.countMetric("req.count.encounters.none", 1);
       }
       Telemetry.histogramMetric("req.count.encounters", results.length);
-      return results;
+      return dedupeAndMergeEncounters(results);
     } catch (e) {
       Telemetry.logError(e as Error, "Failed fetching encounter timeline information for patient");
       throw new Error(`Failed fetching encounter timeline information for patient: ${e}`);

--- a/src/fhir/models/encounter.ts
+++ b/src/fhir/models/encounter.ts
@@ -4,6 +4,7 @@ import { FHIRModel } from "./fhir-model";
 import { codeableConceptLabel } from "../codeable-concept";
 import { formatDateISOToLocal } from "../formatters";
 import { findReference } from "../resource-helper";
+import { SYSTEM_ZUS_CREATED_AT } from "../system-urls";
 import { ResourceMap } from "../types";
 import {
   isEmptyClinicalNote,
@@ -32,6 +33,13 @@ export class EncounterModel extends FHIRModel<fhir4.Encounter> {
         (d) => d.binaryId === binaryID && isSectionDocument(d) && !isEmptyClinicalNote(d)
       );
     }
+  }
+
+  get lastUpdated(): string | undefined {
+    return (
+      this.resource.meta?.lastUpdated ||
+      this.resource.meta?.extension?.find((e) => e.url === SYSTEM_ZUS_CREATED_AT)?.valueDateTime
+    );
   }
 
   get class(): string | undefined {


### PR DESCRIPTION
CDEV-318

Summary of my code:
- Dedupes encounters by certain fields, which are required for deduping. Merges the dupes into one encounter with as many and as recent fields as possible from each dupe.
- Use the deduping/merging every time encounters are fetched.
- Unit tests