### PR TITLE
CTW-1398 Show "Sourced from EHR Network" instead of "Unknown" for 3rd party data without a managing org

### DIFF
--- a/.changeset/nine-chefs-repair.md
+++ b/.changeset/nine-chefs-repair.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Display 'Sourced from EHR Network' instead of 'Unknown' for third party data that doesn't have a manging org.

--- a/src/components/content/allergies/helpers/column.tsx
+++ b/src/components/content/allergies/helpers/column.tsx
@@ -19,7 +19,7 @@ export const patientAllergiesColumns = (builderId: string) => {
       render: (allergy) => (
         <div>
           <div>{allergy.recordedDate}</div>
-          <div>{allergy.managingOrganization}</div>
+          <div>{allergy.patientOrganizationName}</div>
         </div>
       ),
     },

--- a/src/components/content/allergies/helpers/history.tsx
+++ b/src/components/content/allergies/helpers/history.tsx
@@ -41,14 +41,14 @@ function getHistoryEntry(allergy: AllergyModel): HistoryEntryProps {
     id: allergy.id,
     date: allergy.recordedDate,
     versionId: allergy.versionId,
-    title: allergy.managingOrganization,
+    title: allergy.patientOrganizationName,
     details: detailData,
   };
 }
 
 const valuesToDedupeOn = (allergy: AllergyModel) => [
   allergy.recordedDate,
-  allergy.managingOrganization,
+  allergy.patientOrganizationName,
   allergy.clinicalStatus,
   allergy.onset,
   allergy.manifestations,

--- a/src/components/content/allergies/patient-allergies.tsx
+++ b/src/components/content/allergies/patient-allergies.tsx
@@ -76,7 +76,7 @@ export const PatientAllergies = withErrorBoundary(PatientAllergiesComponent, "Pa
 
 export const allergyData = (allergy: AllergyModel) => [
   { label: "Recorded Date", value: allergy.recordedDate },
-  { label: "Recording Organization", value: allergy.managingOrganization },
+  { label: "Recording Organization", value: allergy.patientOrganizationName },
   { label: "Status", value: allergy.clinicalStatus },
   { label: "Type", value: capitalize(allergy.type) },
   { label: "Onset", value: allergy.onset },

--- a/src/fhir/models/allergies.ts
+++ b/src/fhir/models/allergies.ts
@@ -1,4 +1,5 @@
 import { FHIRModel } from "./fhir-model";
+import { PatientModel } from "./patient";
 import { formatDateISOToLocal } from "../formatters";
 import { findReference } from "../resource-helper";
 import { SYSTEM_NDC, SYSTEM_RXNORM, SYSTEM_SNOMED } from "../system-urls";
@@ -45,22 +46,19 @@ export class AllergyModel extends FHIRModel<fhir4.AllergyIntolerance> {
     return manifestations.join(", ");
   }
 
-  get managingOrganization(): string | undefined {
-    const organizationDisplay = findReference(
+  get patientOrganizationName(): string | undefined {
+    const reference = findReference(
       "Patient",
       this.resource.contained,
       this.includedResources,
       this.resource.patient
     );
 
-    const organizationName = findReference(
-      "Organization",
-      this.resource.contained,
-      this.includedResources,
-      organizationDisplay?.managingOrganization
-    )?.name;
+    if (reference) {
+      return new PatientModel(reference, this.includedResources).organizationDisplayName;
+    }
 
-    return organizationDisplay?.managingOrganization?.display || organizationName;
+    return undefined;
   }
 
   get note(): string | undefined {

--- a/src/fhir/models/condition.ts
+++ b/src/fhir/models/condition.ts
@@ -234,7 +234,7 @@ export class ConditionModel extends FHIRModel<fhir4.Condition> {
     );
 
     if (reference) {
-      return new PatientModel(reference, this.includedResources).organization?.name;
+      return new PatientModel(reference, this.includedResources).organizationDisplayName;
     }
 
     return undefined;

--- a/src/fhir/models/fhir-model.ts
+++ b/src/fhir/models/fhir-model.ts
@@ -92,6 +92,10 @@ export abstract class FHIRModel<T extends fhir4.Resource> {
     return find(this.resource.meta?.tag, { system: SYSTEM_SUMMARY }) !== undefined;
   }
 
+  get isThirdPartyData(): boolean {
+    return this.resource.meta?.tag?.some((t) => t.system === SYSTEM_ZUS_THIRD_PARTY) ?? false;
+  }
+
   get patientUPID(): string | undefined {
     if (isFHIRDomainResource(this.resource)) {
       return find(this.resource.extension, { url: SYSTEM_ZUS_UNIVERSAL_ID })?.valueString;

--- a/src/fhir/models/patient.ts
+++ b/src/fhir/models/patient.ts
@@ -69,6 +69,16 @@ export class PatientModel extends FHIRModel<fhir4.Patient> {
     return undefined;
   }
 
+  get organizationDisplayName(): string | undefined {
+    if (this.organization) {
+      return this.organization.name;
+    }
+    if (this.isThirdPartyData) {
+      return "Sourced from EHR Network";
+    }
+    return undefined;
+  }
+
   get use(): fhir4.HumanName["use"] | undefined {
     return this.bestName.use;
   }


### PR DESCRIPTION
Some 3rd party networks contribute data to patients with no managing organization. This results in "Unknown" showing up in the app. We should use the phrase "Sourced from EHR Networks". Discussed w/ UX.