### PR TITLE
Highlight spans in relevant content

### DIFF
--- a/src/components/content/patient-record-search/helpers/relevant-content.tsx
+++ b/src/components/content/patient-record-search/helpers/relevant-content.tsx
@@ -1,0 +1,62 @@
+type Span = {
+  begin: number;
+  end: number;
+};
+
+export function getRelevantContentFromDocumentSearchResult(text: string, spans: Span[]) {
+  const sortedSpans = getNonOverlappingSpans(spans);
+  let idx = 0;
+  const parts: string[] = [];
+  for (const span of sortedSpans) {
+    parts.push(text.slice(idx, span.begin));
+    idx = span.begin;
+    parts.push(text.slice(idx, span.end));
+    idx = span.end;
+  }
+  parts.push(text.slice(idx));
+  parts[0] = parts[0].slice(parts[0].length - 100);
+  return (
+    <>
+      {parts.map((part, i) =>
+        i % 0 === 0 ? (
+          // eslint-disable-next-line react/no-array-index-key
+          <span key={i}>{part}</span>
+        ) : (
+          // eslint-disable-next-line react/no-array-index-key
+          <span key={i} className="ctw-font-semibold">
+            {part}
+          </span>
+        )
+      )}
+    </>
+  );
+}
+
+function getNonOverlappingSpans(spans: Span[]): Span[] {
+  if (spans.length === 0) {
+    return [];
+  }
+
+  // Sort the spans by their start indexes
+  spans.sort((a, b) => a.begin - b.begin);
+
+  const nonOverlappingSpans: Span[] = [spans[0]];
+
+  for (let i = 1; i < spans.length; i += 1) {
+    const currentSpan = spans[i];
+    const previousSpan = nonOverlappingSpans[nonOverlappingSpans.length - 1];
+
+    // Check for overlap with the previous span
+    if (currentSpan.begin <= previousSpan.end) {
+      // Update the end index of the previous span if necessary
+      if (currentSpan.end > previousSpan.end) {
+        previousSpan.end = currentSpan.end;
+      }
+    } else {
+      // No overlap, add the current span to the result array
+      nonOverlappingSpans.push(currentSpan);
+    }
+  }
+
+  return nonOverlappingSpans;
+}

--- a/src/components/content/patient-record-search/helpers/relevant-content.tsx
+++ b/src/components/content/patient-record-search/helpers/relevant-content.tsx
@@ -18,7 +18,7 @@ export function getRelevantContentFromDocumentSearchResult(text: string, spans: 
   return (
     <>
       {parts.map((part, i) =>
-        i % 0 === 0 ? (
+        i % 2 === 0 ? (
           // eslint-disable-next-line react/no-array-index-key
           <span key={i}>{part}</span>
         ) : (

--- a/src/components/content/patient-record-search/helpers/search-result-row.tsx
+++ b/src/components/content/patient-record-search/helpers/search-result-row.tsx
@@ -6,6 +6,7 @@ import { useConditionDetailsDrawer } from "../../conditions/helpers/details";
 import { documentData } from "../../document/patient-documents";
 import { useMedicationDetailsDrawer } from "../../medications/helpers/details";
 import { useResourceDetailsDrawer } from "../../resource/resource-details-drawer";
+import { getRelevantContentFromDocumentSearchResult } from "@/components/content/patient-record-search/helpers/relevant-content";
 import {
   AllergyModel,
   ConditionModel,
@@ -136,23 +137,3 @@ export function SearchResultRow(props: ResourceRowProps) {
       return null;
   }
 }
-
-const getRelevantContentFromDocumentSearchResult = (
-  content: string,
-  spans: { begin: number; end: number }[]
-) => {
-  let relevantContent: JSX.Element;
-  if (spans.length === 0) {
-    relevantContent = <>{content}</>;
-  } else {
-    // TODO - this could be improved to highlight all of the spans and not just the first one
-    relevantContent = (
-      <>
-        <span>{content.substring(spans[0].begin - 100, spans[0].begin)}</span>
-        <span className="ctw-font-semibold">{content.substring(spans[0].begin, spans[0].end)}</span>
-        <span>{content.substring(spans[0].end, spans[0].end + 300)}</span>
-      </>
-    );
-  }
-  return relevantContent;
-};


### PR DESCRIPTION
The function `getNonOverlappingSpans` I pulled from chatGPT in the off-chance that we end up with overlapping spans we can merge them into an array on non-overlapping spans. If it's not possible that spans overlap though, we could remove this function and just keep `getRelevantContentFromDocumentSearchResult`.

Also, I didn't test this out on search results