### PR TITLE
fix: address clinical note issues

### DIFF
--- a/.changeset/six-ligers-joke.md
+++ b/.changeset/six-ligers-joke.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Address various clinical note rendering issues

--- a/src/components/content/resource/helpers/details-card.test.tsx
+++ b/src/components/content/resource/helpers/details-card.test.tsx
@@ -106,22 +106,26 @@ describe("detail card tests", () => {
         ),
         expected: (
           <div>
-            <table>
-              <tbody>
-                <tr key="transposed-0">
-                  <td key="col-0">Col 1</td>
-                  <td key="data-0-0">hi</td>
-                </tr>
-                <tr key="transposed-1">
-                  <td key="col-1">Col 2</td>
-                  <td key="data-1-1">hi again</td>
-                </tr>
-                <tr key="transposed-2">
-                  <td key="col-2">Col 3</td>
-                  <td key="data-2-2">hi again again</td>
-                </tr>
-              </tbody>
-            </table>
+            <div className="ctw-note-transposed">
+              <div key="cell-0-0">
+                <p>
+                  <b>Col 1</b>
+                </p>
+                <p>hi</p>
+              </div>
+              <div key="cell-0-1">
+                <p>
+                  <b>Col 2</b>
+                </p>
+                <p>hi again</p>
+              </div>
+              <div key="cell-0-2">
+                <p>
+                  <b>Col 3</b>
+                </p>
+                <p>hi again again</p>
+              </div>
+            </div>
           </div>
         ),
       },
@@ -152,57 +156,73 @@ describe("detail card tests", () => {
         ),
         expected: (
           <div>
-            <table>
-              <tbody>
-                <tr key="transposed-0">
-                  <td key="col-0">Col 1</td>
-                  <td key="data-0-0">hi</td>
-                </tr>
-                <tr key="transposed-1">
-                  <td key="col-1">Col 2</td>
-                  <td key="data-1-1">hi again</td>
-                </tr>
-                <tr key="transposed-2">
-                  <td key="col-2">Col 3</td>
-                  <td key="data-2-2">hi again again</td>
-                </tr>
-                <tr key="transposed-3" className="ctw-outline">
-                  <td key="col-0">Col 1</td>
-                  <td key="data-3-0">goodbye</td>
-                </tr>
-                <tr key="transposed-4">
-                  <td key="col-1">Col 2</td>
-                  <td key="data-4-1">goodbye again</td>
-                </tr>
-                <tr key="transposed-5">
-                  <td key="col-2">Col 3</td>
-                  <td key="data-5-2">goodbye again again</td>
-                </tr>
-              </tbody>
-            </table>
+            <div className="ctw-note-transposed">
+              <div key="cell-0-0">
+                <p>
+                  <b>Col 1</b>
+                </p>
+                <p>hi</p>
+              </div>
+              <div key="cell-0-1">
+                <p>
+                  <b>Col 2</b>
+                </p>
+                <p>hi again</p>
+              </div>
+              <div key="cell-0-2">
+                <p>
+                  <b>Col 3</b>
+                </p>
+                <p>hi again again</p>
+              </div>
+              <div key="transpose-separator-0" className="ctw-note-transposed-row-separator" />
+              <div key="cell-1-0">
+                <p>
+                  <b>Col 1</b>
+                </p>
+                <p>goodbye</p>
+              </div>
+              <div key="cell-1-1">
+                <p>
+                  <b>Col 2</b>
+                </p>
+                <p>goodbye again</p>
+              </div>
+              <div key="cell-1-2">
+                <p>
+                  <b>Col 3</b>
+                </p>
+                <p>goodbye again again</p>
+              </div>
+            </div>
           </div>
         ),
       },
