### PR TITLE
Add env to useCTW

### DIFF
--- a/src/components/core/providers/use-ctw.ts
+++ b/src/components/core/providers/use-ctw.ts
@@ -48,6 +48,7 @@ export function useCTW() {
   }, [context, getAuthToken]);
 
   return {
+    env: context.env,
     getRequestContext,
     featureFlags: context.featureFlags,
   };


### PR DESCRIPTION
For nextjs we need env available. Adding it the the value returned by `useCTW`