### PR TITLE
CTW-1370/iframe ZAP onRecordSave for medications

### DIFF
--- a/.changeset/silly-frogs-return.md
+++ b/.changeset/silly-frogs-return.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Support onRecordSave for medications components in the iframe ZAP.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import {
   PatientTimeline,
   ZusAggregatedProfile,
   ZusAggregatedProfileIFrame,
+  MedicationStatementModel,
 } from ".";
 
 import { PatientMedicationDispense } from "./components/content/medication-dispense/patient-medication-dispense";
@@ -64,7 +65,7 @@ const theme: ThemeProviderProps["theme"] = {
   },
   iframe: {
     fontFamily: "Avenir",
-    fontSize: "16px",
+    fontSize: "160px",
   },
 };
 
@@ -152,6 +153,12 @@ const components: DemoComponent[] = [
           }}
           conditionsAllProps={{ onlyAllowAddOutsideConditions: true }}
           includePatientDemographicsForm={false}
+          resources={["medications-outside", "medications-all", "medications"]}
+          medicationsOutsideProps={{
+            onAddToRecord: async (record: MedicationStatementModel) => {
+              console.log("onAddToRecord", record);
+            },
+          }}
         />
       );
     },
@@ -168,6 +175,12 @@ const components: DemoComponent[] = [
             }}
             conditionsAllProps={{ onlyAllowAddOutsideConditions: true }}
             includePatientDemographicsForm={false}
+            resources={["medications-outside", "medications-all", "medications"]}
+            medicationsOutsideProps={{
+              onAddToRecord: async (record: MedicationStatementModel) => {
+                console.log("onAddToRecord", record);
+              },
+            }}
           />
         </div>
       );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,6 @@ import {
   PatientTimeline,
   ZusAggregatedProfile,
   ZusAggregatedProfileIFrame,
-  MedicationStatementModel,
 } from ".";
 
 import { PatientMedicationDispense } from "./components/content/medication-dispense/patient-medication-dispense";
@@ -169,12 +168,6 @@ const components: DemoComponent[] = [
             }}
             conditionsAllProps={{ onlyAllowAddOutsideConditions: true }}
             includePatientDemographicsForm={false}
-            resources={["medications-outside", "medications-all", "medications"]}
-            medicationsOutsideProps={{
-              onAddToRecord: async (record: MedicationStatementModel) => {
-                console.log("onAddToRecord", record);
-              },
-            }}
           />
         </div>
       );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,7 +65,7 @@ const theme: ThemeProviderProps["theme"] = {
   },
   iframe: {
     fontFamily: "Avenir",
-    fontSize: "160px",
+    fontSize: "16px",
   },
 };
 
@@ -153,12 +153,6 @@ const components: DemoComponent[] = [
           }}
           conditionsAllProps={{ onlyAllowAddOutsideConditions: true }}
           includePatientDemographicsForm={false}
-          resources={["medications-outside", "medications-all", "medications"]}
-          medicationsOutsideProps={{
-            onAddToRecord: async (record: MedicationStatementModel) => {
-              console.log("onAddToRecord", record);
-            },
-          }}
         />
       );
     },

