### PR TITLE
Replace dangerously set inner html (part 2)

### DIFF
--- a/.changeset/yellow-plums-brush.md
+++ b/.changeset/yellow-plums-brush.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Increase security for displaying CCDA docs.

--- a/src/components/content/CCDA/ccda_viewer/components/Section/Section.tsx
+++ b/src/components/content/CCDA/ccda_viewer/components/Section/Section.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-danger */ // silent linter for dangerouslySetInnerHTML because it is taken care of using dompurify
 import DOMPurify from "dompurify";
+import { Interweave } from "interweave";
 import { useState } from "react";
 import { fixHtml } from "../../helpers";
 import { SectionType } from "../../types";
@@ -24,11 +25,7 @@ export const Section = ({
       </div>
       {isOpen && (
         <div className="ctw-ccda-section-wrapper">
-          <div
-            dangerouslySetInnerHTML={{
-              __html: DOMPurify.sanitize(fixHtml(humanReadable)),
-            }}
-          />
+          <Interweave content={DOMPurify.sanitize(fixHtml(humanReadable))} />
         </div>
       )}
     </div>


### PR DESCRIPTION
Replace dangerously setting inner html with Interweave instead, for CCDA docs.