### PR TITLE
CDEV-471 ADT Table: Add 7days, remove all time

### DIFF
--- a/.changeset/wet-cheetahs-prove.md
+++ b/.changeset/wet-cheetahs-prove.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Changes the views for the ADT table to inclue past 7 days and instead of all time, 90 days.

--- a/src/components/content/patients-adt/patients-adt-alerts-table.tsx
+++ b/src/components/content/patients-adt/patients-adt-alerts-table.tsx
@@ -96,7 +96,8 @@ function ADTTableComponent({
   const openADTDetails = useADTAlertDetailsDrawer();
   const [currentPage, setCurrentPage] = useState(1);
   const { getRequestContext } = useCTW();
-  const { viewOptions, past30days } = getDateRangeView<EncounterModel>("periodStart");
+  const { past7days, past30days, past3months, past6Months, pastYear } =
+    getDateRangeView<EncounterModel>("periodStart");
   const {
     data: dataFilteredSorted,
     setViewOption,
@@ -109,6 +110,7 @@ function ADTTableComponent({
     records: data,
   });
 
+  const viewOptions = [past7days, past30days, past3months, past6Months, pastYear];
   const dataFilteredSortedDeduped = dedupeAndMergeEncounters(dataFilteredSorted, "patientsADT");
   const dataOnPage = dataFilteredSortedDeduped.slice(
     (currentPage - 1) * PAGE_SIZE,

--- a/src/components/content/patients-adt/patients-adt-alerts-table.tsx
+++ b/src/components/content/patients-adt/patients-adt-alerts-table.tsx
@@ -96,8 +96,7 @@ function ADTTableComponent({
   const openADTDetails = useADTAlertDetailsDrawer();
   const [currentPage, setCurrentPage] = useState(1);
   const { getRequestContext } = useCTW();
-  const { past7days, past30days, past3months, past6Months, pastYear } =
-    getDateRangeView<EncounterModel>("periodStart");
+  const { past7days, past30days, past3months } = getDateRangeView<EncounterModel>("periodStart");
   const {
     data: dataFilteredSorted,
     setViewOption,
@@ -110,7 +109,7 @@ function ADTTableComponent({
     records: data,
   });
 
-  const viewOptions = [past7days, past30days, past3months, past6Months, pastYear];
+  const viewOptions = [past7days, past30days, past3months];
   const dataFilteredSortedDeduped = dedupeAndMergeEncounters(dataFilteredSorted, "patientsADT");
   const dataOnPage = dataFilteredSortedDeduped.slice(
     (currentPage - 1) * PAGE_SIZE,

--- a/src/components/content/resource/helpers/view-date-range.ts
+++ b/src/components/content/resource/helpers/view-date-range.ts
@@ -11,6 +11,10 @@ function dateFilter<T extends object>(field: keyof T, days: number) {
 export function getDateRangeView<T extends object>(field: Extract<keyof T, string>) {
   const viewOptions: ViewOption<T>[] = [
     {
+      display: "Past 7 days",
+      filters: [dateFilter<T>(field, 7)],
+    },
+    {
       display: "Past 30 days",
       filters: [dateFilter<T>(field, 30)],
     },
@@ -33,9 +37,11 @@ export function getDateRangeView<T extends object>(field: Extract<keyof T, strin
   ];
   return {
     viewOptions,
-    past30days: viewOptions[0],
-    past3months: viewOptions[1],
-    past6Months: viewOptions[2],
-    allTime: viewOptions[4],
+    past7days: viewOptions[0],
+    past30days: viewOptions[1],
+    past3months: viewOptions[2],
+    past6Months: viewOptions[3],
+    pastYear: viewOptions[4],
+    allTime: viewOptions[5],
   };
 }


### PR DESCRIPTION
CDEV-471
Changes the views for the ADT table to inclue past 7 days and instead of all time, 90 days