### PR TITLE
Fix withErrorBoundary to better capture errors

### DIFF
--- a/.changeset/spicy-falcons-suffer.md
+++ b/.changeset/spicy-falcons-suffer.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Setup with error boundary to better capture errors. This fixes a bug where the wrapped component was being rendered outside ErrorBoundary.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "1.69.7",
+  "version": "1.69.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "1.69.7",
+      "version": "1.69.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile-iframe.tsx
@@ -222,7 +222,7 @@ const ZusAggregatedProfileIFrameComponent = (props: ZusAggregatedProfileProps) =
   ]);
 
   if (!zapURL) {
-    return false;
+    return null;
   }
   return (
     <iframe

--- a/src/components/core/error-boundary.tsx
+++ b/src/components/core/error-boundary.tsx
@@ -1,14 +1,14 @@
 import {
   Component,
   ComponentType,
+  createElement,
   ErrorInfo,
-  ForwardRefExoticComponent,
   ForwardedRef,
+  forwardRef,
+  ForwardRefExoticComponent,
   PropsWithoutRef,
   ReactNode,
   RefAttributes,
-  createElement,
-  forwardRef,
 } from "react";
 import * as CTWBox from "@/components/core/ctw-box";
 import { pickBy } from "@/utils/nodash";
@@ -97,10 +97,11 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 }
 
-export function withErrorBoundary<CProps extends Object>(
+export function withErrorBoundary<CProps extends object>(
   component: ComponentType<CProps>,
   name?: string,
   trackView = true
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): ForwardRefExoticComponent<PropsWithoutRef<CProps> & RefAttributes<any>> {
   const Wrapped = forwardRef<ComponentType<CProps>, CProps>(
     (props: CProps, ref: ForwardedRef<ComponentType<CProps>>) =>

--- a/src/components/core/error-boundary.tsx
+++ b/src/components/core/error-boundary.tsx
@@ -97,13 +97,13 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 }
 
-export function withErrorBoundary<Props extends Object>(
-  component: ComponentType<Props>,
+export function withErrorBoundary<CProps extends Object>(
+  component: ComponentType<CProps>,
   name?: string,
   trackView = true
-): ForwardRefExoticComponent<PropsWithoutRef<Props> & RefAttributes<any>> {
-  const Wrapped = forwardRef<ComponentType<Props>, Props>(
-    (props: Props, ref: ForwardedRef<ComponentType<Props>>) =>
+): ForwardRefExoticComponent<PropsWithoutRef<CProps> & RefAttributes<any>> {
+  const Wrapped = forwardRef<ComponentType<CProps>, CProps>(
+    (props: CProps, ref: ForwardedRef<ComponentType<CProps>>) =>
       createElement(ErrorBoundary, { name, trackView }, createElement(component, { ...props, ref }))
   );
 

--- a/src/components/core/error-boundary.tsx
+++ b/src/components/core/error-boundary.tsx
@@ -1,4 +1,15 @@
-import { Component, ErrorInfo, ReactNode } from "react";
+import {
+  Component,
+  ComponentType,
+  ErrorInfo,
+  ForwardRefExoticComponent,
+  ForwardedRef,
+  PropsWithoutRef,
+  ReactNode,
+  RefAttributes,
+  createElement,
+  forwardRef,
+} from "react";
 import * as CTWBox from "@/components/core/ctw-box";
 import { pickBy } from "@/utils/nodash";
 import { Telemetry } from "@/utils/telemetry";
@@ -86,14 +97,18 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 }
 
-export function withErrorBoundary<T>(
-  wrappedComponent: (props: T) => ReactNode,
+export function withErrorBoundary<Props extends Object>(
+  component: ComponentType<Props>,
   name?: string,
   trackView = true
-) {
-  return (props: T) => (
-    <ErrorBoundary name={name} trackView={trackView}>
-      {wrappedComponent(props)}
-    </ErrorBoundary>
+): ForwardRefExoticComponent<PropsWithoutRef<Props> & RefAttributes<any>> {
+  const Wrapped = forwardRef<ComponentType<Props>, Props>(
+    (props: Props, ref: ForwardedRef<ComponentType<Props>>) =>
+      createElement(ErrorBoundary, { name, trackView }, createElement(component, { ...props, ref }))
   );
+
+  // Format for display in DevTools
+  Wrapped.displayName = `withErrorBoundary(${name})`;
+
+  return Wrapped;
 }


### PR DESCRIPTION
Approach taken from -- https://github.com/bvaughn/react-error-boundary/blob/master/src/withErrorBoundary.ts#L13

See discussion -- https://zushealth.slack.com/archives/C05231F29LP/p1696952204445749

tl;dr: This should fix an issue in CTW standalone where components that throw errors were not properly being caught by `withErrorBoundary`. This was due to the fact that we were doing `wrappedComponent(props)` which meant the wrapped component was rendering **outside** the `ErrorBoundary` component. This prevented `ErrorBoundary` component from catching the error.