### PR TITLE
CTW-1512 Removing date check on observations now that back-fill is done

### DIFF
--- a/.changeset/eighty-bobcats-yell.md
+++ b/.changeset/eighty-bobcats-yell.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Remove date check for observations now that back-fill is complete.

--- a/src/fhir/observations.ts
+++ b/src/fhir/observations.ts
@@ -13,12 +13,10 @@ export function usePatientObservations(loincCodes: string[]) {
     QUERY_KEY_PATIENT_OBSERVATIONS,
     [loincCodes],
     async (requestContext, patient) =>
-      patient.createdAt && patient.createdAt >= "2023-07-19"
-        ? withTimerMetric(fetchObservationsTrendData(loincCodes), "req.timing.all_observations")(
-            requestContext,
-            patient
-          )
-        : []
+      withTimerMetric(fetchObservationsTrendData(loincCodes), "req.timing.all_observations")(
+        requestContext,
+        patient
+      )
   );
 }
 


### PR DESCRIPTION
DRT finished back-filling data so that we no longer need this date check on patient observations.