### PR TITLE
ZusIcon viewport dynamically changes based on content

### DIFF
--- a/.changeset/heavy-walls-cough.md
+++ b/.changeset/heavy-walls-cough.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+ZusIcon viewport dynamically adjusts based on whether "zus" text is visible.

--- a/src/components/core/icons/zus-icon.tsx
+++ b/src/components/core/icons/zus-icon.tsx
@@ -3,7 +3,12 @@ type ZusIconProps = {
   includeZusText?: boolean;
 };
 export const ZusIcon = ({ className, includeZusText = false }: ZusIconProps) => (
-  <svg viewBox="0 0 47 24" fill="none" xmlns="http://www.w3.org/2000/svg" className={className}>
+  <svg
+    viewBox={includeZusText ? "0 0 47 24" : "0 0 24 24"}
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
     <title>Zus Health</title>
     <g clip-path="url(#clip0_105_5210)">
       <path


### PR DESCRIPTION
When "zus" text isn't shown in `ZusIcon`, the viewport will dynamically adjust.