### PR TITLE
CTW-1366/Fix width of medication row

### DIFF
--- a/.changeset/young-trains-pretend.md
+++ b/.changeset/young-trains-pretend.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix medications search result width

--- a/src/components/content/patient-record-search/helpers/result-type/result-med-statement.tsx
+++ b/src/components/content/patient-record-search/helpers/result-type/result-med-statement.tsx
@@ -15,7 +15,7 @@ export function ResultMedStatement({ result, resource }: ResultMedStatementProps
   const { lastPrescribedDate, lastPrescriber } = resource;
 
   return (
-    <div className="ctw-patient-record-search-result ctw-btn">
+    <div className="ctw-patient-record-search-result">
       <div className="ctw-flex ctw-flex-row ctw-items-end ctw-justify-between">
         <h3 className="ctw-search-result-heading">
           Medication: <span>{resource.display}</span>

--- a/src/components/content/patient-record-search/helpers/style.scss
+++ b/src/components/content/patient-record-search/helpers/style.scss
@@ -17,7 +17,7 @@
   }
 
   .ctw-patient-record-search-result {
-    @apply ctw-w-full ctw-text-left;
+    @apply ctw-mt-1.5 ctw-w-full ctw-text-left;
 
     .ctw-patient-record-search-result-btn {
       @apply ctw-cursor-pointer ctw-border-0 ctw-bg-transparent ctw-p-0 ctw-text-left ctw-outline-none;
@@ -38,6 +38,8 @@
 
   .ctw-search-result-heading {
     @apply ctw-mb-0 ctw-text-lg ctw-font-bold;
+
+    margin-block-start: 1rem;
   }
 
   .ctw-patient-record-search-details {


### PR DESCRIPTION
- Remove padding from medication row
- CTW resets the browser h3 margin-block-start to 0. To normalize it this PR sets it to `1rem` (just for this component). There is no tailwind equivalent that I could find which is why I used css and not a tailwind class.