### PR TITLE
CTW-1497/Support feature flag ctw-patient-history-form

### DIFF
--- a/.changeset/strange-rabbits-compete.md
+++ b/.changeset/strange-rabbits-compete.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": minor
+---
+
+Hide request records button when feature flag ctw-patient-history-form is disabled.

--- a/src/components/content/patient-history/patient-history-action.tsx
+++ b/src/components/content/patient-history/patient-history-action.tsx
@@ -1,5 +1,6 @@
 import { PatientHistoryLastRetrieved } from "./patient-history-last-retrieved";
 import { RequestRecordsButton } from "./request-records-button";
+import { useFeatureToggle } from "@/hooks/use-feature-toggle";
 
 export type PatientHistoryActionProps = {
   hideRequestRecords?: boolean;
@@ -9,15 +10,19 @@ export type PatientHistoryActionProps = {
 export const PatientHistoryLastRetrievedWithAction = ({
   hideRequestRecords = false,
   includePatientDemographicsForm = false,
-}: PatientHistoryActionProps) => (
-  <>
-    <div>
-      <PatientHistoryLastRetrieved />
-    </div>
-    <div>
-      {!hideRequestRecords && (
-        <RequestRecordsButton includePatientDemographicsForm={includePatientDemographicsForm} />
-      )}
-    </div>
-  </>
-);
+}: PatientHistoryActionProps) => {
+  const hideRequestRecordsFormToggle = !useFeatureToggle("ctw-patient-history-form").enabled;
+
+  return (
+    <>
+      <div>
+        <PatientHistoryLastRetrieved />
+      </div>
+      <div>
+        {!(hideRequestRecords || hideRequestRecordsFormToggle) && (
+          <RequestRecordsButton includePatientDemographicsForm={includePatientDemographicsForm} />
+        )}
+      </div>
+    </>
+  );
+};

--- a/src/components/content/zus-aggregated-profile/zus-aggregated-profile.tsx
+++ b/src/components/content/zus-aggregated-profile/zus-aggregated-profile.tsx
@@ -106,6 +106,7 @@ const ZusAggregatedProfileComponent = ({
   removeRequestRecords = false,
 }: ZusAggregatedProfileProps) => {
   const isSearchEnabledToggle = useFeatureToggle("ctw-patient-record-search");
+  const showRequestRecordsFormToggle = useFeatureToggle("ctw-patient-history-form").enabled;
 
   // Get the configuration for each tab group by resource type
   const subcomponentProps: Record<keyof ZusAggregatedProfileTabs, unknown> = {
@@ -143,6 +144,9 @@ const ZusAggregatedProfileComponent = ({
     return <Loading />;
   }
 
+  const showRequestRecordsButton =
+    !!showRequestRecordsFormToggle && !removeRequestRecords && !isSearchEnabledToggle.enabled;
+
   return (
     <AnalyticsProvider componentName="ZusAggregatedProfile">
       <div className="ctw-zus-aggregated-profile ctw-scrollable-pass-through-height">
@@ -170,7 +174,7 @@ const ZusAggregatedProfileComponent = ({
           content={tabbedContent}
           forceHorizontalTabs={forceHorizontalTabs}
           topRightContent={
-            <RenderIf condition={!removeRequestRecords && isSearchEnabledToggle.enabled === false}>
+            <RenderIf condition={showRequestRecordsButton}>
               <RequestRecordsButton
                 className="ctw-mr-1.5"
                 includePatientDemographicsForm={includePatientDemographicsForm}

--- a/src/components/core/providers/ctw-context.tsx
+++ b/src/components/core/providers/ctw-context.tsx
@@ -5,6 +5,7 @@ import { OnResourceSaveCallback } from "@/fhir/action-helper";
 
 export type FeatureFlags = {
   enableViewFhirButton?: boolean;
+  patientRequestForm?: boolean;
 };
 
 export type CTWState = {

--- a/src/hooks/use-feature-toggle.ts
+++ b/src/hooks/use-feature-toggle.ts
@@ -4,7 +4,7 @@ import { useFeatureVariant } from "./use-feature-variant";
 import { FeatureFlagContext } from "@/components/core/providers/feature-flag-provider";
 
 export type FeatureToggle = {
-  enabled?: boolean;
+  enabled?: boolean | undefined;
   ready: boolean;
   errorGettingToggles?: boolean;
 };


### PR DESCRIPTION
Support feature flag ctw-patient-history-form. This will hide the request records button if this flag is disabled. It is enabled for everyone currently.

Tested this running locally by toggling the `ctw-patient-history-form` feature flag in unleash to be disabled for that builder.