### PR TITLE
add lint rules around react query

### DIFF
--- a/.changeset/thirty-turtles-smell.md
+++ b/.changeset/thirty-turtles-smell.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Add react query linting rules.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,8 +2,8 @@
  * @type {import('@types/eslint').Linter.BaseConfig}
  */
 module.exports = {
-  extends: ["@kensho-technologies/eslint-config", "prettier"],
-  plugins: ["unused-imports", "sort-exports"],
+  extends: ["@kensho-technologies/eslint-config"],
+  plugins: ["unused-imports", "sort-exports", "@tanstack/query"],
   // Ignore js files as we now have typescript parsing rules.
   // See https://stackoverflow.com/a/65063702 for more.
   ignorePatterns: [
@@ -21,6 +21,9 @@ module.exports = {
     project: ["./tsconfig.json"],
   },
   rules: {
+    "@tanstack/query/exhaustive-deps": "error",
+    "@tanstack/query/prefer-query-object-syntax": "warn",
+    "@tanstack/query/stable-query-client": "error",
     "@typescript-eslint/await-thenable": "error",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-unnecessary-condition": "error",

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,7 +3,7 @@
  */
 module.exports = {
   extends: ["@kensho-technologies/eslint-config"],
-  plugins: ["unused-imports", "sort-exports", "@tanstack/query"],
+  plugins: ["unused-imports", "sort-exports", "prettier", "@tanstack/query"],
   // Ignore js files as we now have typescript parsing rules.
   // See https://stackoverflow.com/a/65063702 for more.
   ignorePatterns: [

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,8 +2,8 @@
  * @type {import('@types/eslint').Linter.BaseConfig}
  */
 module.exports = {
-  extends: ["@kensho-technologies/eslint-config"],
-  plugins: ["unused-imports", "sort-exports", "prettier", "@tanstack/query"],
+  extends: ["@kensho-technologies/eslint-config", "prettier"],
+  plugins: ["unused-imports", "sort-exports", "@tanstack/query"],
   // Ignore js files as we now have typescript parsing rules.
   // See https://stackoverflow.com/a/65063702 for more.
   ignorePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "1.69.6",
+  "version": "1.69.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "1.69.6",
+      "version": "1.69.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -47,6 +47,7 @@
         "@faker-js/faker": "^7.6.0",
         "@kensho-technologies/eslint-config": "^26.1.2",
         "@tailwindcss/line-clamp": "^0.4.4",
+        "@tanstack/eslint-plugin-query": "^4.36.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "12.1.5",
         "@testing-library/user-event": "^14.4.3",
@@ -2446,6 +2447,19 @@
       "dev": true,
       "peerDependencies": {
         "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query": {
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-4.36.0.tgz",
+      "integrity": "sha512-dfKjV4k7QSAg7ROe25RlshcfkZsZKPIHcDibYtjckAlNkrwBFacCjwCsdNCt/neru6D7yCJYR0P59Ww8tg1JLQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -17094,6 +17108,13 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
       "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "dev": true,
+      "requires": {}
+    },
+    "@tanstack/eslint-plugin-query": {
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-4.36.0.tgz",
+      "integrity": "sha512-dfKjV4k7QSAg7ROe25RlshcfkZsZKPIHcDibYtjckAlNkrwBFacCjwCsdNCt/neru6D7yCJYR0P59Ww8tg1JLQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@faker-js/faker": "^7.6.0",
     "@kensho-technologies/eslint-config": "^26.1.2",
     "@tailwindcss/line-clamp": "^0.4.4",
+    "@tanstack/eslint-plugin-query": "^4.36.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "^14.4.3",

--- a/src/components/core/providers/patient-provider.tsx
+++ b/src/components/core/providers/patient-provider.tsx
@@ -82,12 +82,17 @@ export function usePatient(): UseQueryResult<PatientModel, unknown> {
 
   const { patientID, systemURL, tags } = context;
 
-  return useQuery({ queryKey: [QUERY_KEY_PATIENT, patientID, systemURL, tags], queryFn: withTimerMetric(async () => {
+  return useQuery({
+    queryKey: [QUERY_KEY_PATIENT, patientID, systemURL, tags],
+    queryFn: withTimerMetric(async () => {
       const requestContext = await getRequestContext();
       return getBuilderFhirPatient(requestContext, patientID, systemURL, {
         _tag: tags?.map((tag) => `${tag.system}|${tag.code}`) ?? [],
       });
-    }, "req.get_builder_fhir_patient"), staleTime: PATIENT_STALE_TIME, enabled: !!patientID });
+    }, "req.get_builder_fhir_patient"),
+    staleTime: PATIENT_STALE_TIME,
+    enabled: !!patientID,
+  });
 }
 
 export function usePatientPromise() {
@@ -151,13 +156,17 @@ export function useQueryWithPatient<T, T2>(
     );
   }
 
-  return useQuery({ queryKey: [queryKey, patientResponse.data, ...keys], queryFn: async () => {
+  return useQuery({
+    queryKey: [queryKey, patientResponse.data, ...keys],
+    queryFn: async () => {
       const requestContext = await getRequestContext();
       // Ignore eslint warning as we should always have a valid
       // patient thanks to the enabled check.
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return query(requestContext, patientResponse.data!, keys);
-    }, enabled: !!patientResponse.data?.UPID && enabled });
+    },
+    enabled: !!patientResponse.data?.UPID && enabled,
+  });
 }
 
 // Need to keep this function for builder-scoped queries.

--- a/src/components/core/providers/patient-provider.tsx
+++ b/src/components/core/providers/patient-provider.tsx
@@ -82,16 +82,12 @@ export function usePatient(): UseQueryResult<PatientModel, unknown> {
 
   const { patientID, systemURL, tags } = context;
 
-  return useQuery(
-    [QUERY_KEY_PATIENT, patientID, systemURL, tags],
-    withTimerMetric(async () => {
+  return useQuery({ queryKey: [QUERY_KEY_PATIENT, patientID, systemURL, tags], queryFn: withTimerMetric(async () => {
       const requestContext = await getRequestContext();
       return getBuilderFhirPatient(requestContext, patientID, systemURL, {
         _tag: tags?.map((tag) => `${tag.system}|${tag.code}`) ?? [],
       });
-    }, "req.get_builder_fhir_patient"),
-    { staleTime: PATIENT_STALE_TIME, enabled: !!patientID }
-  );
+    }, "req.get_builder_fhir_patient"), staleTime: PATIENT_STALE_TIME, enabled: !!patientID });
 }
 
 export function usePatientPromise() {
@@ -155,19 +151,13 @@ export function useQueryWithPatient<T, T2>(
     );
   }
 
-  return useQuery(
-    [queryKey, patientResponse.data?.UPID, ...keys],
-    async () => {
+  return useQuery({ queryKey: [queryKey, patientResponse.data, ...keys], queryFn: async () => {
       const requestContext = await getRequestContext();
       // Ignore eslint warning as we should always have a valid
       // patient thanks to the enabled check.
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return query(requestContext, patientResponse.data!, keys);
-    },
-    {
-      enabled: !!patientResponse.data?.UPID && enabled,
-    }
-  );
+    }, enabled: !!patientResponse.data?.UPID && enabled });
 }
 
 // Need to keep this function for builder-scoped queries.

--- a/src/components/core/providers/use-query-with-ctw.ts
+++ b/src/components/core/providers/use-query-with-ctw.ts
@@ -10,12 +10,8 @@ export function useQueryWithCTW<T, T2>(
 ) {
   const { getRequestContext } = useCTW();
 
-  return useQuery(
-    [queryKey, ...keys],
-    async () => {
+  return useQuery({ queryKey: [queryKey, ...keys], queryFn: async () => {
       const requestContext = await getRequestContext();
       return query(requestContext, keys);
-    },
-    { enabled }
-  );
+    }, enabled });
 }

--- a/src/components/core/providers/use-query-with-ctw.ts
+++ b/src/components/core/providers/use-query-with-ctw.ts
@@ -10,8 +10,12 @@ export function useQueryWithCTW<T, T2>(
 ) {
   const { getRequestContext } = useCTW();
 
-  return useQuery({ queryKey: [queryKey, ...keys], queryFn: async () => {
+  return useQuery({
+    queryKey: [queryKey, ...keys],
+    queryFn: async () => {
       const requestContext = await getRequestContext();
       return query(requestContext, keys);
-    }, enabled });
+    },
+    enabled,
+  });
 }


### PR DESCRIPTION
Add recommended `@tanstack/query` plugin to help ensure we keep up with best react query linting rules. Tested locally with a few patients to ensure queries looked like they were behaving the same. 