### PR TITLE
fix: add discharge disposition to details cell

### DIFF
--- a/.changeset/curvy-tomatoes-travel.md
+++ b/.changeset/curvy-tomatoes-travel.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Show discharge disposition in encounter table if available

--- a/src/components/content/encounters/helpers/columns.tsx
+++ b/src/components/content/encounters/helpers/columns.tsx
@@ -36,10 +36,12 @@ export const patientEncounterColumns = (builderId: string): TableColumn<Encounte
   {
     title: "Details",
     render: (encounter) => {
+      const { dischargeDisposition } = encounter;
       const diagnoses = compact(encounter.diagnoses);
       const notes = encounter.clinicalNotes.map((note) => note.noteTitle);
       return (
         <div>
+          {dischargeDisposition && <div>Discharge: {dischargeDisposition}</div>}
           {notes.length > 0 && (
             <SimpleMoreList items={notes} limit={3} total={notes.length} prefix="Notes:" />
           )}

--- a/src/components/content/resource/helpers/details-card.test.tsx
+++ b/src/components/content/resource/helpers/details-card.test.tsx
@@ -80,7 +80,11 @@ describe("detail card tests", () => {
   describe("transpose", () => {
     const tests = [
       {
-        skip: true,
+        name: "just string",
+        value: "Discharged to home care or self care (routine discharge)",
+        expected: "Discharged to home care or self care (routine discharge)",
+      },
+      {
         name: "one table, one data row, no thead row",
         value: (
           <div>
@@ -122,7 +126,6 @@ describe("detail card tests", () => {
         ),
       },
       {
-        skip: true,
         name: "one table, two data rows, no thead row",
         value: (
           <div>

--- a/src/components/content/resource/helpers/details-card.tsx
+++ b/src/components/content/resource/helpers/details-card.tsx
@@ -196,9 +196,12 @@ export const DetailsCard = ({ details, hideEmpty = true, documentButton }: Detai
           <div className="ctw-title-container">Details</div>
           <div className="ctw-flex">{documentButton}</div>
         </div>
-        {details
-          .filter((d) => !hideEmpty || d.value || d.value === 0)
-          .map(({ label }, idx) => {
+        {transposedValues.length > 0 &&
+          details.map(({ label, value }, idx) => {
+            if (!hideEmpty || (!value && value !== 0)) {
+              return <></>;
+            }
+
             const valueWithTransposedTables = transposedValues[idx];
             if (!label) {
               return (


### PR DESCRIPTION
If a discharge disposition exists for an encounter, we'll add it as the first item in the `Details` column
![Screenshot 2023-09-14 at 3 28 23 PM](https://github.com/zeus-health/ctw-component-library/assets/1211418/aca703c3-d64b-4e31-a7e7-84a9c577288d)
