### PR TITLE
CTW-1532/ADT Remove 3 months

### DIFF
--- a/.changeset/perfect-experts-double.md
+++ b/.changeset/perfect-experts-double.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Remove 3 month view from Hospitalizations

--- a/src/components/content/patients-adt/patients-adt-alerts-table.tsx
+++ b/src/components/content/patients-adt/patients-adt-alerts-table.tsx
@@ -98,7 +98,7 @@ function ADTTableComponent({
   const openADTDetails = useADTAlertDetailsDrawer(goToPatient);
   const [currentPage, setCurrentPage] = useState(1);
   const { getRequestContext } = useCTW();
-  const { past7days, past30days, past3months } = getDateRangeView<EncounterModel>("periodStart");
+  const { past7days, past30days } = getDateRangeView<EncounterModel>("periodStart");
   const {
     data: dataFilteredSorted,
     setViewOption,
@@ -111,7 +111,7 @@ function ADTTableComponent({
     records: data,
   });
 
-  const viewOptions = [past7days, past30days, past3months];
+  const viewOptions = [past7days, past30days];
   const dataFilteredSortedDeduped = dedupeAndMergeEncounters(dataFilteredSorted, "patientsADT");
   const dataOnPage = dataFilteredSortedDeduped.slice(
     (currentPage - 1) * PAGE_SIZE,


### PR DESCRIPTION
[CTW-1532](https://zeushealth.atlassian.net/browse/CTW-1532)

Remove 3 month view from the Hospitalizations table, as part of setting 30 days as the new maximum history.

<img width="593" alt="image" src="https://github.com/zeus-health/ctw-component-library/assets/33408946/87e25ef4-a263-41e6-8b28-be1e3f2bce0c">


[CTW-1532]: https://zeushealth.atlassian.net/browse/CTW-1532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