--- a/src/components/content/medications/patient-medications-all.tsx
+++ b/src/components/content/medications/patient-medications-all.tsx
@@ -22,7 +22,7 @@ import { useBaseTranslations } from "@/i18n";
 export type PatientMedicationsAllProps = {
   className?: string;
   readOnly?: boolean;
-  onAddToRecord?: (record: MedicationStatementModel) => void;
+  onAddToRecord?: (record: MedicationStatementModel) => void | Promise<void>;
 };
 
 function PatientMedicationsAllComponent({

--- a/src/components/content/medications/patient-medications-all.tsx
+++ b/src/components/content/medications/patient-medications-all.tsx
@@ -22,7 +22,7 @@ import { useBaseTranslations } from "@/i18n";
 export type PatientMedicationsAllProps = {
   className?: string;
   readOnly?: boolean;
-  onAddToRecord?: (record: MedicationStatementModel) => void | Promise<void>;
+  onAddToRecord?: (record: MedicationStatementModel) => Promise<void> | void;
 };
 
 function PatientMedicationsAllComponent({

--- a/src/components/content/medications/patient-medications-outside.tsx
+++ b/src/components/content/medications/patient-medications-outside.tsx
@@ -17,7 +17,7 @@ import { QUERY_KEY_BASIC, QUERY_KEY_OTHER_PROVIDER_MEDICATIONS } from "@/utils/q
 export type PatientMedicationsOutsideProps = {
   className?: string;
   onOpenHistoryDrawer?: () => void;
-  onAddToRecord?: (record: MedicationStatementModel) => void;
+  onAddToRecord?: (record: MedicationStatementModel) => Promise<void> | void;
   readOnly?: boolean;
 };
 

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
@@ -27,24 +27,22 @@ export type ZapIFrameConfig = {
   ZusAggregatedProfileProps: ZusAggregatedProfileProps;
   iframeTheme: IFrameTheme;
 };
-export const ZapMessageTypes = {
-  onPatientSave: "ZusAggregatedProfileOnPatientSave" as const,
-  onAddToRecord: "ZusAggregatedProfileOnAddToRecord" as const,
-  onResourceSave: "ZusAggregatedProfileOnResourceSave" as const,
-  iframeConfig: "ZusAggregatedProfileIFrameConfig" as const,
-  iframeReady: "ZusAggregatedProfileIFrameReady" as const,
-};
-type ZapMessageTypesType = typeof ZapMessageTypes;
+export const ZapIFrameConfigMessageType = "ZusAggregatedProfileIFrameConfig";
+export const ZapIFrameReadyMessageType = "ZusAggregatedProfileIFrameReady";
+export const ZapOnResourceSaveMessageType = "ZusAggregatedProfileOnResourceSave";
+export const ZapOnPatientSaveMessageType = "ZusAggregatedProfileOnPatientSave";
+export const ZapOnAddToRecordMessageType = "ZusAggregatedProfileOnAddToRecord";
+
 export type ZapMessageEventData<EventType, EventPayload = never> = {
   type: EventType;
   payload?: EventPayload;
   error?: string;
   id?: string;
 };
-export type ZapMessageEventIFrameConfig = ZapMessageEventData<ZapMessageTypesType["iframeConfig"]>;
-export type ZapMessageEventIFrameReady = ZapMessageEventData<ZapMessageTypesType["iframeReady"]>;
+export type ZapMessageEventIFrameConfig = ZapMessageEventData<typeof ZapIFrameConfigMessageType>;
+export type ZapMessageEventIFrameReady = ZapMessageEventData<typeof ZapIFrameReadyMessageType>;
 export type ZapMessageEventOnResourceSave = ZapMessageEventData<
-  ZapMessageTypesType["onResourceSave"],
+  typeof ZapOnResourceSaveMessageType,
   {
     resource: Resource;
     action: "create" | "update";
@@ -52,7 +50,7 @@ export type ZapMessageEventOnResourceSave = ZapMessageEventData<
   }
 >;
 export type ZapMessageEventOnAddToRecord = ZapMessageEventData<
-  ZapMessageTypesType["onAddToRecord"],
+  typeof ZapOnAddToRecordMessageType,
   {
     resource: fhir4.MedicationStatement;
     includedResources?: Record<string, fhir4.Resource>;
@@ -79,7 +77,7 @@ const ZusAggregatedProfileIFrameComponent = (props: ZusAggregatedProfileProps) =
 
   useEffect(() => {
     const onAddToRecordHandler = async ({ data }: ZapMessageEvent) => {
-      if (data.type === ZapMessageTypes.onAddToRecord && typeof data.payload !== "undefined") {
+      if (data.type === ZapOnAddToRecordMessageType && typeof data.payload !== "undefined") {
         const medicationStatement = new MedicationStatementModel(
           data.payload.resource,
           data.payload.includedResources
@@ -126,7 +124,7 @@ const ZusAggregatedProfileIFrameComponent = (props: ZusAggregatedProfileProps) =
   useEffect(() => {
     // listener to know when iframe ZAP is ready
     const onMessageReady = ({ data }: ZapMessageEvent) => {
-      if (data.type === ZapMessageTypes.iframeReady) {
+      if (data.type === ZapIFrameReadyMessageType) {
         setHostedZapReady(true);
       }
     };
@@ -138,7 +136,7 @@ const ZusAggregatedProfileIFrameComponent = (props: ZusAggregatedProfileProps) =
     // set up ZAP URL and listener for resource save
     let requestContext: CTWRequestContext | undefined;
     const onMessageSave = ({ data }: ZapMessageEvent) => {
-      if (data.type === ZapMessageTypes.onResourceSave && typeof data.payload !== "undefined") {
+      if (data.type === ZapOnResourceSaveMessageType && typeof data.payload !== "undefined") {
         const { resource, action, error } = data.payload;
         requestContext?.onResourceSave(resource, action, new Error(error));
       }
@@ -177,7 +175,7 @@ const ZusAggregatedProfileIFrameComponent = (props: ZusAggregatedProfileProps) =
 
       iframeRef.current?.contentWindow?.postMessage(
         {
-          type: ZapMessageTypes.iframeConfig,
+          type: ZapIFrameConfigMessageType,
           config: {
             CTWProviderProps: ctwProviderProps,
             PatientProviderProps: patientProviderProps,

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
@@ -179,7 +179,7 @@ const ZusAggregatedProfileIFrameComponent = (props: ZusAggregatedProfileProps) =
       iframeRef.current?.contentWindow?.postMessage(
         {
           type: ZapIFrameConfigMessageType,
-          config: {
+          payload: {
             CTWProviderProps: ctwProviderProps,
             PatientProviderProps: patientProviderProps,
             ZusAggregatedProfileProps: {

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
@@ -36,7 +36,7 @@ export const ZapOnAddToRecordMessageType = "ZusAggregatedProfileOnAddToRecord";
 export type ZapMessageEventData<EventType, EventPayload = undefined> = {
   type: EventType;
   id?: string;
-} & ({ payload: EventPayload; error: never } | { payload: never; error: string });
+} & ({ payload: EventPayload; error?: never } | { payload?: never; error: string });
 
 export type ZapIFrameConfigMessageEvent = ZapMessageEventData<typeof ZapIFrameConfigMessageType>;
 export type ZapIFrameReadyMessageEvent = ZapMessageEventData<typeof ZapIFrameReadyMessageType>;
@@ -76,7 +76,7 @@ const ZusAggregatedProfileIFrameComponent = (props: ZusAggregatedProfileProps) =
 
   useEffect(() => {
     const onAddToRecordHandler = async ({ data }: ZapMessageEvent) => {
-      if (data.type === ZapOnAddToRecordMessageType && typeof data.payload !== "undefined") {
+      if (data.type === ZapOnAddToRecordMessageType && typeof data.error !== "string") {
         const medicationStatement = new MedicationStatementModel(
           data.payload.resource,
           data.payload.includedResources
@@ -142,7 +142,7 @@ const ZusAggregatedProfileIFrameComponent = (props: ZusAggregatedProfileProps) =
     })();
 
     const onMessageSave = ({ data }: ZapMessageEvent) => {
-      if (data.type === ZapOnResourceSaveMessageType && typeof data.payload !== "undefined") {
+      if (data.type === ZapOnResourceSaveMessageType && typeof data.error !== "string") {
         const { resource, action, error } = data.payload;
         requestContext?.onResourceSave(resource, action, new Error(error));
       }

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
@@ -56,6 +56,7 @@ export type ZapOnAddToRecordMessageEvent = ZapMessageEventData<
     component: "medications-outside" | "medications-all";
   }
 >;
+
 export type ZapMessageEvent = MessageEvent<
   | ZapOnAddToRecordMessageEvent
   | ZapOnResourceSaveMessageEvent


### PR DESCRIPTION
- Handle callbacks for `onAddToRecord` handlers when medications are added within the embedded iframe ZAP.
- Typing for the ZAP MessageEvents

---
Because we're continuing to add more event types with different use cases and bodies, this PR also adds some typing to the messages being sent from parent and iframe. The TLDR is that in there is now a `payload` and `error` attribute on the message data:
```ts
data: {
  type: string.   // this is unchanged from how we did it before
  payload: T      // this is new, instead of adding attributes to the flat `data` object. A successful
                  //  event can post a message with attributes on the `data.payload` object.
  error?: string  // An unsuccessful event can post an error message.
```
This isn't just stylistic, the reason here is to separate transport information from the events message and data. The unique structure of a message should all live in the `payload`.  A message sent like
```ts
postMessage({
  type: "ZusAggregatedProfileOnResourceSave",
  error: error.message,
})
```
would convey an error from the `IFrameZusAggregatedProfile` component itself saying it was unable to handle a `"ZusAggregatedProfileOnResourceSave"` message. However, a message sent like
```ts
postMessage({
  type: "ZusAggregatedProfileOnResourceSave",
  payload: {
    resource: fhirResource,
    action: "create",
    error: "Some error message",
  }
})
```
would convey that we have a message about an error that happened in a sub-component. The message is valid, the payload is valid, it just so happens that it is informing the other end to pass that "error" into a callback. The takeaway is that `.error` and `.payload.error` mean completely different things.

This change won't break anything because in ctw-component-library, only the new `onAddToRecord` needs to read payload and on the ctw side there would only be a breaking change if someone uses this version of the library before we deploy [this ctw PR](https://github.com/zeus-health/ctw/pull/760) which will make the standalone ZAP be able to handle both styles of messages, and we can let that live for a good amount of time.