### PR TITLE
CTW-1530 fixing issue with package response type

### DIFF
--- a/.changeset/clever-gorillas-pull.md
+++ b/.changeset/clever-gorillas-pull.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix package response type

--- a/src/services/subscriptions/subscriptions.ts
+++ b/src/services/subscriptions/subscriptions.ts
@@ -51,12 +51,14 @@ type GetPatientSubscriptionAPIResponse = {
 };
 
 type GetPackageAPIResponse = {
-  type: string;
-  id: string;
-  attributes: {
-    description: string;
-    name: string;
-    meta: PackageMeta;
+  data: {
+    type: string;
+    id: string;
+    attributes: {
+      description: string;
+      name: string;
+      meta: PackageMeta;
+    };
   };
 };
 
@@ -117,14 +119,13 @@ export function usePatientSubscription() {
         }
 
         const packageId = patientSubscriptionResponse.data[0].relationships.package.data.id;
-
         const zusPackage = (await getPackage(requestContext, packageId)) as GetPackageAPIResponse;
 
         patientSubscription.package = {
           id: packageId,
-          description: zusPackage.attributes.description,
-          name: zusPackage.attributes.name,
-          meta: zusPackage.attributes.meta,
+          description: zusPackage.data.attributes.description,
+          name: zusPackage.data.attributes.name,
+          meta: zusPackage.data.attributes.meta,
         };
 
         return patientSubscription;


### PR DESCRIPTION
I had originally tested the UI against a sandbox test patient that didn't have a subscription package and I had tested the network calls manually against Postman. Clearly not sufficient testing. I tested this PR by running the component library against a patient with an actual subscription package and verified that the subscription info is rendered correctly. I will verify in prod after deploy by going to a patient with a package subscription and confirming the subscription info is rendered correctly.