### PR TITLE
Minor hack to fix + and "Add filter" wrapping

### DIFF
--- a/.changeset/soft-toys-sniff.md
+++ b/.changeset/soft-toys-sniff.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Minor CSS fix for add filters in CTW

--- a/src/components/core/filter-bar/filter-bar.tsx
+++ b/src/components/core/filter-bar/filter-bar.tsx
@@ -215,7 +215,10 @@ export const FilterBar = ({ className, onChange, filters, defaultState = {} }: F
           }
         }}
       >
-        <div className="ctw-mb-2 ctw-space-x-1 ctw-whitespace-nowrap ctw-px-2 ctw-py-2">
+        {/* ctw-flex and ctw-items-center fixes a brief issue in CTW
+            where the icon is not inlined until the FontAwesome
+            styles load */}
+        <div className="ctw-mb-2 ctw-flex ctw-items-center ctw-space-x-1 ctw-p-2">
           <FontAwesomeIcon icon={faPlus} className="ctw-w-4" />
           <span>Add Filters</span>
         </div>


### PR DESCRIPTION

Jira Ticket Number: none

## What does this PR accomplish?

The issue is that the CSS for FontAwesome comes in async so the default inline style on the icon isn't present on page load. This causes the + icon and the "Add Filter" text to wrap to two lines in CTW briefly.

## How did you test it?

Manually tested same change in CTW.

## How will you know that this is working after deployment?

Deploy to remix/next and verify it is no longer flashing wrapped.

<img width="116" alt="Screenshot 2023-11-17 at 1 10 54 PM" src="https://github.com/zeus-health/ctw-component-library/assets/1568246/6bf2a723-87fd-4478-ad13-c6e35ae1885d">