### PR TITLE
CTW-1445 Modify subscription description

### DIFF
--- a/.changeset/clean-dryers-tell.md
+++ b/.changeset/clean-dryers-tell.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Modify subscription descriptions and make text smaller

--- a/src/components/content/encounters/helpers/modal-hooks.tsx
+++ b/src/components/content/encounters/helpers/modal-hooks.tsx
@@ -3,6 +3,7 @@ import { Notes } from "../../resource/helpers/notes";
 import { useResourceDetailsDrawer } from "../../resource/resource-details-drawer";
 import { EncounterModel } from "@/fhir/models/encounter";
 import { parseWithoutFormat } from "@/utils/dates";
+import { orderBy } from "@/utils/nodash";
 import { capitalize } from "@/utils/nodash/fp";
 
 export function usePatientEncounterDetailsDrawer() {
@@ -34,7 +35,8 @@ export function usePatientEncounterDetailsDrawer() {
     getSourceDocument: true,
     details: encounterData,
     enableDismissAndReadActions: true,
-    renderChild: (m) => m.clinicalNotes.length > 0 && <Notes entries={m.clinicalNotes} />,
+    renderChild: (m) =>
+      m.clinicalNotes.length > 0 && <Notes entries={orderBy(m.clinicalNotes, "title")} />,
   });
 }
 

--- a/src/components/content/overview/patient-subscription.test.ts
+++ b/src/components/content/overview/patient-subscription.test.ts
@@ -12,7 +12,7 @@ describe("getDataSources", () => {
       meta: {
         freshmakerProviders: ["commonwell"],
         initialProviders: ["bamboo"],
-        subscriptionProviders: ["test"],
+        subscriptionProviders: ["test", "bamboo"],
         recurringProvidersWithInterval: [{ provider: "commonwell", intervalDays: 7 }],
       },
     },
@@ -24,11 +24,11 @@ describe("getDataSources", () => {
     const expectedOutput = [
       {
         name: "EHR Network",
-        details: ["intelligent refresh", "full refresh at least every 7 days"],
+        details: ["intelligent refresh"],
       },
       {
         name: "ADT",
-        details: ["initial history pull"],
+        details: ["initial history pull", "new data alerts"],
       },
       {
         name: "test",

--- a/src/components/content/overview/patient-subscription.tsx
+++ b/src/components/content/overview/patient-subscription.tsx
@@ -50,17 +50,19 @@ export const PatientSubscriptionDetails = () => {
     );
   }
 
-  const dataSources = getDataSources(
-    patient.data.isTestPatient && !patientSubscription.data.package // If a test/demo patient doesn't have a package then use this demo content
+  // If a test/demo patient doesn't have a package then use this demo content
+  const patientPackage =
+    patient.data.isTestPatient && !patientSubscription.data.package
       ? demoPatientSubscription
-      : patientSubscription.data
-  );
+      : patientSubscription.data;
+
+  const dataSources = getDataSources(patientPackage);
 
   return (
-    <>
+    <div className="ctw-text-sm">
       <div>
         <span className="ctw-font-medium">{patient.data.display}</span> is enrolled in{" "}
-        <span className="ctw-font-medium">{patientSubscription.data.package?.name}</span>
+        <span className="ctw-font-medium">{patientPackage.package?.name}</span>
       </div>
       <div className="ctw-pt-3">This provides access to the following data:</div>
       <ul className="ctw-mx-0 ctw-list-disc ctw-pl-4">
@@ -70,7 +72,7 @@ export const PatientSubscriptionDetails = () => {
           </li>
         ))}
       </ul>
-    </>
+    </div>
   );
 };
 
@@ -110,12 +112,9 @@ export const getDataSources = (patientSubscription: PatientSubscription) => {
       name: s,
       details: compact([
         translatedPackages.initialProviders.includes(s) && "initial history pull",
-        translatedPackages.freshmakerProviders.includes(s) && "intelligent refresh",
-        translatedPackages.recurringProvidersWithInterval.some((x) => x.provider === s) &&
-          `full refresh at least every ${
-            translatedPackages.recurringProvidersWithInterval.find((x) => x.provider === s)
-              ?.intervalDays
-          } days`,
+        (translatedPackages.freshmakerProviders.includes(s) ||
+          translatedPackages.recurringProvidersWithInterval.some((x) => x.provider === s)) &&
+          "intelligent refresh",
         translatedPackages.subscriptionProviders.includes(s) && "new data alerts",
       ]),
     };


### PR DESCRIPTION
Modifying the subscription description to exclude references to specific time intervals (per DA's direction), making the description text smaller, and ordering notes in encounter drawer alphabetically to be consistent with document drawer.