### PR TITLE
Fix add filter button text whitespace breaking

### DIFF
--- a/.changeset/clever-plums-fly.md
+++ b/.changeset/clever-plums-fly.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix whitespace breaking on "add filter" dropdown.

--- a/src/components/core/list-box/list-box.tsx
+++ b/src/components/core/list-box/list-box.tsx
@@ -106,7 +106,7 @@ export const ListBox = forwardRef(
                       )}
                     >
                       <span
-                        className={cx("ctw-inline-flex ctw-align-middle", {
+                        className={cx("ctw-inline-flex ctw-whitespace-nowrap ctw-align-middle", {
                           "ctw-font-semibold": selected && !useBasicStyles,
                         })}
                       >


### PR DESCRIPTION
Change "Add Filter" dropdown whitespace to not break lines
<img width="182" alt="Screenshot 2023-09-25 at 2 01 10 PM" src="https://github.com/zeus-health/ctw-component-library/assets/6380075/e752c810-58ac-4687-b636-673f39927ce7">

and instead to stay on the same line
<img width="288" alt="Screenshot 2023-09-25 at 2 00 18 PM" src="https://github.com/zeus-health/ctw-component-library/assets/6380075/c19d375e-24a5-4900-87c8-9f06bdd5ad67">
