### PR TITLE
Favor showing RxNorm display values for medication

### DIFF
--- a/.changeset/flat-spoons-vanish.md
+++ b/.changeset/flat-spoons-vanish.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Favor showing RxNorm display values for medications.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zus-health/ctw-component-library",
-  "version": "2.1.3",
+  "version": "2.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zus-health/ctw-component-library",
-      "version": "2.1.3",
+      "version": "2.1.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/fhir/codeable-concept.test.ts
+++ b/src/fhir/codeable-concept.test.ts
@@ -1,0 +1,67 @@
+import { CodeableConcept } from "fhir/r4";
+import { codeableConceptLabel } from "./codeable-concept";
+import { SYSTEM_ICD10_CM, SYSTEM_NULL_FLAVOR, SYSTEM_RXNORM } from "./system-urls";
+import { cloneDeep } from "@/utils/nodash";
+
+describe("codeable concept", () => {
+  describe("codeableConceptLabel", () => {
+    const concept: CodeableConcept = {
+      text: "meloxicam 7.5 MG Oral Tablet",
+      coding: [
+        {
+          code: "311486",
+          system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+        },
+        {
+          code: "41493",
+          display: "meloxicam",
+          system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+        },
+        {
+          code: "UNK",
+          display: "unknown",
+          system: "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+        },
+      ],
+    };
+
+    const conceptWithoutText = cloneDeep(concept);
+    conceptWithoutText.text = undefined;
+
+    test("returns text if there is one", () => {
+      expect(codeableConceptLabel(concept)).toEqual("meloxicam 7.5 MG Oral Tablet");
+    });
+
+    test("returns first display if there is no text", () => {
+      expect(codeableConceptLabel(conceptWithoutText)).toEqual("meloxicam");
+    });
+
+    test("returns first code if there is no text and no displays", () => {
+      const concept2: CodeableConcept = {
+        coding: [
+          {
+            code: "311486",
+            system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+          },
+          {
+            code: "41493",
+            system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+          },
+        ],
+      };
+
+      expect(codeableConceptLabel(concept2)).toEqual("311486");
+    });
+
+    test("returns display of specific system", () => {
+      expect(codeableConceptLabel(concept, SYSTEM_RXNORM)).toEqual("meloxicam");
+      expect(codeableConceptLabel(concept, SYSTEM_NULL_FLAVOR)).toEqual("unknown");
+    });
+
+    test("returns text if specific system has no display", () => {
+      expect(codeableConceptLabel(concept, SYSTEM_ICD10_CM)).toEqual(
+        "meloxicam 7.5 MG Oral Tablet"
+      );
+    });
+  });
+});

--- a/src/fhir/codeable-concept.test.ts
+++ b/src/fhir/codeable-concept.test.ts
@@ -16,6 +16,17 @@ describe("codeable concept", () => {
           code: "41493",
           display: "meloxicam",
           system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+          extension: [
+            {
+              url: "https://zusapi.com/terminology/enrichment",
+              valueString: "ActiveIngredient",
+            },
+          ],
+        },
+        {
+          code: "41493",
+          display: "meloxicam 7.5 MG Tablet",
+          system: "http://www.nlm.nih.gov/research/umls/rxnorm",
         },
         {
           code: "UNK",
@@ -54,7 +65,7 @@ describe("codeable concept", () => {
     });
 
     test("returns display of specific system", () => {
-      expect(codeableConceptLabel(concept, SYSTEM_RXNORM)).toEqual("meloxicam");
+      expect(codeableConceptLabel(concept, SYSTEM_RXNORM)).toEqual("meloxicam 7.5 MG Tablet");
       expect(codeableConceptLabel(concept, SYSTEM_NULL_FLAVOR)).toEqual("unknown");
     });
 

--- a/src/fhir/codeable-concept.ts
+++ b/src/fhir/codeable-concept.ts
@@ -5,8 +5,21 @@
 import { SYSTEM_ENRICHMENT } from "./system-urls";
 import { compact, find } from "@/utils/nodash";
 
-export const codeableConceptLabel = (concept?: fhir4.CodeableConcept): string =>
-  concept?.text ?? concept?.coding?.[0]?.display ?? concept?.coding?.[0]?.code ?? "";
+export const codeableConceptLabel = (
+  concept?: fhir4.CodeableConcept,
+  favoredSystemDisplay?: string
+): string => {
+  if (favoredSystemDisplay && concept?.coding) {
+    const coding = concept.coding.find((c) => c.system === favoredSystemDisplay && c.display);
+    if (coding && coding.display) {
+      return coding.display;
+    }
+  }
+
+  const firstWithDisplay = concept?.coding?.find((c) => c.display);
+  const firstWithCode = concept?.coding?.find((c) => c.code);
+  return concept?.text ?? firstWithDisplay?.display ?? firstWithCode?.code ?? "";
+};
 
 // Returns text if there is one, otherwise returns the first display text or an empty string.
 export const codeableConceptTextOrDisplay = (concept?: fhir4.CodeableConcept): string => {

--- a/src/fhir/codeable-concept.ts
+++ b/src/fhir/codeable-concept.ts
@@ -5,12 +5,24 @@
 import { SYSTEM_ENRICHMENT } from "./system-urls";
 import { compact, find } from "@/utils/nodash";
 
+/**
+  Finds the best display text for a CodeableConcept.
+ 
+  Priority order is:
+    1. The display of the coding with the given favoredSystemDisplay
+       (skipping enrichment extensions!).
+    2. The text of the CodeableConcept.
+    3. The display of the first coding with a display.
+    4. The code of the first coding with a code.
+ */
 export const codeableConceptLabel = (
   concept?: fhir4.CodeableConcept,
   favoredSystemDisplay?: string
 ): string => {
   if (favoredSystemDisplay && concept?.coding) {
-    const coding = concept.coding.find((c) => c.system === favoredSystemDisplay && c.display);
+    const coding = concept.coding.find(
+      (c) => c.system === favoredSystemDisplay && c.display && !c.extension
+    );
     if (coding && coding.display) {
       return coding.display;
     }

--- a/src/fhir/models/medication-statement.ts
+++ b/src/fhir/models/medication-statement.ts
@@ -20,6 +20,7 @@ import {
   LENS_EXTENSION_MEDICATION_LAST_PRESCRIBER,
   LENS_EXTENSION_MEDICATION_QUANTITY,
   LENS_EXTENSION_MEDICATION_REFILLS,
+  SYSTEM_RXNORM,
 } from "@/fhir/system-urls";
 import { capitalize, compact, find, get } from "@/utils/nodash/fp";
 
@@ -70,7 +71,8 @@ export class MedicationStatementModel extends FHIRModel<fhir4.MedicationStatemen
 
   get display() {
     return codeableConceptLabel(
-      getMedicationCodeableConcept(this.resource, this.includedResources)
+      getMedicationCodeableConcept(this.resource, this.includedResources),
+      SYSTEM_RXNORM
     );
   }
 


### PR DESCRIPTION
Jira Ticket Number: CTW-1526

## What does this PR accomplish?

Improves how we find the appropriate "label" for a codeable concept. We can now optionally specify a system to favor, in which case we'll try and find the `display` value associated with that system coding (skipping those with extensions so that we skip enrichments). Additionally, instead of falling back to the first coding when there is no text, we now instead fall back to the first coding with a display, and then first coding with a code.

## How did you test it?

Wrote unit tests and verified data in component for my sandbox builder.

## How will you know that this is working after deployment?

Verify in sandbox/prod and check with team.