### PR TITLE
IFrame ZAP to pass same theme to CTWProvider as parent window.

### DIFF
--- a/.changeset/gorgeous-tomatoes-sell.md
+++ b/.changeset/gorgeous-tomatoes-sell.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+IFrame theme is passed to iframe with CTWProviderProps to fix a UX bug caused by the iframe ZAPs ThemeProvider having different context value than the parent window ThemeProvider.

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
@@ -170,7 +170,10 @@ const ZusAggregatedProfileIFrameComponent = (props: ZusAggregatedProfileProps) =
         enableTelemetry: telemetry.enableTelemetry,
         headers: requestContext.headers as Record<string, string> | undefined,
         locals: theme.locals,
-        theme: theme.theme,
+        theme: {
+          ...theme.theme,
+          iframe: theme.iframeTheme,
+        },
       };
 
       const patientProviderProps = {
@@ -189,6 +192,7 @@ const ZusAggregatedProfileIFrameComponent = (props: ZusAggregatedProfileProps) =
               medicationsOutsideProps: omit("onAddToRecord", props.medicationsOutsideProps),
               medicationsAllProps: omit("onAddToRecord", props.medicationsAllProps),
             },
+            // todo: refactor this out. It is redundant with CTWProviderProps.theme.iframe but it's expected by the standalone ZAP.
             iframeTheme: theme.iframeTheme,
           },
         },


### PR DESCRIPTION
IFrame ZAP should have the same ThemeProvider context as the parent window ThemeProvider. The `theme` passed into `CTWProvider` contains both the tailwind theme and iframe theme. The `ZusAggregatedProfileIFrame` component gets those two themes from the `ThemeProvider` as separate objects. Originally we would send the iframe theme as a separate configuration to the standalone ZAP, but then in the standalone ZAP the `ThemeProvider` actually doesn't have the iframe theme. The `Drawer` component now uses the `ThemeProvider` to access the iframe theme as well so we need to make sure it's in the `CTWProviderProps["theme"]` sent to the iframe. 