### PR TITLE
CTW-1388 Enable semantic and generative search results

### DIFF
--- a/.changeset/violet-oranges-applaud.md
+++ b/.changeset/violet-oranges-applaud.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Enable semantic and generative AI search results.

--- a/src/components/content/patient-record-search/patient-record-search.tsx
+++ b/src/components/content/patient-record-search/patient-record-search.tsx
@@ -6,7 +6,6 @@ import { SearchResultRow } from "./helpers/search-result-row";
 import { FeedbackForm } from "@/components/content/patient-record-search/helpers/feedback-form";
 import { FeedbackProvider } from "@/components/content/patient-record-search/helpers/feedback-provider";
 import { ErrorAlert } from "@/components/core/alert";
-import { Title } from "@/components/core/ctw-box";
 import { withErrorBoundary } from "@/components/core/error-boundary";
 import { Loading } from "@/components/core/loading";
 import { DEFAULT_PAGE_SIZE, ExpandList } from "@/components/core/pagination/expand-list";
@@ -21,11 +20,10 @@ import {
 import "./helpers/style.scss";
 
 export type PatientRecordSearchProps = {
-  hideTitle?: boolean;
   className?: cx.Argument;
 };
 
-function PatientRecordSearchComponent({ className, hideTitle = false }: PatientRecordSearchProps) {
+function PatientRecordSearchComponent({ className }: PatientRecordSearchProps) {
   const [count, setCount] = useState(DEFAULT_PAGE_SIZE);
   const [searchTextInputValue, setSearchTextInputValue] = useState("");
   const [searchValue, setSearchValue] = useState("");
@@ -35,14 +33,14 @@ function PatientRecordSearchComponent({ className, hideTitle = false }: PatientR
     isFetching,
     isLoading,
     isError,
-  } = usePatientRecordSearch(searchValue);
+  } = usePatientRecordSearch(searchValue, searchWasQuestion);
   const { trackInteraction } = useAnalytics();
 
   const handleSubmitForm = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       const query = searchTextInputValue.trim();
-      setSearchWasQuestion(query[query.length - 1] === "?");
+      setSearchWasQuestion(query.endsWith("?"));
       setSearchValue(query);
       setCount(DEFAULT_PAGE_SIZE);
       trackInteraction("search", { action: "patient-record-search" });
@@ -70,14 +68,6 @@ function PatientRecordSearchComponent({ className, hideTitle = false }: PatientR
         "ctw-patient-record-search ctw-scrollable-pass-through-height ctw-space-x-0 ctw-space-y-2 ctw-text-base"
       )}
     >
-      <RenderIf condition={!hideTitle}>
-        <Title className="ctw-border-0 ctw-border-b-0 ctw-border-solid ctw-border-divider-light">
-          <h3 className="ctw-m-0 ctw-inline-block ctw-p-0 ctw-pb-3 ctw-text-lg ctw-font-medium ctw-capitalize">
-            search records
-          </h3>
-        </Title>
-      </RenderIf>
-
       <form className="ctw-patient-record-search-input ctw-relative" onSubmit={handleSubmitForm}>
         <div className="ctw-search-icon-wrapper">
           <SearchIcon className="ctw-search-icon" />
@@ -103,48 +93,48 @@ function PatientRecordSearchComponent({ className, hideTitle = false }: PatientR
       ) : (
         <div className="ctw-patient-record-search-results-list ctw-scrollable-pass-through-height">
           <div className="ctw-patient-record-search-results ctw-align-left ctw-ml-0">
-            <RenderIf condition={!userHasSearched}>
-              <span className="ctw-text-1xl ctw-text-content-dark ctw-block ctw-text-left ctw-font-medium">
-                Search patient conditions, medications, documents and allergies.
-              </span>
-            </RenderIf>
+            {/* FeedbackProvider will allow all the feedback forms to get the id of the query */}
+            <FeedbackProvider id={data.id}>
+              <RenderIf condition={!userHasSearched}>
+                <span className="ctw-text-1xl ctw-text-content-dark ctw-block ctw-text-left ctw-font-medium">
+                  Search patient conditions, medications, documents and allergies.
+                </span>
+              </RenderIf>
 
-            <RenderIf condition={userHasSearched && !hasResults && !isError}>
-              <span className="ctw-text-1xl ctw-text-content-dark ctw-block ctw-text-left ctw-font-medium">
-                Search did not return any results.
-              </span>
-            </RenderIf>
+              <RenderIf condition={isError}>
+                <div className="ctw-w-full">
+                  <ErrorAlert header="Error">There was an error running your search.</ErrorAlert>
+                </div>
+              </RenderIf>
 
-            <RenderIf condition={isError}>
-              <div className="ctw-w-full">
-                <ErrorAlert header="Error">There was an error running your search.</ErrorAlert>
-              </div>
-            </RenderIf>
+              <RenderIf condition={userHasSearched && searchWasQuestion && !isError}>
+                <div className="ctw-pb-5 ctw-font-normal">
+                  {data.response}
+                  <FeedbackForm name="query-response" />
+                </div>
+              </RenderIf>
 
-            {/* user has made a search and there are results */}
-            <RenderIf condition={userHasSearched && hasResults}>
-              {/* FeedbackProvider will allow all the feedback forms to get the id of the query */}
-              <FeedbackProvider id={data.id}>
-                <RenderIf condition={searchWasQuestion}>
-                  <span className="ctw-font-normal">
-                    {data.response}
-                    <FeedbackForm name="query-response" />
-                  </span>
-                </RenderIf>
+              <RenderIf condition={userHasSearched && !hasResults && !isError}>
+                <span className="ctw-text-1xl ctw-text-content-dark ctw-block ctw-text-left ctw-font-medium">
+                  Search did not find results.
+                </span>
+              </RenderIf>
 
+              {/* user has made a search and there are results */}
+              <RenderIf condition={userHasSearched && hasResults}>
                 {/* Search Results */}
                 <span className="ctw-text-1xl ctw-text-content-dark ctw-block ctw-text-left ctw-font-medium">
-                  Found {data.results.length} results
+                  Found {data.results.length} results.
                 </span>
                 {data.results.slice(0, count).map((result: PatientRecordSearchResult, idx) => (
                   // eslint-disable-next-line react/no-array-index-key
                   <SearchResultRow key={idx} document={result.document} />
                 ))}
-              </FeedbackProvider>
-              <div className="ctw-mt-5">
-                <ExpandList total={data.results.length} count={count} changeCount={setCount} />
-              </div>
-            </RenderIf>
+                <div className="ctw-mt-5">
+                  <ExpandList total={data.results.length} count={count} changeCount={setCount} />
+                </div>
+              </RenderIf>
+            </FeedbackProvider>
           </div>
         </div>
       )}

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile.tsx
@@ -193,10 +193,7 @@ const ZusAggregatedProfileComponent = ({
 
         {/* If Patient Search is open, show it instead of tabs */}
         <RenderIf condition={patientRecordSearchIsOpen}>
-          <PatientRecordSearch
-            hideTitle
-            className="ctw-mt-3 ctw-flex ctw-space-x-5 ctw-border-b ctw-border-divider-light"
-          />
+          <PatientRecordSearch className="ctw-mt-3 ctw-flex ctw-space-x-5 ctw-border-b ctw-border-divider-light" />
         </RenderIf>
 
         {/* Show tabs when Patient Search isn't open */}

--- a/src/fhir/document.ts
+++ b/src/fhir/document.ts
@@ -83,7 +83,9 @@ export async function getDocumentsByIdFromFQS(
         cursor: "",
         first: 1000,
         filter: {
-          id: ["in", ids],
+          ids: {
+            anymatch: ids,
+          },
         },
         sort: {
           lastUpdated: "DESC",

--- a/src/services/fqs/queries/documents.ts
+++ b/src/services/fqs/queries/documents.ts
@@ -19,9 +19,16 @@ export const documentsQuery = gql`
     $upid: ID!
     $cursor: String!
     $sort: DocumentReferenceSortParams!
+    $filter: DocumentReferenceFilterParams! = {}
     $first: Int!
   ) {
-    DocumentReferenceConnection(upid: $upid, after: $cursor, sort: $sort, first: $first) {
+    DocumentReferenceConnection(
+      upid: $upid
+      after: $cursor
+      sort: $sort
+      filter: $filter
+      first: $first
+    ) {
       pageInfo {
         hasNextPage
       }

--- a/src/services/patient-record-search/patient-record-search.ts
+++ b/src/services/patient-record-search/patient-record-search.ts
@@ -214,7 +214,7 @@ export function usePatientRecordSearch(
           query: searchTerm,
           upid: patient.UPID,
           include: searchOptions,
-          n_results: includeAnswer ? 4 : 10,
+          n_results: includeAnswer ? 4 : 10, // TODO: This is a temporary hack to be kind to the search API when requesting the generative AI response.
           resource_types: [
             "AllergyIntolerance",
             "Condition",

--- a/src/services/patient-record-search/patient-record-search.ts
+++ b/src/services/patient-record-search/patient-record-search.ts
@@ -17,7 +17,7 @@ import { DocumentModel } from "@/fhir/models/document";
 import { fetchObservationsById } from "@/fhir/observations";
 import { LENS_EXTENSION_ID } from "@/fhir/system-urls";
 import { fetchConditionsByIdFQS } from "@/services/conditions";
-import { groupBy, keyBy, mapValues } from "@/utils/nodash";
+import { groupBy, keyBy, mapValues, uniq } from "@/utils/nodash";
 import { QUERY_KEY_AI_SEARCH } from "@/utils/query-keys";
 
 type PatientRecordSearchResourceType =
@@ -186,7 +186,8 @@ class PatientRecordSearch {
 }
 
 export function usePatientRecordSearch(
-  searchTerm: string
+  searchTerm: string,
+  includeAnswer: boolean
 ): UseQueryResult<PatientRecordSearchResults> {
   return useQueryWithPatient(
     QUERY_KEY_AI_SEARCH,
@@ -196,14 +197,24 @@ export function usePatientRecordSearch(
       const fetchResourcesById = async <T>(
         ids: string[],
         fn: (r: CTWRequestContext, p: PatientModel, ids: string[]) => Promise<T[]>
-      ): Promise<T[]> => (ids.length === 0 ? [] : fn(requestContext, patient, ids));
+      ): Promise<T[]> => (ids.length === 0 ? [] : fn(requestContext, patient, uniq(ids)));
 
       if (searchTerm) {
+        const searchOptions = ["keyword"];
+
+        if (includeAnswer) {
+          searchOptions.push("answer");
+        }
+
+        if (searchTerm.split(" ").length > 2) {
+          searchOptions.push("semantic");
+        }
+
         const body = JSON.stringify({
           query: searchTerm,
           upid: patient.UPID,
-          include: ["keyword"], // , "semantic"],
-          n_results: 10,
+          include: searchOptions,
+          n_results: includeAnswer ? 4 : 10,
           resource_types: [
             "AllergyIntolerance",
             "Condition",
@@ -257,7 +268,9 @@ export function usePatientRecordSearch(
           id: patientRecordSearchResult.id,
           query: patientRecordSearchResult.queryString,
           response: patientRecordSearchResult.responseString,
-          results: patientRecordSearchResult.filteredResults,
+          results: patientRecordSearchResult.filteredResults.sort((r) =>
+            r.document.reason.search_type.includes("semantic") ? 1 : -1
+          ),
           total: patientRecordSearchResult.filteredResults.length,
         };
       }


### PR DESCRIPTION
Updating search so that we include the semantic search if the search phrase has more than 2 words. If the user ends with a question mark we'll also include the AI generated response. This behavior is subject to change in the future, just doing this as a short term way of making it available in the app.

Also fixing an issue with how we retrieve documents from FQS by ID.