### PR TITLE
CTW-1240/Search Tool Smal CSS Fix

### DIFF
--- a/.changeset/honest-bags-beam.md
+++ b/.changeset/honest-bags-beam.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fixed PatientRecordSearch results heading and vertical spacing styles.

--- a/src/components/content/patient-record-search/helpers/result-type/result-allergy-intolerance.tsx
+++ b/src/components/content/patient-record-search/helpers/result-type/result-allergy-intolerance.tsx
@@ -23,7 +23,7 @@ export function ResultAllergyIntolerance({ result, resource }: ResultAllergyInto
   return (
     <div className="ctw-patient-record-search-result">
       <div className="ctw-flex ctw-flex-row ctw-items-end ctw-justify-between">
-        <h3 className="ctw-mb-0">
+        <h3 className="ctw-search-result-heading">
           AllergyIntolerance: <span className="ctw-capitalize">{resource.display}</span>
         </h3>
         <FeedbackForm name={`${metadata.resource_type}/${metadata.resource_id}`} />

--- a/src/components/content/patient-record-search/helpers/result-type/result-condition.tsx
+++ b/src/components/content/patient-record-search/helpers/result-type/result-condition.tsx
@@ -19,7 +19,7 @@ export function ResultCondition({ result, resource }: ResultConditionProps) {
   return (
     <div className="ctw-patient-record-search-result">
       <div className="ctw-flex ctw-flex-row ctw-items-end ctw-justify-between">
-        <h3 className="ctw-mb-0">
+        <h3 className="ctw-search-result-heading">
           Condition: <span>{resource.display}</span>
         </h3>
         <FeedbackForm name={`${metadata.resource_type}/${metadata.resource_id}`} />

--- a/src/components/content/patient-record-search/helpers/result-type/result-document.tsx
+++ b/src/components/content/patient-record-search/helpers/result-type/result-document.tsx
@@ -21,7 +21,7 @@ export function ResultDocument({ result, resource }: ResultDocumentProps) {
   return (
     <div className="ctw-patient-record-search-result">
       <div className="ctw-flex ctw-flex-row ctw-items-end ctw-justify-between">
-        <h3 className="ctw-mb-0">
+        <h3 className="ctw-search-result-heading">
           Document: <span>{resource.title}</span>
         </h3>
         <FeedbackForm name={`${metadata.resource_type}/${metadata.resource_id}`} />

--- a/src/components/content/patient-record-search/helpers/result-type/result-med-statement.tsx
+++ b/src/components/content/patient-record-search/helpers/result-type/result-med-statement.tsx
@@ -17,7 +17,7 @@ export function ResultMedStatement({ result, resource }: ResultMedStatementProps
   return (
     <div className="ctw-patient-record-search-result ctw-btn">
       <div className="ctw-flex ctw-flex-row ctw-items-end ctw-justify-between">
-        <h3 className="ctw-mb-0">
+        <h3 className="ctw-search-result-heading">
           Medication: <span>{resource.display}</span>
         </h3>
         <FeedbackForm name={`${metadata.resource_type}/${metadata.resource_id}`} />

--- a/src/components/content/patient-record-search/helpers/result-type/result-observation.tsx
+++ b/src/components/content/patient-record-search/helpers/result-type/result-observation.tsx
@@ -15,7 +15,7 @@ export function ResultObservation({ result, resource }: ResultObservationProps) 
   return (
     <div className="ctw-patient-record-search-result">
       <div className="ctw-flex ctw-flex-row ctw-items-end ctw-justify-between">
-        <h3 className="ctw-mb-0">
+        <h3 className="ctw-search-result-heading">
           Observation: <span>{resource.display}</span>
         </h3>
         <FeedbackForm name={`${metadata.resource_type}/${metadata.resource_id}`} />

--- a/src/components/content/patient-record-search/helpers/style.scss
+++ b/src/components/content/patient-record-search/helpers/style.scss
@@ -12,8 +12,8 @@
   }
 
   .ctw-patient-record-search-results-list {
-    @apply ctw-m-0 ctw-ml-0;
-    min-height: 600px;
+    @apply ctw-m-0 ctw-ml-0 ctw-space-y-2.5;
+    min-height: 400px;
   }
 
   .ctw-patient-record-search-result {
@@ -36,20 +36,24 @@
     }
   }
 
+  .ctw-search-result-heading {
+    @apply ctw-mb-0 ctw-text-lg ctw-font-bold;
+  }
+
   .ctw-patient-record-search-details {
     @apply ctw-mb-0 ctw-w-full ctw-hyphens-auto ctw-break-words ctw-text-sm ctw-text-content-black;
 
-    > {
-      @apply ctw-text-sm;
+    [data-label] {
+      @apply ctw-text-sm ctw-text-content-black;
       // Search details can utilize data-label to display a label for the data. If they are empty divs or have the
       // "ctw-without-label" class, they will not display that label.
-      :not([data-label=""])::before {
-        @apply ctw-mr-1 ctw-font-medium;
+      &:not([data-label=""])::before {
+        @apply ctw-mr-1;
         content: attr(data-label) ": ";
         display: inline-block;
         float: left;
       }
-      > :empty {
+      &:empty {
         display: none;
       }
     }

--- a/src/components/content/patient-record-search/patient-record-search.tsx
+++ b/src/components/content/patient-record-search/patient-record-search.tsx
@@ -101,7 +101,7 @@ function PatientRecordSearchComponent({ className, hideTitle = false }: PatientR
       </form>
 
       <RenderIf condition={showLoadingSpinner}>
-        <div className="ctw-flex ctw-justify-center ctw-space-x-1 ctw-align-middle">
+        <div className="ctw-mt-3 ctw-flex ctw-justify-center ctw-space-x-1 ctw-align-middle">
           <Loading />
         </div>
       </RenderIf>


### PR DESCRIPTION
Fixed CSS styles on heading and spacing between results as those styles were not applied in ctw.

In CTW the heading and spacing didn't come across:
<img width="1407" alt="Screenshot 2023-08-31 at 1 19 50 PM" src="https://github.com/zeus-health/ctw-component-library/assets/6380075/caeafc4e-96b4-4ed0-b07e-ffe094657622">


Made those explicit in the PR:
<img width="985" alt="Screenshot 2023-08-31 at 1 18 41 PM" src="https://github.com/zeus-health/ctw-component-library/assets/6380075/d440cce2-607d-4dc1-b8bd-b18426555b3a">
