### PR TITLE
Drop cross-fetch/polyfill from fhir-kit-client

### DIFF
--- a/.changeset/loud-days-reply.md
+++ b/.changeset/loud-days-reply.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Add patch to remove a polyfill that may be causing auth issues for CTW stand alone.

--- a/patches/fhir-kit-client+1.9.2.patch
+++ b/patches/fhir-kit-client+1.9.2.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/fhir-kit-client/lib/http-client.js b/node_modules/fhir-kit-client/lib/http-client.js
+index 3b4b6ca..0486c4c 100644
+--- a/node_modules/fhir-kit-client/lib/http-client.js
++++ b/node_modules/fhir-kit-client/lib/http-client.js
+@@ -1,6 +1,6 @@
+ /* global Request, Headers */
+ require('es6-promise').polyfill();
+-require('cross-fetch/polyfill');
++// require('cross-fetch/polyfill');
+ 
+ const { logRequestError, logRequestInfo, logResponseInfo } = require('./logging');
+ 


### PR DESCRIPTION
Jira Ticket Number: CTW-1558

## What does this PR accomplish?

Drops cross-fetch/polyfill usage from our fhir-kit-client dependency.

## How did you test it?

Manually tested resulting `dist` folder in component library build within the node_modules of https://github.com/luthfib/auth0-nextjs-repro/tree/fetch-issue and saw problem go away.

## How will you know that this is working after deployment?

Upgrade component library version in the `auth0-nextjs-repro` and verify problem is now fixed. Then do the same for the CTW next app.
