### PR TITLE
CTW-1480/ADT row actions revised

### DIFF
--- a/src/fhir/basic.ts
+++ b/src/fhir/basic.ts
@@ -138,10 +138,13 @@ export async function mapBasicsOf<R extends fhir4.Resource, T extends FHIRModel<
 ) {
   const requestContext = await getRequestContext();
   const subjects = resources.map((resource) => `${resource.resourceType}/${resource.id}`);
-  const { resources: basics } = await searchCommonRecords("Basic", requestContext, {
-    _tag: `https://zusapi.com/accesscontrol/owner|builder/${requestContext.builderId}`,
-    subject: subjects.join(","),
-  });
+  const { resources: basics } =
+    subjects.length > 0
+      ? await searchCommonRecords("Basic", requestContext, {
+          _tag: `https://zusapi.com/accesscontrol/owner|builder/${requestContext.builderId}`,
+          subject: subjects.join(","),
+        })
+      : { resources: [] };
   return mapBasics(resources, basics);
 }
 


### PR DESCRIPTION
ISSUE: Just realized that only querying the basics you need for that page is incompatible with non-simple pagination. We will overestimate the total hospitalizations we want to display when the filter for showing dismissed records is not enabled.

CTW-1480
Fixes ADT table row actions. Previously broken in prod b/c of big request size.

Solution: Only query the basics for that page.