### PR TITLE
CTW-1398 Remove version history from resource history drawer

### DIFF
--- a/.changeset/shaggy-crabs-press.md
+++ b/.changeset/shaggy-crabs-press.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Remove version history from resource history drawer

--- a/src/components/content/allergies/helpers/history.tsx
+++ b/src/components/content/allergies/helpers/history.tsx
@@ -10,7 +10,6 @@ export function useAllergiesHistory(allergy: AllergyModel) {
     resourceType: "AllergyIntolerance",
     model: allergy,
     queryKey: QUERY_KEY_ALLERGY_HISTORY,
-    includeVersionHistory: false,
     valuesToDedupeOn,
     getHistoryEntry,
     clientSideFiltersFQS,

--- a/src/services/fqs/queries/conditions.ts
+++ b/src/services/fqs/queries/conditions.ts
@@ -13,7 +13,7 @@ export interface ConditionGraphqlResponse {
 }
 
 export const conditionsQuery = gql`
-  ${fragmentCondition(false)}
+  ${fragmentCondition}
   query Conditions(
     $upid: ID!
     $cursor: String!

--- a/src/services/fqs/queries/fragments/condition.ts
+++ b/src/services/fqs/queries/fragments/condition.ts
@@ -1,10 +1,7 @@
 import { fragmentCoding, fragmentPatient } from "../fragments";
 
-export function fragmentCondition(isConditionHistory: boolean) {
-  const patientFragment = isConditionHistory ? "" : fragmentPatient;
-  const subjectFragment = isConditionHistory
-    ? ""
-    : `subject {
+const patientFragment = fragmentPatient;
+const subjectFragment = `subject {
       reference
       resource {
         ... on Patient {
@@ -19,7 +16,8 @@ export function fragmentCondition(isConditionHistory: boolean) {
         }
       }
     }`;
-  return `
+
+export const fragmentCondition = `
     ${fragmentCoding}
     ${patientFragment}
     fragment Condition on Condition {
@@ -129,4 +127,3 @@ export function fragmentCondition(isConditionHistory: boolean) {
       }
     }
   `;
-}

--- a/src/services/fqs/queries/versions.ts
+++ b/src/services/fqs/queries/versions.ts
@@ -20,7 +20,7 @@ export function versionsQuery(resourceType: ResourceTypeString, resourceIds: str
 function getResourceFragment(resourceType: ResourceTypeString) {
   switch (resourceType) {
     case "Condition":
-      return fragmentCondition(true);
+      return fragmentCondition;
     default:
       throw new Error(`Resource type to FQS query not implemented yet for ${resourceType}`);
   }


### PR DESCRIPTION
See [this slack thread](https://zushealth.slack.com/archives/C03NWTVCGJV/p1695221829563379) for background on discussion with product/UX.

Essentially we have deemed that it is unnecessary to surface the version history *of a single FHIR resource* in the history section of the details drawer. The primary intent of this section is to highlight what other organizations have participated in care, so being able to show something like the status transitions of a condition (eg. when it went from active to inactive) is not necessary. In an effort to simplify the code and the logic behind this feature, reduce calls to the back-end, and address the bug in CTW-1398 where we're showing "Unknown" as the title for older versions of a condition resource, we are removing this functionality.