### PR TITLE
HTML to JSX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "1.60.0",
+  "version": "1.60.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "1.60.0",
+      "version": "1.60.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -26,6 +26,7 @@
         "dompurify": "^2.4.1",
         "fhir-kit-client": "^1.9.1",
         "i18next": "^22.4.15",
+        "interweave": "^13.1.0",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
         "patch-package": "^6.5.1",
@@ -19253,8 +19254,7 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -22260,6 +22260,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/interweave": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/interweave/-/interweave-13.1.0.tgz",
+      "integrity": "sha512-JIDq0+2NYg0cgL7AB26fBcV0yZdiJvPDBp+aF6k8gq6Cr1kH5Gd2/Xqn7j8z+TGb8jCWZn739jzalCz+nPYwcA==",
+      "dependencies": {
+        "escape-html": "^1.0.3"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/milesjohnson"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/invariant": {
@@ -45674,7 +45689,7 @@
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "form-data": "4.0.0"
+        "form-data": "^3.0.0"
       }
     },
     "@types/normalize-package-data": {
@@ -49078,8 +49093,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -50888,7 +50902,7 @@
         "@graphql-typed-document-node/core": "^3.1.1",
         "cross-fetch": "^3.1.5",
         "extract-files": "^9.0.0",
-        "form-data": "4.0.0"
+        "form-data": "^3.0.0"
       }
     },
     "gunzip-maybe": {
@@ -51350,6 +51364,14 @@
         "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "interweave": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/interweave/-/interweave-13.1.0.tgz",
+      "integrity": "sha512-JIDq0+2NYg0cgL7AB26fBcV0yZdiJvPDBp+aF6k8gq6Cr1kH5Gd2/Xqn7j8z+TGb8jCWZn739jzalCz+nPYwcA==",
+      "requires": {
+        "escape-html": "^1.0.3"
       }
     },
     "invariant": {
@@ -54817,7 +54839,7 @@
         "decimal.js": "^10.4.2",
         "domexception": "^4.0.0",
         "escodegen": "^2.0.0",
-        "form-data": "4.0.0",
+        "form-data": "^4.0.0",
         "html-encoding-sniffer": "^3.0.0",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "dompurify": "^2.4.1",
     "fhir-kit-client": "^1.9.1",
     "i18next": "^22.4.15",
+    "interweave": "^13.1.0",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
     "patch-package": "^6.5.1",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.2.3).
+ * Mock Service Worker (1.2.1).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/src/components/content/resource/helpers/details-card.tsx
+++ b/src/components/content/resource/helpers/details-card.tsx
@@ -25,14 +25,14 @@ export const DetailsCard = ({ details, hideEmpty = true, documentButton }: Detai
             return (
               // eslint-disable-next-line react/no-array-index-key
               <div key={idx} className="ctw-text-gray-900 ctw-flex ctw-items-baseline">
-                <div className="ctw-m-0">{value}</div>
+                <div className="ctw-m-0 ctw-w-full">{value}</div>
               </div>
             );
           }
           return (
             <div key={label} className="ctw-text-gray-900 ctw-flex ctw-items-baseline">
               <dt className="ctw-w-1/3 ctw-flex-shrink-0 ctw-font-medium">{label}</dt>
-              <dd className="ctw-m-0">{value}</dd>
+              <dd className="ctw-m-0 ctw-w-full">{value}</dd>
             </div>
           );
         })}

--- a/src/components/content/resource/helpers/notes.tsx
+++ b/src/components/content/resource/helpers/notes.tsx
@@ -1,3 +1,4 @@
+import { Interweave } from "interweave";
 import sanitizeHtml from "sanitize-html";
 import { NotesEntry } from "./notes-entry";
 import { DocumentModel } from "@/fhir/models/document";
@@ -13,8 +14,8 @@ function getNoteDisplay(noteText: string | undefined) {
   const cleanNote = sanitizeHtml(noteText, {
     disallowedTagsMode: "escape",
   });
-  // eslint-disable-next-line react/no-danger
-  return <div dangerouslySetInnerHTML={{ __html: cleanNote }} />;
+
+  return <Interweave content={cleanNote} />;
 }
 
 export const Notes = ({ entries }: NotesProps) => (


### PR DESCRIPTION
Changes the way we display notes, so that default styling is applied (e.g. headers no longer display as raw text, but in the same way headers in the other components are displayed). 

This new method turns the HTML to JSX first, which has the added benefit of letting us avoid using dangerouslySetInnerHTML, and letting us modifying HTML elements into React components in the future. 