+
       {
         name: "one table, one data row, thead row, content",
         value: <div content={smallDivContent} />,
         expected: (
-          <table>
-            <tbody>
-              <tr key="transposed-0">
-                <td key="col-0">Col 1</td>
-                <td key="data-0-0">hi</td>
-              </tr>
-              <tr key="transposed-1">
-                <td key="col-1">Col 2</td>
-                <td key="data-1-1">hi again</td>
-              </tr>
-              <tr key="transposed-2">
-                <td key="col-2">Col 3</td>
-                <td key="data-2-2">hi again again</td>
-              </tr>
-            </tbody>
-          </table>
+          <div className="ctw-note-transposed">
+            <div key="cell-0-0">
+              <p>
+                <b>Col 1</b>
+              </p>
+              <p>hi</p>
+            </div>
+            <div key="cell-0-1">
+              <p>
+                <b>Col 2</b>
+              </p>
+              <p>hi again</p>
+            </div>
+            <div key="cell-0-2">
+              <p>
+                <b>Col 3</b>
+              </p>
+              <p>hi again again</p>
+            </div>
+          </div>
         ),
       },
       {
@@ -213,75 +233,93 @@ describe("detail card tests", () => {
             <ul>
               <li>
                 <h2 key={0}>Consultation (Within 1 month) - Closed</h2>
-                <table>
-                  <tbody>
-                    <tr key="transposed-0">
-                      <td key="col-0">Specialty</td>
-                      <td key="data-0-0">Neurology</td>
-                    </tr>
-                    <tr key="transposed-1">
-                      <td key="col-1">Diagnoses / Procedures</td>
-                      <td key="data-1-1">
-                        <p key="0">Diagnoses</p>
-                        <p key="1">Muscular dystrophy.</p>
-                        <br key="2">{null}</br>
-                      </td>
-                    </tr>
-                    <tr key="transposed-2">
-                      <td key="col-2">Referred By Contact</td>
-                      <td key="data-2-2">
-                        <p key="0">Knight, Bryan J, DO</p>
-                        <p key="1">1 Lincolon St</p>
-                        <p key="2">Ste 2400</p>
-                        <p key="3">Boston, MA 02111</p>
-                        <p key="4">Phone: 508-555-5555</p>
-                        <p key="5">Fax: 781-555-5555</p>
-                        <p key="6">Email: bknight@zushealth.com</p>
-                      </td>
-                    </tr>
-                    <tr key="transposed-3">
-                      <td key="col-3">Referred To Contact</td>
-                      <td key="data-3-3">
-                        <p key="0">Acme Health</p>
-                        <p key="1">200 Jefferson St</p>
-                        <p key="2">Newton, MA 02462-1607</p>
-                        <p key="3">Phone: 617-555-5555</p>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-                <table>
-                  <tbody>
-                    <tr key="transposed-0">
-                      <td key="col-0">Referral ID</td>
-                      <td key="data-0-0">789456789456</td>
-                    </tr>
-                    <tr key="transposed-1">
-                      <td key="col-1">Status</td>
-                      <td key="data-1-1">Closed</td>
-                    </tr>
-                    <tr key="transposed-2">
-                      <td key="col-2">Reason</td>
-                      <td key="data-2-2">{null}</td>
-                    </tr>
-                    <tr key="transposed-3">
-                      <td key="col-3">Start Date</td>
-                      <td key="data-3-3">12/25/2022</td>
-                    </tr>
-                    <tr key="transposed-4">
-                      <td key="col-4">Expiration Date</td>
-                      <td key="data-4-4">12/25/2022</td>
-                    </tr>
-                    <tr key="transposed-5">
-                      <td key="col-5">Visits Requested</td>
-                      <td key="data-5-5">1</td>
-                    </tr>
-                    <tr key="transposed-6">
-                      <td key="col-6">Visits Authorized</td>
-                      <td key="data-6-6">1</td>
-                    </tr>
-                  </tbody>
-                </table>
+                <div className="ctw-note-transposed">
+                  <div key="cell-0-0">
+                    <p>
+                      <b>Specialty</b>
+                    </p>
+                    <p>Neurology</p>
+                  </div>
+                  <div key="cell-0-1">
+                    <p>
+                      <b>Diagnoses / Procedures</b>
+                    </p>
+                    <p>
+                      <p key="0">Diagnoses</p>
+                      <p key="1">Muscular dystrophy.</p>
+                      <br key="2">{null}</br>
+                    </p>
+                  </div>
+                  <div key="cell-0-2">
+                    <p>
+                      <b>Referred By Contact</b>
+                    </p>
+                    <p>
+                      <p key="0">Knight, Bryan J, DO</p>
+                      <p key="1">1 Lincolon St</p>
+                      <p key="2">Ste 2400</p>
+                      <p key="3">Boston, MA 02111</p>
+                      <p key="4">Phone: 508-555-5555</p>
+                      <p key="5">Fax: 781-555-5555</p>
+                      <p key="6">Email: bknight@zushealth.com</p>
+                    </p>
+                  </div>
+                  <div key="cell-0-3">
+                    <p>
+                      <b>Referred To Contact</b>
+                    </p>
+                    <p>
+                      <p key="0">Acme Health</p>
+                      <p key="1">200 Jefferson St</p>
+                      <p key="2">Newton, MA 02462-1607</p>
+                      <p key="3">Phone: 617-555-5555</p>
+                    </p>
+                  </div>
+                </div>
+                <div className="ctw-note-transposed">
+                  <div key="cell-0-0">
+                    <p>
+                      <b>Referral ID</b>
+                    </p>
+                    <p>789456789456</p>
+                  </div>
+                  <div key="cell-0-1">
+                    <p>
+                      <b>Status</b>
+                    </p>
+                    <p>Closed</p>
+                  </div>
+                  <div key="cell-0-2">
+                    <p>
+                      <b>Reason</b>
+                    </p>
+                    <p>{null}</p>
+                  </div>
+                  <div key="cell-0-3">
+                    <p>
+                      <b>Start Date</b>
+                    </p>
+                    <p>12/25/2022</p>
+                  </div>
+                  <div key="cell-0-4">
+                    <p>
+                      <b>Expiration Date</b>
+                    </p>
+                    <p>12/25/2022</p>
+                  </div>
+                  <div key="cell-0-5">
+                    <p>
+                      <b>Visits Requested</b>
+                    </p>
+                    <p>1</p>
+                  </div>
+                  <div key="cell-0-6">
+                    <p>
+                      <b>Visits Authorized</b>
+                    </p>
+                    <p>1</p>
+                  </div>
+                </div>
                 <table key="3">
                   <thead key="1">
                     <tr key="1">

--- a/src/components/content/resource/helpers/details-card.test.tsx
+++ b/src/components/content/resource/helpers/details-card.test.tsx
@@ -108,21 +108,15 @@ describe("detail card tests", () => {
           <div>
             <div className="ctw-note-transposed">
               <div key="cell-0-0">
-                <p>
-                  <b>Col 1</b>
-                </p>
+                <p className="ctw-font-medium">Col 1</p>
                 <p>hi</p>
               </div>
               <div key="cell-0-1">
-                <p>
-                  <b>Col 2</b>
-                </p>
+                <p className="ctw-font-medium">Col 2</p>
                 <p>hi again</p>
               </div>
               <div key="cell-0-2">
-                <p>
-                  <b>Col 3</b>
-                </p>
+                <p className="ctw-font-medium">Col 3</p>
                 <p>hi again again</p>
               </div>
             </div>
@@ -158,40 +152,28 @@ describe("detail card tests", () => {
           <div>
             <div className="ctw-note-transposed">
               <div key="cell-0-0">
-                <p>
-                  <b>Col 1</b>
-                </p>
+                <p className="ctw-font-medium">Col 1</p>
                 <p>hi</p>
               </div>
               <div key="cell-0-1">
-                <p>
-                  <b>Col 2</b>
-                </p>
+                <p className="ctw-font-medium">Col 2</p>
                 <p>hi again</p>
               </div>
               <div key="cell-0-2">
-                <p>
-                  <b>Col 3</b>
-                </p>
+                <p className="ctw-font-medium">Col 3</p>
                 <p>hi again again</p>
               </div>
               <div key="transpose-separator-0" className="ctw-note-transposed-row-separator" />
               <div key="cell-1-0">
-                <p>
-                  <b>Col 1</b>
-                </p>
+                <p className="ctw-font-medium">Col 1</p>
                 <p>goodbye</p>
               </div>
               <div key="cell-1-1">
-                <p>
-                  <b>Col 2</b>
-                </p>
+                <p className="ctw-font-medium">Col 2</p>
                 <p>goodbye again</p>
               </div>
               <div key="cell-1-2">
-                <p>
-                  <b>Col 3</b>
-                </p>
+                <p className="ctw-font-medium">Col 3</p>
                 <p>goodbye again again</p>
               </div>
             </div>
@@ -205,21 +187,15 @@ describe("detail card tests", () => {
         expected: (
           <div className="ctw-note-transposed">
             <div key="cell-0-0">
-              <p>
-                <b>Col 1</b>
-              </p>
+              <p className="ctw-font-medium">Col 1</p>
               <p>hi</p>
             </div>
             <div key="cell-0-1">
-              <p>
-                <b>Col 2</b>
-              </p>
+              <p className="ctw-font-medium">Col 2</p>
               <p>hi again</p>
             </div>
             <div key="cell-0-2">
-              <p>
-                <b>Col 3</b>
-              </p>
+              <p className="ctw-font-medium">Col 3</p>
               <p>hi again again</p>
             </div>
           </div>
@@ -235,15 +211,11 @@ describe("detail card tests", () => {
                 <h2 key={0}>Consultation (Within 1 month) - Closed</h2>
                 <div className="ctw-note-transposed">
                   <div key="cell-0-0">
-                    <p>
-                      <b>Specialty</b>
-                    </p>
+                    <p className="ctw-font-medium">Specialty</p>
                     <p>Neurology</p>
                   </div>
                   <div key="cell-0-1">
-                    <p>
-                      <b>Diagnoses / Procedures</b>
-                    </p>
+                    <p className="ctw-font-medium">Diagnoses / Procedures</p>
                     <p>
                       <p key="0">Diagnoses</p>
                       <p key="1">Muscular dystrophy.</p>
@@ -251,9 +223,7 @@ describe("detail card tests", () => {
                     </p>
                   </div>
                   <div key="cell-0-2">
-                    <p>
-                      <b>Referred By Contact</b>
-                    </p>
+                    <p className="ctw-font-medium">Referred By Contact</p>
                     <p>
                       <p key="0">Knight, Bryan J, DO</p>
                       <p key="1">1 Lincolon St</p>
@@ -265,9 +235,7 @@ describe("detail card tests", () => {
                     </p>
                   </div>
                   <div key="cell-0-3">
-                    <p>
-                      <b>Referred To Contact</b>
-                    </p>
+                    <p className="ctw-font-medium">Referred To Contact</p>
                     <p>
                       <p key="0">Acme Health</p>
                       <p key="1">200 Jefferson St</p>
@@ -278,45 +246,31 @@ describe("detail card tests", () => {
                 </div>
                 <div className="ctw-note-transposed">
                   <div key="cell-0-0">
-                    <p>
-                      <b>Referral ID</b>
-                    </p>
+                    <p className="ctw-font-medium">Referral ID</p>
                     <p>789456789456</p>
                   </div>
                   <div key="cell-0-1">
-                    <p>
-                      <b>Status</b>
-                    </p>
+                    <p className="ctw-font-medium">Status</p>
                     <p>Closed</p>
                   </div>
                   <div key="cell-0-2">
-                    <p>
-                      <b>Reason</b>
-                    </p>
+                    <p className="ctw-font-medium">Reason</p>
                     <p>{null}</p>
                   </div>
                   <div key="cell-0-3">
-                    <p>
-                      <b>Start Date</b>
-                    </p>
+                    <p className="ctw-font-medium">Start Date</p>
                     <p>12/25/2022</p>
                   </div>
                   <div key="cell-0-4">
-                    <p>
-                      <b>Expiration Date</b>
-                    </p>
+                    <p className="ctw-font-medium">Expiration Date</p>
                     <p>12/25/2022</p>
                   </div>
                   <div key="cell-0-5">
-                    <p>
-                      <b>Visits Requested</b>
-                    </p>
+                    <p className="ctw-font-medium">Visits Requested</p>
                     <p>1</p>
                   </div>
                   <div key="cell-0-6">
-                    <p>
-                      <b>Visits Authorized</b>
-                    </p>
+                    <p className="ctw-font-medium">Visits Authorized</p>
                     <p>1</p>
                   </div>
                 </div>

--- a/src/components/content/resource/helpers/details-card.tsx
+++ b/src/components/content/resource/helpers/details-card.tsx
@@ -73,6 +73,11 @@ export const recursivelyTransposeTables = (node: ReactNode, curDepth: number): R
 };
 
 const transposeTable = (tbl: ReactElement): ReactElement => {
+  // if there's no children, then return with original tbl
+  if (!tbl.props || !tbl.props.children || !Array.isArray(tbl.props.children)) {
+    return tbl;
+  }
+
   // find the thead, otherwise skip
   const theads = (tbl.props.children as ReactElement[]).filter((child) => child.type === "thead");
   if (theads.length !== 1) {

--- a/src/components/content/resource/helpers/details-card.tsx
+++ b/src/components/content/resource/helpers/details-card.tsx
@@ -111,9 +111,6 @@ const transposeTable = (tbl: ReactElement): ReactElement => {
     return tbl;
   }
 
-  // header values as the first column in the rows
-  const newRows = [] as JSX.Element[];
-
   const dataRows = Array.isArray(tbody.props.children)
     ? (tbody.props.children as ReactElement[])
     : ([tbody.props.children] as ReactElement[]);
@@ -121,29 +118,28 @@ const transposeTable = (tbl: ReactElement): ReactElement => {
     return tbl;
   }
 
-  // let transposeIdx = 0;
-  dataRows.forEach((dataRow, rowIdx) => {
+  const newRows = dataRows.reduce((acc, dataRow, rowIdx) => {
     // now for each cell in the data row
     const dataCells = Array.isArray(dataRow.props.children)
       ? (dataRow.props.children as ReactElement[])
       : ([dataRow.props.children] as ReactElement[]);
 
-    dataCells.forEach((dataCell, cellIdx) => {
+    const newDivs = dataCells.reduce((accRow, dataCell, cellIdx) => {
       const headerRow = headerRows[cellIdx];
 
-      newRows.push(
+      return [
+        ...accRow,
         // eslint-disable-next-line react/no-array-index-key
         <div key={`cell-${rowIdx}-${cellIdx}`}>
-          <p>
-            <b>{headerRow.props.children}</b>
-          </p>
+          <p className="ctw-font-medium">{headerRow.props.children}</p>
           <p>{dataCell.props.children}</p>
-        </div>
-      );
-    });
+        </div>,
+      ];
+    }, [] as ReactElement[]);
 
+    // add an extra div we need to separate data rows
     if (dataRows.length - 1 > rowIdx) {
-      newRows.push(
+      newDivs.push(
         <div
           // eslint-disable-next-line react/no-array-index-key
           key={`transpose-separator-${rowIdx}`}
@@ -151,7 +147,9 @@ const transposeTable = (tbl: ReactElement): ReactElement => {
         />
       );
     }
-  });
+
+    return [...acc, ...newDivs];
+  }, [] as ReactElement[]);
 
   return <div className="ctw-note-transposed">{newRows}</div>;
 };

--- a/src/components/content/resource/helpers/details-card.tsx
+++ b/src/components/content/resource/helpers/details-card.tsx
@@ -76,7 +76,7 @@ export const recursivelyTransposeTables = (node: ReactNode, curDepth: number): R
 
 const transposeTable = (tbl: ReactElement): ReactElement => {
   // if there's no children, then return with original tbl
-  if (!tbl.props || !tbl.props.children || !Array.isArray(tbl.props.children)) {
+  if (!Array.isArray(tbl.props?.children)) {
     return tbl;
   }
 

--- a/src/components/content/resource/helpers/details-card.tsx
+++ b/src/components/content/resource/helpers/details-card.tsx
@@ -183,7 +183,9 @@ const transposeTable = (tbl: ReactElement): ReactElement => {
 };
 
 export const DetailsCard = ({ details, hideEmpty = true, documentButton }: DetailsProps) => {
-  const [transposedValues, setTransposedValues] = useState([] as ReactNode[]);
+  const [transposedValues, setTransposedValues] = useState(
+    details.map(() => <div>Loading Note...</div>) as ReactNode[]
+  );
 
   // transposing the tables can take 1-2 seconds, so wrapping in an useEffect to
   // prevent the screen from freezing
@@ -206,7 +208,8 @@ export const DetailsCard = ({ details, hideEmpty = true, documentButton }: Detai
             // if we want to hide empty rows and the value is falsy and the value
             // is not zero, then hide it
             if (hideEmpty && !value && value !== 0) {
-              return <></>;
+              // eslint-disable-next-line react/no-array-index-key
+              return <div key={idx} />;
             }
 
             const valueWithTransposedTables = transposedValues[idx];

--- a/src/components/content/resource/helpers/note-style.scss
+++ b/src/components/content/resource/helpers/note-style.scss
@@ -11,3 +11,22 @@
 .responsiveTable tbody tr {
   border: 1px solid #fff;
 }
+
+.ctw-note-transposed {
+  display: block;
+  padding-bottom: 25px;
+}
+
+.ctw-note-transposed div {
+  display: block;
+  padding-bottom: 25px;
+}
+
+.ctw-note-transposed p {
+  padding: 0px;
+  margin: 0px;
+}
+
+.ctw-note-transposed-row-separator {
+  border-top: solid 1px #000;
+}


### PR DESCRIPTION
Addresses a few issues with clinical notes:
1. Verify the table actually has a `thead` and `tbody` before trying to transpose
2. Show loading status while transposing table
3. Switch from `<table>` to `<div>` for transposed rows. This results in a cleaner experience