### PR TITLE
Add padding to sides of resource action buttons on xs viewport

### DIFF
--- a/.changeset/yellow-doors-drum.md
+++ b/.changeset/yellow-doors-drum.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Add padding to sides of resource action buttons on xs breakpoints.

--- a/src/components/content/resource/helpers/view-button.tsx
+++ b/src/components/content/resource/helpers/view-button.tsx
@@ -30,7 +30,7 @@ export const ViewButton = <T extends object>({
   return (
     <DropdownMenuAction
       type="select"
-      buttonClassName={cx(className, "ctw-bg-transparent ctw-border-none ctw-p-0")}
+      buttonClassName={cx(className, "ctw-bg-transparent ctw-border-none ctw-p-0 max-sm:ctw-px-2")}
       onItemSelect={(item) => {
         const selectedOption = options.filter((option) => option.display === item.key)[0];
         onChange(selectedOption);

--- a/src/components/content/resource/resource-table-actions.tsx
+++ b/src/components/content/resource/resource-table-actions.tsx
@@ -52,7 +52,7 @@ export const ResourceTableActions = <T extends MinRecordItem>({
         )}
         {filterOptions && filterOptions.filters.length > 0 && <FilterBar {...filterOptions} />}
       </div>
-      <div className="ctw-mb-2 ctw-ml-0 ctw-w-full ctw-whitespace-nowrap sm:ctw-mb-0 sm:ctw-ml-auto sm:ctw-w-auto">
+      <div className="ctw-mb-2 ctw-ml-0 ctw-w-full ctw-whitespace-nowrap max-sm:ctw-px-2 sm:ctw-mb-0 sm:ctw-ml-auto sm:ctw-w-auto">
         {action}
       </div>
     </div>

--- a/src/components/core/drawer.tsx
+++ b/src/components/core/drawer.tsx
@@ -171,7 +171,7 @@ function DrawerContent({
                 {showCloseFooter && (
                   <Drawer.Footer>
                     <Drawer.CloseButton
-                      label="Close"
+                      label={showBackButton ? "Back" : "Close"}
                       onClose={() => {
                         onClose();
                         trackInteraction("close_drawer", {

--- a/src/components/core/filter-bar/filter-bar.tsx
+++ b/src/components/core/filter-bar/filter-bar.tsx
@@ -215,7 +215,7 @@ export const FilterBar = ({ className, onChange, filters, defaultState = {} }: F
           }
         }}
       >
-        <div className="ctw-mb-2 ctw-space-x-1 ctw-whitespace-nowrap ctw-py-2">
+        <div className="ctw-mb-2 ctw-space-x-1 ctw-whitespace-nowrap ctw-py-2 max-sm:ctw-px-2">
           <FontAwesomeIcon icon={faPlus} className="ctw-w-4" />
           <span>Add Filters</span>
         </div>

--- a/src/components/core/sort-button/sort-button.tsx
+++ b/src/components/core/sort-button/sort-button.tsx
@@ -30,7 +30,7 @@ export const SortButton = <T extends object>({
   return (
     <DropdownMenuAction
       type="select"
-      buttonClassName={cx(className, "ctw-bg-transparent ctw-border-none ctw-p-0")}
+      buttonClassName={cx(className, "ctw-bg-transparent ctw-border-none ctw-p-0 max-sm:ctw-px-2")}
       onItemSelect={(item) => {
         const selectedOption = options.filter((option) => option.display === item.key)[0];
         onChange(selectedOption);


### PR DESCRIPTION
When the resource action buttons (view, sort and filter) were on small screens they went full width. This PR makes it so their edges align with the other content of the ZAP.

<img width="606" alt="Screenshot 2023-10-06 at 2 03 13 PM" src="https://github.com/zeus-health/ctw-component-library/assets/6380075/35410cc6-4cda-4b8a-a29e-1ff7864cc8c8">


Additionally on iframe the "Close" button on drawer now says, "Back" to match the close button icon switch from ❌ to ◀️ .