### PR TITLE
fix: only show one date if both dates are the same

### DIFF
--- a/.changeset/twenty-points-prove.md
+++ b/.changeset/twenty-points-prove.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Only show one date if encounter start and end dates are the same

--- a/src/components/content/encounters/helpers/modal-hooks.tsx
+++ b/src/components/content/encounters/helpers/modal-hooks.tsx
@@ -1,11 +1,24 @@
+import { differenceInDays } from "date-fns";
 import { useResourceDetailsDrawer } from "../../resource/resource-details-drawer";
 import { EncounterModel } from "@/fhir/models/encounter";
+import { parseWithoutFormat } from "@/utils/dates";
 import { capitalize } from "@/utils/nodash/fp";
 
 export function usePatientEncounterDetailsDrawer() {
   return useResourceDetailsDrawer({
     header: (m) => {
       if (m.periodStart && m.periodEnd) {
+        const parsedStartDate = parseWithoutFormat(m.periodStart);
+        const parsedEndDate = parseWithoutFormat(m.periodEnd);
+
+        if (
+          parsedStartDate &&
+          parsedEndDate &&
+          differenceInDays(parsedStartDate, parsedEndDate) === 0
+        ) {
+          return `${m.periodStart}`;
+        }
+
         return `${m.periodStart} - ${m.periodEnd}`;
       }
       if (m.periodStart) {

--- a/src/utils/dates.test.ts
+++ b/src/utils/dates.test.ts
@@ -15,8 +15,8 @@ describe("date parsing tests", () => {
     },
 
     {
-      name: "iso, NYC EST locale, seconds",
-      input: "2023-04-07T12:34:45-04:00",
+      name: "iso, seconds",
+      input: "2023-04-07T12:34:45",
       expected: parseISO("2023-04-07T12:34:45"),
     },
     {

--- a/src/utils/dates.test.ts
+++ b/src/utils/dates.test.ts
@@ -30,14 +30,14 @@ describe("date parsing tests", () => {
       expected: parseISO("2023-04-07T15:34:00-04:00"),
     },
     {
-      name: "us format, no locale, mins, no padded zeroes",
+      name: "us format, no locale, AM/PM, mins, no padded zeroes",
       input: "4/7/2023 3:34 PM",
       expected: parseISO("2023-04-07T15:34:00-04:00"),
     },
     {
-      name: "us format, no locale, mins, no padded zeroes",
+      name: "us format, no locale, 24HR, mins, no padded zeroes",
       input: "4/7/2023 15:34",
-      expected: parseISO("2023-04-07T15:34:00-04:00"),
+      expected: parseISO("2023-04-07T15:34:00"),
     },
   ];
 

--- a/src/utils/dates.test.ts
+++ b/src/utils/dates.test.ts
@@ -1,0 +1,48 @@
+import { parseISO } from "date-fns";
+import { parseWithoutFormat } from "./dates";
+
+describe("date parsing tests", () => {
+  const tests = [
+    {
+      name: "iso, no locale, seconds",
+      input: "2023-04-07T12:34:45",
+      expected: parseISO("2023-04-07T12:34:45"),
+    },
+    {
+      name: "iso, UTC locale, seconds",
+      input: "2023-04-07T12:34:45Z",
+      expected: parseISO("2023-04-07T12:34:45Z"),
+    },
+
+    {
+      name: "iso, NYC EST locale, seconds",
+      input: "2023-04-07T12:34:45-04:00",
+      expected: parseISO("2023-04-07T12:34:45-04:00"),
+    },
+    {
+      name: "us format, no locale, seconds",
+      input: "04/07/2023 13:34:45",
+      expected: parseISO("2023-04-07T13:34:45-04:00"),
+    },
+    {
+      name: "us format, no locale, mins",
+      input: "04/07/2023 3:34 PM",
+      expected: parseISO("2023-04-07T15:34:00-04:00"),
+    },
+    {
+      name: "us format, no locale, mins, no padded zeroes",
+      input: "4/7/2023 3:34 PM",
+      expected: parseISO("2023-04-07T15:34:00-04:00"),
+    },
+    {
+      name: "us format, no locale, mins, no padded zeroes",
+      input: "4/7/2023 15:34",
+      expected: parseISO("2023-04-07T15:34:00-04:00"),
+    },
+  ];
+
+  test.each(tests)("$name", ({ input, expected }) => {
+    const actual = parseWithoutFormat(input);
+    expect(expected).toEqual(actual);
+  });
+});

--- a/src/utils/dates.test.ts
+++ b/src/utils/dates.test.ts
@@ -17,22 +17,22 @@ describe("date parsing tests", () => {
     {
       name: "iso, NYC EST locale, seconds",
       input: "2023-04-07T12:34:45-04:00",
-      expected: parseISO("2023-04-07T12:34:45-04:00"),
+      expected: parseISO("2023-04-07T12:34:45"),
     },
     {
       name: "us format, no locale, seconds",
       input: "04/07/2023 13:34:45",
-      expected: parseISO("2023-04-07T13:34:45-04:00"),
+      expected: parseISO("2023-04-07T13:34:45"),
     },
     {
       name: "us format, no locale, mins",
       input: "04/07/2023 3:34 PM",
-      expected: parseISO("2023-04-07T15:34:00-04:00"),
+      expected: parseISO("2023-04-07T15:34:00"),
     },
     {
       name: "us format, no locale, AM/PM, mins, no padded zeroes",
       input: "4/7/2023 3:34 PM",
-      expected: parseISO("2023-04-07T15:34:00-04:00"),
+      expected: parseISO("2023-04-07T15:34"),
     },
     {
       name: "us format, no locale, 24HR, mins, no padded zeroes",

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,6 +1,4 @@
 import { parse, parseISO } from "date-fns";
-// eslint-disable-next-line import/no-named-default
-import { default as LOCALE_US } from "date-fns/locale/en-US";
 
 const DATE_FORMATS = [
   // 04/17/1983 3:50:00.000 PM
@@ -33,9 +31,7 @@ export const parseWithoutFormat = (dateTime: string): Date | undefined => {
   // next try our custom patterns that we expect
   for (let dateFormatIdx = 0; dateFormatIdx < DATE_FORMATS.length; dateFormatIdx += 1) {
     const dateFormat = DATE_FORMATS[dateFormatIdx];
-    retval = parse(dateTime, dateFormat, new Date(), {
-      locale: LOCALE_US,
-    });
+    retval = parse(dateTime, dateFormat, new Date());
     if (!Number.isNaN(retval.getMilliseconds())) {
       return retval;
     }

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,4 +1,6 @@
 import { parse, parseISO } from "date-fns";
+// eslint-disable-next-line import/no-named-default
+import { default as LOCALE_US } from "date-fns/locale/en-US";
 
 const DATE_FORMATS = [
   // 04/17/1983 3:50:00.000 PM
@@ -31,7 +33,9 @@ export const parseWithoutFormat = (dateTime: string): Date | undefined => {
   // next try our custom patterns that we expect
   for (let dateFormatIdx = 0; dateFormatIdx < DATE_FORMATS.length; dateFormatIdx += 1) {
     const dateFormat = DATE_FORMATS[dateFormatIdx];
-    retval = parse(dateTime, dateFormat, new Date());
+    retval = parse(dateTime, dateFormat, new Date(), {
+      locale: LOCALE_US,
+    });
     if (!Number.isNaN(retval.getMilliseconds())) {
       return retval;
     }

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,0 +1,41 @@
+import { parse, parseISO } from "date-fns";
+
+const DATE_FORMATS = [
+  // 04/17/1983 3:50:00.000 PM
+  "MM/dd/yyyy h:mm:ss.SSS aa",
+  // 04/17/1983 15:50:00.000
+  "MM/dd/yyyy HH:mm:ss.SSS",
+  // 04/17/1983 3:50:00 PM
+  "MM/dd/yyyy h:mm:ss aa",
+  // 04/17/1983 15:50:00
+  "MM/dd/yyyy HH:mm:ss",
+  // 04/17/1983 3:50 PM
+  "MM/dd/yyyy h:mm aa",
+  // 4/17/1983 3:50 PM
+  "M/dd/yyyy h:mm aa",
+  // 04/17/1983 15:50
+  "MM/dd/yyyy HH:mm",
+  // 4/17/1983 15:50
+  "M/dd/yyyy HH:mm",
+  // 04/17/1983
+  "MM/dd/yyyy",
+];
+
+export const parseWithoutFormat = (dateTime: string): Date | undefined => {
+  // first try ISO
+  let retval = parseISO(dateTime);
+  if (!Number.isNaN(retval.getMilliseconds())) {
+    return retval;
+  }
+
+  // next try our custom patterns that we expect
+  for (let dateFormatIdx = 0; dateFormatIdx < DATE_FORMATS.length; dateFormatIdx += 1) {
+    const dateFormat = DATE_FORMATS[dateFormatIdx];
+    retval = parse(dateTime, dateFormat, new Date());
+    if (!Number.isNaN(retval.getMilliseconds())) {
+      return retval;
+    }
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
If an encounter has both a start and end date that are the same, we used to render it as `01/01/2022 - 01/01/2022`. With this PR, it will now only show `01/01/2022`