### PR TITLE
CTW-1577 Fixing issue with showing add button when we shouldn't

### DIFF
--- a/.changeset/rare-suns-travel.md
+++ b/.changeset/rare-suns-travel.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Fix issue showing add button for medications even when readonly set

--- a/src/components/content/medications/patient-medications-all.tsx
+++ b/src/components/content/medications/patient-medications-all.tsx
@@ -51,7 +51,7 @@ function PatientMedicationsAllComponent({
   const rowActions = useRowActions(onAddToRecord);
 
   const openDetails = useMedicationDetailsDrawer({
-    rowActions,
+    rowActions: readOnly ? undefined : rowActions,
     enableDismissAndReadActions: true,
   });
 


### PR DESCRIPTION
Jira Ticket Number: CTW-1577

## What does this PR accomplish?

We have been showing the "Add" button in the medication drawer even when `readOnly` is set to true. This PR fixes that issue.

## How did you test it?

Tested locally with `readOnly` set both ways.

## How will you know that this is working after deployment?

I will verify in Elation sandbox that it is set up as expected.

## Any outstanding items or follow ups with Jira tickets?

Need to do CTW version bump.