### PR TITLE
Fix/open_drawer event should show drawer name

### DIFF
--- a/.changeset/strong-grapes-appear.md
+++ b/.changeset/strong-grapes-appear.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix open_drawer analytic to send drawer name.

--- a/src/components/core/providers/drawer-provider.tsx
+++ b/src/components/core/providers/drawer-provider.tsx
@@ -32,7 +32,7 @@ export function DrawerProvider({ children }: ProviderProps) {
             // Datadog we write the drawer name into the metric name itself (prop ignored by analytics)
             datadogMetricName: `open_drawer.${props.telemetryName ?? ""}`.replace(/(\.)$/, ""),
             // For analytics, we pass the name of the drawer as an event attribute name
-            name: props.telemetryName,
+            value: props.telemetryName,
           });
         });
       },

--- a/src/components/core/providers/drawer-provider.tsx
+++ b/src/components/core/providers/drawer-provider.tsx
@@ -31,7 +31,7 @@ export function DrawerProvider({ children }: ProviderProps) {
           analytics.trackInteraction("open_drawer", {
             // Datadog we write the drawer name into the metric name itself (prop ignored by analytics)
             datadogMetricName: `open_drawer.${props.telemetryName ?? ""}`.replace(/(\.)$/, ""),
-            // For analytics, we pass the name of the drawer as an event attribute name
+            // For analytics, we pass the name of the drawer as an event attribute
             value: props.telemetryName,
           });
         });

--- a/src/components/core/providers/drawer-provider.tsx
+++ b/src/components/core/providers/drawer-provider.tsx
@@ -29,7 +29,10 @@ export function DrawerProvider({ children }: ProviderProps) {
         setTimeout(() => {
           setIsOpen(true);
           analytics.trackInteraction("open_drawer", {
+            // Datadog we write the drawer name into the metric name itself (prop ignored by analytics)
             datadogMetricName: `open_drawer.${props.telemetryName ?? ""}`.replace(/(\.)$/, ""),
+            // For analytics, we pass the name of the drawer as an event attribute name
+            name: props.telemetryName,
           });
         });
       },


### PR DESCRIPTION
Sends the drawer name as `value` of `open_drawer` event. 