### PR TITLE
CTW-1462 Removing FQS long poll and query invalidation for read/dismiss

### DIFF
--- a/.changeset/cool-stingrays-reflect.md
+++ b/.changeset/cool-stingrays-reflect.md
@@ -1,0 +1,5 @@
+---
+"@zus-health/ctw-component-library": patch
+---
+
+Remove FQS poll and query invalidation for read/dismiss

--- a/src/components/content/conditions/patient-conditions-outside.tsx
+++ b/src/components/content/conditions/patient-conditions-outside.tsx
@@ -10,7 +10,6 @@ import { RowActionsConfigProp } from "@/components/core/table/table-rows";
 import { ConditionModel } from "@/fhir/models";
 import { useBaseTranslations } from "@/i18n";
 import { usePatientConditionsOutside } from "@/services/conditions";
-import { QUERY_KEY_PATIENT_SUMMARY_CONDITIONS } from "@/utils/query-keys";
 
 export type PatientConditionsOutsideProps = {
   className?: string;
@@ -60,7 +59,7 @@ export const PatientConditionsOutside = withErrorBoundary(
 function useRowActions(): (r: ConditionModel) => RowActionsConfigProp<ConditionModel> {
   const { t } = useBaseTranslations();
   const showAddConditionForm = useAddConditionForm();
-  const { isLoading, toggleDismiss } = useToggleDismiss(QUERY_KEY_PATIENT_SUMMARY_CONDITIONS);
+  const { isLoading, toggleDismiss } = useToggleDismiss();
 
   return (record: ConditionModel): RowActionsConfigProp<ConditionModel> => {
     const archiveLabel = record.isDismissed

--- a/src/components/content/hooks/use-toggle-dismiss.ts
+++ b/src/components/content/hooks/use-toggle-dismiss.ts
@@ -2,7 +2,6 @@ import { useCallback, useState } from "react";
 import { useCTW } from "@/components/core/providers/use-ctw";
 import { toggleDismiss } from "@/fhir/basic";
 import { FHIRModel } from "@/fhir/models/fhir-model";
-import { queryClient } from "@/utils/request";
 
 interface UseToggleDismissResult {
   /**
@@ -21,7 +20,7 @@ interface UseToggleDismissResult {
  *
  * @param queryToInvalidate  Query to refetch
  */
-export function useToggleDismiss(queryToInvalidate?: string): UseToggleDismissResult {
+export function useToggleDismiss(): UseToggleDismissResult {
   const { getRequestContext } = useCTW();
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -29,7 +28,6 @@ export function useToggleDismiss(queryToInvalidate?: string): UseToggleDismissRe
   const handleToggleDismiss = useCallback(async (model: FHIRModel<fhir4.Resource>) => {
     setIsLoading(true);
     await toggleDismiss(model, await getRequestContext());
-    await queryClient.invalidateQueries([queryToInvalidate]);
     setIsLoading(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/components/content/hooks/use-toggle-dismiss.ts
+++ b/src/components/content/hooks/use-toggle-dismiss.ts
@@ -17,8 +17,6 @@ interface UseToggleDismissResult {
 
 /**
  * This hook is toggles the dismiss status for the specified FHIR model.
- *
- * @param queryToInvalidate  Query to refetch
  */
 export function useToggleDismiss(): UseToggleDismissResult {
   const { getRequestContext } = useCTW();

--- a/src/components/content/hooks/use-toggle-read.ts
+++ b/src/components/content/hooks/use-toggle-read.ts
@@ -2,7 +2,6 @@ import { useCallback, useState } from "react";
 import { useCTW } from "@/components/core/providers/use-ctw";
 import { toggleRead } from "@/fhir/basic";
 import { FHIRModel } from "@/fhir/models/fhir-model";
-import { queryClient } from "@/utils/request";
 
 interface UseToggleReadResult {
   /**
@@ -19,7 +18,7 @@ interface UseToggleReadResult {
 /**
  * This hook toggles the read status for the specified FHIR model.
  */
-export function useToggleRead(queryToInvalidate?: string): UseToggleReadResult {
+export function useToggleRead(): UseToggleReadResult {
   const { getRequestContext } = useCTW();
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -33,7 +32,6 @@ export function useToggleRead(queryToInvalidate?: string): UseToggleReadResult {
     }
     setIsLoading(true);
     await toggleRead(model, await getRequestContext());
-    await queryClient.invalidateQueries([queryToInvalidate]);
     setIsLoading(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/components/content/medications/patient-medications-all.tsx
+++ b/src/components/content/medications/patient-medications-all.tsx
@@ -101,7 +101,7 @@ function useRowActions(onAddToRecord?: (record: MedicationStatementModel) => voi
   const { t } = useBaseTranslations();
   const userBuilderId = useUserBuilderId();
   const showAddMedicationForm = useAddMedicationForm();
-  const { toggleRead } = useToggleRead(QUERY_KEY_PATIENT_SUMMARY_MEDICATIONS);
+  const { toggleRead } = useToggleRead();
 
   return (record: MedicationStatementModel): RowActionsConfigProp<MedicationStatementModel> =>
     record.ownedByBuilder(userBuilderId)

--- a/src/components/content/medications/patient-medications-outside.tsx
+++ b/src/components/content/medications/patient-medications-outside.tsx
@@ -11,7 +11,6 @@ import { MedicationStatementModel } from "@/fhir/models";
 import { useQueryAllPatientMedications } from "@/hooks/use-medications";
 import { useBaseTranslations } from "@/i18n";
 import { Spinner } from "@/index";
-import { QUERY_KEY_PATIENT_SUMMARY_MEDICATIONS } from "@/utils/query-keys";
 
 export type PatientMedicationsOutsideProps = {
   className?: string;
@@ -55,9 +54,7 @@ function useRowActions(onAddToRecord?: (record: MedicationStatementModel) => voi
   const { t } = useBaseTranslations();
   const { trackInteraction } = useAnalytics();
   const showAddMedicationForm = useAddMedicationForm();
-  const { isLoading, toggleDismiss: toggleArchive } = useToggleDismiss(
-    QUERY_KEY_PATIENT_SUMMARY_MEDICATIONS
-  );
+  const { isLoading, toggleDismiss: toggleArchive } = useToggleDismiss();
 
   return (record: MedicationStatementModel): RowActionsConfigProp<MedicationStatementModel> => {
     const archiveLabel = record.isDismissed

--- a/src/components/content/resource/resource-table.tsx
+++ b/src/components/content/resource/resource-table.tsx
@@ -44,7 +44,7 @@ export const ResourceTable = <T extends fhir4.Resource, M extends FHIRModel<T>>(
 
   const shouldShowTableHead = typeof showTableHead === "boolean" ? showTableHead : !breakpoints.sm;
 
-  const { toggleRead } = useToggleRead(queryKey);
+  const { toggleRead } = useToggleRead();
 
   // Create the RowActions react node
   const RowActionsWithAdditions = useAdditionalResourceActions({

--- a/src/components/content/resource/use-additional-resource-actions.tsx
+++ b/src/components/content/resource/use-additional-resource-actions.tsx
@@ -111,8 +111,8 @@ function useDismissAndReadActions(enableDismissAndReadActions = false, queryKey?
   const requestContext = useRequestContext();
   const { trackInteraction } = useAnalytics();
 
-  const { isLoading: isToggleDismissLoading, toggleDismiss } = useToggleDismiss(queryKey);
-  const { isLoading: isToggleReadLoading, toggleRead } = useToggleRead(queryKey);
+  const { isLoading: isToggleDismissLoading, toggleDismiss } = useToggleDismiss();
+  const { isLoading: isToggleReadLoading, toggleRead } = useToggleRead();
   return (record: FHIRModel<Resource>): RowActionsConfigProp<FHIRModel<Resource>> => {
     const archiveLabel = record.isDismissed
       ? t("resourceTable.restore")

--- a/src/components/content/resource/use-additional-resource-actions.tsx
+++ b/src/components/content/resource/use-additional-resource-actions.tsx
@@ -30,11 +30,10 @@ export const useAdditionalResourceActions = <T extends Resource, M extends FHIRM
   rowActions,
   enableDismissAndReadActions,
   isInFooter = false,
-  queryKey,
 }: ResourceTableProps<M>) => {
   const { featureFlags } = useCTW();
   const [selectedAction, setSelectedAction] = useState("card");
-  const dismissAndReadActions = useDismissAndReadActions(enableDismissAndReadActions, queryKey);
+  const dismissAndReadActions = useDismissAndReadActions(enableDismissAndReadActions);
 
   return ({ record, onSuccess, stacked = false }: RowActionsProps<M>) => {
     const extraActions = dismissAndReadActions(record) ?? [];
@@ -105,7 +104,7 @@ export const useAdditionalResourceActions = <T extends Resource, M extends FHIRM
   };
 };
 
-function useDismissAndReadActions(enableDismissAndReadActions = false, queryKey?: string) {
+function useDismissAndReadActions(enableDismissAndReadActions = false) {
   const userBuilderId = useUserBuilderId();
   const { t } = useBaseTranslations();
   const requestContext = useRequestContext();

--- a/src/fhir/action-helper.ts
+++ b/src/fhir/action-helper.ts
@@ -54,7 +54,12 @@ export async function createOrEditFhirResource(
     // Wait for FQS to have the latest version of the resource.
     // This way callers can safely refetch/invalidateQueries
     // and be sure to get fresh data from FQS.
-    if (isFHIRDomainResource(response) && response.id && response.meta?.lastUpdated) {
+    if (
+      resource.resourceType !== "Basic" &&
+      isFHIRDomainResource(response) &&
+      response.id &&
+      response.meta?.lastUpdated
+    ) {
       await longPollFQS(
         requestContext,
         resource.resourceType,


### PR DESCRIPTION
Jira Ticket Number: CTW-1462

## What does this PR accomplish?

Ran into issues long-polling FQS for Basic resources as a Care Team User due to lack of permissions reading those resources. This PR removes that long-poll as well as any query invalidation when reading/dismissing resources. Functionally this just means that when you dismiss a resource it doesn't immediately disappear from the list (it just greys out) and when you're done reading all the resources the red dot doesn't go away until you refresh the page. These feel like reasonable compromises to get this fix out and are actually a pretty big performance improvement to the speed to reading/dismissing resources (since long-polling and invalidating the resource query on every read/dismiss seemed like overkill anyway). 

## How did you test it?

Tested locally.

## How will you know that this is working after deployment?

Will verify UI after deploy.

## Any outstanding items or follow ups with Jira tickets?

CTW repo update.
