### PR TITLE
CTW-1445 Hiding subscription info until we get permissions sorted out

### DIFF
--- a/.changeset/twelve-islands-share.md
+++ b/.changeset/twelve-islands-share.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Hide subscription info until permissions sorted out

--- a/src/components/content/overview/patient-overview.tsx
+++ b/src/components/content/overview/patient-overview.tsx
@@ -1,4 +1,3 @@
-import { PatientSubscriptionDetails } from "./patient-subscription";
 import { PatientHistoryLastRetrievedWithAction } from "../patient-history/patient-history-action";
 import { PatientRecordSearch } from "../patient-record-search/patient-record-search";
 import { withErrorBoundary } from "@/components/core/error-boundary";
@@ -13,9 +12,10 @@ export const PatientOverviewComponent = ({
   <div className="ctw-flex ctw-w-full ctw-flex-row">
     <div className="ctw-mx-2 ctw-my-5 ctw-h-fit ctw-basis-2/6 ctw-rounded-lg ctw-border ctw-border-solid ctw-border-divider-light">
       <div className="ctw-space-y-2 ctw-p-2">
-        <div className="ctw-px-3 ctw-pt-3">
+        {/* const searchIsEnabled = useHasFeatureFlag(FeatureFlags.patientRecordSearch); */}
+        {/* <div className="ctw-px-3 ctw-pt-3">
           <PatientSubscriptionDetails />
-        </div>
+        </div> */}
         <div className="ctw-border-0 ctw-border-t ctw-border-solid ctw-border-divider-light ctw-px-3 ctw-pt-3">
           <PatientHistoryLastRetrievedWithAction
             includePatientDemographicsForm={includePatientDemographicsForm}

--- a/src/components/content/overview/patient-overview.tsx
+++ b/src/components/content/overview/patient-overview.tsx
@@ -16,7 +16,7 @@ export const PatientOverviewComponent = ({
         {/* <div className="ctw-px-3 ctw-pt-3">
           <PatientSubscriptionDetails />
         </div> */}
-        <div className="ctw-border-0 ctw-border-t ctw-border-solid ctw-border-divider-light ctw-px-3 ctw-pt-3">
+        <div className="ctw-px-3 ctw-pt-3">
           <PatientHistoryLastRetrievedWithAction
             includePatientDemographicsForm={includePatientDemographicsForm}
           />

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ export * from "@/components/content/conditions/patient-conditions-outside-badge"
 export * from "@/components/content/conditions/patient-conditions-profile";
 export * from "@/components/content/conditions/unread-conditions-notification";
 export * from "@/components/content/care-team/patient-careteam";
+export * from "@/components/content/overview/patient-overview";
+export * from "@/components/content/overview/patient-subscription";
 export * from "@/components/content/diagnostic-reports/patient-diagnostic-reports";
 export * from "@/components/content/diagnostic-reports/unread-diagnostic-reports-notification";
 export * from "@/components/content/document/patient-documents";


### PR DESCRIPTION
Care team users don't currently have the necessary permissions to view package metadata, so they get a 401 when we try to display patient subscriptions. Temporarily removing this functionality until we get the permissions sorted out. Also exporting the overview component and the subscription description component so we can use them in standalone.