### PR TITLE
Bug/Show add to record when builder does not already own record

### DIFF
--- a/.changeset/modern-peaches-cough.md
+++ b/.changeset/modern-peaches-cough.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix "Add to Record" button to show when user builder doesn't own the record already.

--- a/src/components/content/medications/patient-medications-all.tsx
+++ b/src/components/content/medications/patient-medications-all.tsx
@@ -102,7 +102,7 @@ function useRowActions(onAddToRecord?: (record: MedicationStatementModel) => voi
   const { toggleRead } = useToggleRead();
 
   return (record: MedicationStatementModel): RowActionsConfigProp<MedicationStatementModel> =>
-    !record.ownedByBuilder(userBuilderId)
+    record.ownedByBuilder(userBuilderId)
       ? []
       : [
           {


### PR DESCRIPTION
Only show the "Add" button when the users builder does not own the record